### PR TITLE
More NetworkManager template functionality

### DIFF
--- a/dbusmock/templates/networkmanager.py
+++ b/dbusmock/templates/networkmanager.py
@@ -454,8 +454,8 @@ def AddWiFiConnection(self, dev_path, connection_name, ssid_name, key_mgmt):
 
     if not access_point:
         raise dbus.exceptions.DBusException(
-            MAIN_IFACE + '.DoesNotExist',
-            'Access point with SSID [%s] could not be found' % (ssid_name))
+            'Access point with SSID [%s] could not be found' % (ssid_name),
+            name=MAIN_IFACE + '.DoesNotExist')
 
     hw_address = access_point.Get(ACCESS_POINT_IFACE, 'HwAddress')
     mode = access_point.Get(ACCESS_POINT_IFACE, 'Mode')

--- a/dbusmock/templates/networkmanager.py
+++ b/dbusmock/templates/networkmanager.py
@@ -24,6 +24,7 @@ import binascii
 from dbusmock import MOCK_IFACE
 import dbusmock
 
+
 BUS_NAME = 'org.freedesktop.NetworkManager'
 MAIN_OBJ = '/org/freedesktop/NetworkManager'
 MAIN_IFACE = 'org.freedesktop.NetworkManager'
@@ -158,6 +159,13 @@ def activate_connection(self, conn, dev, ap):
     return active_conn
 
 
+def deactivate_connection(self, active_conn_path):
+    NM = dbusmock.get_object(MAIN_OBJ)
+
+    for dev_path in NM.GetDevices():
+        RemoveActiveConnection(self, dev_path, active_conn_path)
+
+
 def add_and_activate_connection(self, conn_conf, dev, ap):
     name = ap.rsplit('/', 1)[1]
     RemoveWifiConnection(self, dev, '/org/freedesktop/NetworkManager/Settings/' + name)
@@ -172,6 +180,7 @@ def add_and_activate_connection(self, conn_conf, dev, ap):
 
 def load(mock, parameters):
     mock.activate_connection = activate_connection
+    mock.deactivate_connection = deactivate_connection
     mock.add_and_activate_connection = add_and_activate_connection
     mock.AddMethods(MAIN_IFACE, [
         ('GetDevices', '', 'ao',
@@ -180,6 +189,7 @@ def load(mock, parameters):
         ('state', '', 'u', "ret = self.Get('%s', 'State')" % MAIN_IFACE),
         ('CheckConnectivity', '', 'u', "ret = self.Get('%s', 'Connectivity')" % MAIN_IFACE),
         ('ActivateConnection', 'ooo', 'o', "ret = self.activate_connection(self, args[0], args[1], args[2])"),
+        ('DeactivateConnection', 'o', '', "self.deactivate_connection(self, args[0])"),
         ('AddAndActivateConnection', 'a{sa{sv}}oo', 'oo', "ret = self.add_and_activate_connection(self, args[0], args[1], args[2])"),
     ])
 
@@ -205,7 +215,7 @@ def load(mock, parameters):
                       'Connections': dbus.Array([], signature='o')}
     settings_methods = [('ListConnections', '', 'ao', "ret = self.Get('%s', 'Connections')" % SETTINGS_IFACE),
                         ('GetConnectionByUuid', 's', 'o', ''),
-                        ('AddConnection', 'a{sa{sv}}', 'o', ''),
+                        ('AddConnection', 'a{sa{sv}}', 'o', 'ret = self.SettingsAddConnection(args[0])'),
                         ('SaveHostname', 's', '', '')]
     mock.AddObject(SETTINGS_OBJ,
                    SETTINGS_IFACE,
@@ -485,10 +495,12 @@ def AddWiFiConnection(self, dev_path, connection_name, ssid_name, key_mgmt):
                        'Secrets': dbus.Dictionary({}, signature='sa{sv}'),
                    },
                    [
-                       ('Delete', '', '', ''),
+                       ('Delete', '', '', 'self.ConnectionDelete("%s")' % connection_path),
                        ('GetSettings', '', 'a{sa{sv}}', "ret = self.Get('%s', 'Settings')" % CSETTINGS_IFACE),
                        ('GetSecrets', 's', 'a{sa{sv}}', "ret = self.Get('%s', 'Secrets')" % CSETTINGS_IFACE),
-                       ('Update', 'a{sa{sv}}', '', ''),
+                       (
+                        'Update', 'a{sa{sv}}', '',
+                        'self.ConnectionUpdate("%s", args[0])' % connection_path),
                    ])
 
     connections.append(dbus.ObjectPath(connection_path))
