### PR TITLE
tests/test_timedated.py: update for v235

### DIFF
--- a/tests/test_timedated.py
+++ b/tests/test_timedated.py
@@ -65,12 +65,18 @@ class TestTimedated(dbusmock.DBusTestCase):
 
     def test_default_ntp(self):
         out = self.run_timedatectl()
-        self.assertRegex(out, 'NTP (enabled|synchronized): yes')
+        if 'systemd-timesyncd.service' in out:
+            self.assertRegex(out, 'systemd-timesyncd.service active: yes')
+        else:
+            self.assertRegex(out, 'NTP (enabled|synchronized): yes')
 
     def test_changing_ntp(self):
         self.obj_timedated.SetNTP(False, False)
         out = self.run_timedatectl()
-        self.assertRegex(out, 'NTP (enabled|synchronized): no')
+        if 'systemd-timesyncd.service' in out:
+            self.assertRegex(out, 'systemd-timesyncd.service active: no')
+        else:
+            self.assertRegex(out, 'NTP (enabled|synchronized): no')
 
     def test_default_local_rtc(self):
         out = self.run_timedatectl()


### PR DESCRIPTION
v235 has changed the text output of the timedated command, upgrade
test suite to handle those strings / assertions.

Signed-off-by: Dimitri John Ledkov <xnox@ubuntu.com>