### PR TITLE
Add support for suspend-then-hibernate

### DIFF
--- a/dbusmock/templates/logind.py
+++ b/dbusmock/templates/logind.py
@@ -34,11 +34,13 @@ def load(mock, parameters):
         ('Suspend', 'b', '', ''),
         ('Hibernate', 'b', '', ''),
         ('HybridSleep', 'b', '', ''),
+        ('SuspendThenHibernate', 'b', '', ''),
         ('CanPowerOff', '', 's', 'ret = "%s"' % parameters.get('CanPowerOff', 'yes')),
         ('CanReboot', '', 's', 'ret = "%s"' % parameters.get('CanReboot', 'yes')),
         ('CanSuspend', '', 's', 'ret = "%s"' % parameters.get('CanSuspend', 'yes')),
         ('CanHibernate', '', 's', 'ret = "%s"' % parameters.get('CanHibernate', 'yes')),
         ('CanHybridSleep', '', 's', 'ret = "%s"' % parameters.get('CanHybridSleep', 'yes')),
+        ('CanSuspendThenHibernate', '', 's', 'ret = "%s"' % parameters.get('CanSuspendThenHibernate', 'yes')),
 
         ('GetSession', 's', 'o', 'ret = "/org/freedesktop/login1/session/" + args[0]'),
         ('ActivateSession', 's', '', ''),


### PR DESCRIPTION
Suspend to hibernate is a new feature in systemd, merged in:
github.com/systemd/systemd/pull/8274

It was renamed to suspend then hibernate in:
https://github.com/systemd/systemd/pull/8606