@@ -627,3 +639,188 @@ def RemoveActiveConnection(self, dev_path, active_connection_path):
     self.SetProperty(MAIN_OBJ, MAIN_IFACE, 'ActiveConnections', active_connections)
 
     self.RemoveObject(active_connection_path)
+
+
+@dbus.service.method(SETTINGS_IFACE,
+                     in_signature='a{sa{sv}}', out_signature='o')
+def SettingsAddConnection(self, connection_settings):
+    '''Add a connection.
+
+    connection_settings is a String String Variant Map Map. See
+    https://developer.gnome.org/NetworkManager/0.9/spec.html
+        #type-String_String_Variant_Map_Map
+
+    If you omit uuid, this method adds one for you.
+    '''
+
+    if not 'uuid' in connection_settings['connection']:
+        connection_settings['connection']['uuid'] = str(uuid.uuid4())
+
+    NM = dbusmock.get_object(MAIN_OBJ)
+    settings_obj = dbusmock.get_object(SETTINGS_OBJ)
+    main_connections = settings_obj.ListConnections()
+
+    # Mimic how NM names connections
+    connection_name = str(len(main_connections))
+
+    connection_path = SETTINGS_OBJ + '/' + connection_name
+
+    if connection_path in main_connections:
+        raise dbus.exceptions.DBusException(
+            'Connection %s already exists' % connection_path,
+            name=MAIN_IFACE + '.AlreadyExists',)
+
+    self.AddObject(connection_path,
+                   CSETTINGS_IFACE,
+                   {
+                       'Settings': dbus.Dictionary(connection_settings, signature='sa{sv}'),
+                       'Secrets': dbus.Dictionary({}, signature='sa{sv}'),
+                   },
+                   [
+                       ('Delete', '', '', 'self.ConnectionDelete("%s")' % connection_path),
+                       (
+                        'GetSettings', '', 'a{sa{sv}}',
+                        "ret = self.Get('%s', 'Settings')" % CSETTINGS_IFACE),
+                       (
+                        'GetSecrets', 's', 'a{sa{sv}}',
+                        "ret = self.Get('%s', 'Secrets')" % CSETTINGS_IFACE),
+                       (
+                        'Update', 'a{sa{sv}}', '',
+                        'self.ConnectionUpdate("%s", args[0])' % connection_path),
+                   ])
+
+    main_connections.append(connection_path)
+    settings_obj.Set(SETTINGS_IFACE, 'Connections', main_connections)
+
+    settings_obj.EmitSignal(SETTINGS_IFACE, 'NewConnection', 'o', [connection_path])
+
+    auto_connect = False
+    if 'autoconnect' in connection_settings['connection']:
+        auto_connect = connection_settings['connection']['autoconnect']
+
+    if auto_connect:
+        dev = None
+        devices = NM.GetDevices()
+
+        # Grab the first device.
+        if len(devices) > 0:
+            dev = devices[0]
+
+        if dev:
+            activate_connection(NM, connection_path, dev, connection_path)
+
+    return connection_path
+
+@dbus.service.method(CSETTINGS_IFACE,
+                     in_signature='oa{sa{sv}}', out_signature='')
+def ConnectionUpdate(self, connection_path, settings):
+    '''Update settings on a connection.
+
+    settings is a String String Variant Map Map. See
+    https://developer.gnome.org/NetworkManager/0.9/spec.html
+        #type-String_String_Variant_Map_Map
+    '''
+    NM = dbusmock.get_object(MAIN_OBJ)
+    settings_obj = dbusmock.get_object(SETTINGS_OBJ)
+    conn_obj = dbusmock.get_object(connection_path)
+
+    main_connections = settings_obj.ListConnections()
+
+    if connection_path not in main_connections:
+        raise dbus.exceptions.DBusException(
+            'Connection %s does not exist' % connection_path,
+            name=MAIN_IFACE + '.DoesNotExist',)
+
+    conn_settings = conn_obj.Get(CSETTINGS_IFACE, 'Settings')
+    changed_settings = {}
+    for key, value in settings.items():
+        for k, v in value.items():
+            changed_settings[k] = v
+
+            if not key in conn_settings:
+                conn_settings[key] = dbus.Dictionary({}, signature='sv')
+
+            conn_settings[key][k] = v
+
+    conn_obj.Set(CSETTINGS_IFACE, 'Settings', conn_settings)
+
+    settings_obj.EmitSignal(CSETTINGS_IFACE, 'PropertiesChanged', 'a{sv}', [changed_settings])
+    settings_obj.EmitSignal(CSETTINGS_IFACE, 'Updated', '', [])
+
+    auto_connect = False
+    if 'autoconnect' in settings['connection']:
+        auto_connect = settings['connection']['autoconnect']
+
+    if auto_connect:
+        dev = None
+        devices = NM.GetDevices()
+
+        # Grab the first device.
+        if len(devices) > 0:
+            dev = devices[0]
+
+        if dev:
+            activate_connection(NM, connection_path, dev, connection_path)
+
+    return connection_path
+
+
+@dbus.service.method(CSETTINGS_IFACE,
+                     in_signature='o', out_signature='')
+def ConnectionDelete(self, connection_path):
+    '''Deletes a connection.
+
+    This also
+        * removes the deleted connection from any device,
+        * removes any active connection(s) it might be associated with,
+        * removes it from the Settings interface,
+        * as well as deletes the object from the mock.
+
+    Note: If this was the only active connection, we change the global
+    connection state.
+    '''
+    NM = dbusmock.get_object(MAIN_OBJ)
+    settings_obj = dbusmock.get_object(SETTINGS_OBJ)
+
+    # Find the associated active connection(s).
+    active_connections = NM.Get(MAIN_IFACE, 'ActiveConnections')
+    associated_active_connections = []
+    for ac in active_connections:
+        ac_obj = dbusmock.get_object(ac)
+        ac_con = ac_obj.Get(ACTIVE_CONNECTION_IFACE, 'Connection')
+        if ac_con == connection_path:
+            associated_active_connections.append(ac)
+
+    # We found that the connection we are deleting are associated to all
+    # active connections and subsequently set the global state to
+    # disconnected.
+    if len(active_connections) == len(associated_active_connections):
+        self.SetGlobalConnectionState(NMState.NM_STATE_DISCONNECTED)
+
+    # Remove the connection from all associated devices.
+    # We also remove all associated active connections.
+    for dev_path in NM.GetDevices():
+        dev_obj = dbusmock.get_object(dev_path)
+        connections = dev_obj.Get(DEVICE_IFACE, 'AvailableConnections')
+
+        for ac in associated_active_connections:
+            NM.RemoveActiveConnection(dev_path, ac)
+
+        if connection_path not in connections:
+            continue
+
+        connections.remove(dbus.ObjectPath(connection_path))
+        dev_obj.Set(DEVICE_IFACE, 'AvailableConnections', connections)
+
+    # Remove the connection from the settings interface
+    main_connections = settings_obj.ListConnections()
+    if connection_path not in main_connections:
+        return
+    main_connections.remove(connection_path)
+    settings_obj.Set(SETTINGS_IFACE, 'Connections', main_connections)
+    settings_obj.EmitSignal(SETTINGS_IFACE, 'ConnectionRemoved', 'o', [connection_path])
+
+    # Remove the connection from the mock
+    connection_obj = dbusmock.get_object(connection_path)
+    connection_obj.EmitSignal(CSETTINGS_IFACE, 'Removed', '', [])
+    self.RemoveObject(connection_path)

