### PR TITLE
Fix failure of test_no_adapters with bluez 5.45

### DIFF
--- a/tests/test_bluez5.py
+++ b/tests/test_bluez5.py
@@ -104,7 +104,8 @@ class TestBlueZ5(dbusmock.DBusTestCase):
     def test_no_adapters(self):
         # Check for adapters.
         out = _run_bluetoothctl('list')
-        self.assertEqual([l for l in out if 'Waiting to connect' not in l], [])
+        for line in out:
+            self.assertNotRegex(line, '^Controller ')
 
     def test_one_adapter(self):
         # Chosen parameters.


### PR DESCRIPTION
New messages were introduced in bluez 5.45 which confused this simplistic
test case. So rather than expecting blank, we should expect the output
to change over time. Just so long as the output doesn't list "Controller"
then it's a pass. (LP: #1696480)