### PR TITLE
Added x-canonical-private-synchronous to notifications capabilites

### DIFF
--- a/dbusmock/templates/notification_daemon.py
+++ b/dbusmock/templates/notification_daemon.py
@@ -24,7 +24,7 @@ SYSTEM_BUS = False
 # default capabilities, can be modified with "capabilities" parameter
 default_caps = ['body', 'body-markup', 'icon-static', 'image/svg+xml',
                 'private-synchronous', 'append', 'private-icon-only',
-                'truncation']
+                'truncation', 'x-canonical-private-synchronous']
 
 
 def load(mock, parameters):


### PR DESCRIPTION
Added x-canonical-private-synchronous to the notifications mock capabilities, as the sound indicator needs it