--- a/tests/test_networkmanager.py
+++ b/tests/test_networkmanager.py
@@ -25,6 +25,8 @@ from dbusmock.templates.networkmanager import InfrastructureMode
 from dbusmock.templates.networkmanager import NMActiveConnectionState
 from dbusmock.templates.networkmanager import NMState
 from dbusmock.templates.networkmanager import NMConnectivityState
+from dbusmock.templates.networkmanager import (CSETTINGS_IFACE, MAIN_IFACE,
+                                               SETTINGS_OBJ, SETTINGS_IFACE)
 
 
 p = subprocess.Popen(['which', 'nmcli'], stdout=subprocess.PIPE)
@@ -60,6 +62,9 @@ class TestNetworkManager(dbusmock.DBusTestCase):
             stdout=subprocess.PIPE)
         self.dbusmock = dbus.Interface(self.obj_networkmanager,
                                        dbusmock.MOCK_IFACE)
+        self.settings = dbus.Interface(
+            self.dbus_con.get_object(MAIN_IFACE, SETTINGS_OBJ),
+            SETTINGS_IFACE)
 
     def tearDown(self):
         self.p_mock.terminate()
@@ -254,6 +259,90 @@ class TestNetworkManager(dbusmock.DBusTestCase):
 
         self.dbusmock.RemoveAccessPoint(wifi1, ap1)
         self.assertFalse(re.compile('The_SSID').search(self.read_device_wifi()))
+
+    def test_add_connection(self):
+        self.dbusmock.AddWiFiDevice('mock_WiFi1', 'wlan0',
+                                            DeviceState.ACTIVATED)
+        uuid = '11111111-1111-1111-1111-111111111111'
+        settings = dbus.Dictionary({
+            'connection': dbus.Dictionary({
+                'id': 'test connection',
+                'uuid': uuid,
+                'type': '802-11-wireless',}, signature='sv'),
+            '802-11-wireless': dbus.Dictionary({
+                'ssid': dbus.ByteArray('The_SSID'),}, signature='sv')
+            }, signature='sa{sv}')
+        con1 = self.settings.AddConnection(settings)
+
+        self.assertEqual(con1, '/org/freedesktop/NetworkManager/Settings/0')
+        self.assertRegex(self.read_connection(),
+                         '%s.*\s802-11-wireless' % uuid)
+
+        # Use the same settings, but this one will autoconnect.
+        uuid2 = '22222222-2222-2222-2222-222222222222'
+        settings['connection']['autoconnect'] = dbus.Boolean(
+            True, variant_level=1)
+        settings['connection']['uuid'] = uuid2
+
+        con2 = self.settings.AddConnection(settings)
+        self.assertEqual(con2, '/org/freedesktop/NetworkManager/Settings/1')
+
+        self.assertRegex(self.read_general(), 'connected.*\sfull')
+        self.assertRegex(self.read_connection(),
+                         '%s.*\s802-11-wireless' % uuid2)
+        self.assertRegex(self.read_active_connection(),
+                         '%s.*\s802-11-wireless' % uuid2)
+
+    def test_update_connection(self):
+        uuid = '133d8eb9-6de6-444f-8b37-f40bf9e33226'
+        settings = dbus.Dictionary({
+            'connection': dbus.Dictionary({
+                'id': 'test wireless',
+                'uuid': uuid,
+                'type': '802-11-wireless',}, signature='sv'),
+            '802-11-wireless': dbus.Dictionary({
+                'ssid': dbus.ByteArray('The_SSID'),}, signature='sv')
+            }, signature='sa{sv}')
+
+        con1 = self.settings.AddConnection(settings)
+        con1_iface = dbus.Interface(
+            self.dbus_con.get_object(MAIN_IFACE, con1),
+            CSETTINGS_IFACE)
+
+        self.assertEqual(con1, '/org/freedesktop/NetworkManager/Settings/0')
+        self.assertRegex(self.read_connection(), '%s.*\s802-11-wireless' % uuid)
+
+        new_settings = dbus.Dictionary({
+            'connection': dbus.Dictionary({
+                'id': 'test wired',
+                'type': '802-3-ethernet',}, signature='sv'),
+            '802-3-ethernet': dbus.Dictionary({
+                'name': '802-3-ethernet'
+                }, signature='sv')}, signature='sa{sv}')
+
+        con1_iface.Update(new_settings)
+        self.assertRegex(self.read_connection(), '%s.*\s802-3-ethernet' % uuid)
+
+    def test_remove_connection(self):
+        wifi1 = self.dbusmock.AddWiFiDevice('mock_WiFi1', 'wlan0',
+                                            DeviceState.ACTIVATED)
+        ap1 = self.dbusmock.AddAccessPoint(
+            wifi1, 'Mock_AP1', 'The_SSID', '00:23:F8:7E:12:BB',
+            InfrastructureMode.NM_802_11_MODE_INFRA, 2425, 5400, 82,
+            NM80211ApSecurityFlags.NM_802_11_AP_SEC_KEY_MGMT_PSK)
+        con1 = self.dbusmock.AddWiFiConnection(wifi1, 'Mock_Con1', 'The_SSID', '')
+        self.dbusmock.AddActiveConnection(
+            [wifi1], con1, ap1, 'Mock_Active1',
+            NMActiveConnectionState.NM_ACTIVE_CONNECTION_STATE_ACTIVATED)
+
+        con1_i = dbus.Interface(
+                                self.dbus_con.get_object(MAIN_IFACE, con1),
+                                CSETTINGS_IFACE)
+        con1_i.Delete()
+
+        self.assertRegex(self.read_general(), 'disconnected.*\sfull')
+        self.assertFalse(re.compile('The_SSID.*\s802-11-wireless').search(self.read_active_connection()))
+        self.assertRegex(self.read_device(), 'wlan0.*\sdisconnected')
 
 
 if __name__ == '__main__':

--- a/tests/test_networkmanager.py
+++ b/tests/test_networkmanager.py
@@ -270,7 +270,7 @@ class TestNetworkManager(dbusmock.DBusTestCase):
                 'uuid': uuid,
                 'type': '802-11-wireless',}, signature='sv'),
             '802-11-wireless': dbus.Dictionary({
-                'ssid': dbus.ByteArray('The_SSID'),}, signature='sv')
+                'ssid': dbus.ByteArray('The_SSID'.encode('UTF-8')),}, signature='sv')
             }, signature='sa{sv}')
         con1 = self.settings.AddConnection(settings)
 
@@ -301,7 +301,7 @@ class TestNetworkManager(dbusmock.DBusTestCase):
                 'uuid': uuid,
                 'type': '802-11-wireless',}, signature='sv'),
             '802-11-wireless': dbus.Dictionary({
-                'ssid': dbus.ByteArray('The_SSID'),}, signature='sv')
+                'ssid': dbus.ByteArray('The_SSID'.encode('UTF-8')),}, signature='sv')
             }, signature='sa{sv}')
 
         con1 = self.settings.AddConnection(settings)


### PR DESCRIPTION
Implements the following methods:

 * `org.freedesktop.NetworkManager.DeactivateConnection`
 * `org.freedesktop.NetworkManager.Settings.AddConnection`
 * `org.freedesktop.NetworkManager.Settings.Connection.Update`
 * `org.freedesktop.NetworkManager.Settings.Connection.Delete`

It also allows Connections with `autoconnect`, added using AddConnection, to be automatically connected by the first found device, roughly like NetworkManager itself does.