### PR TITLE
NetworkManager template: add "StateReason" property to devices

### DIFF
--- a/dbusmock/templates/networkmanager.py
+++ b/dbusmock/templates/networkmanager.py
@@ -321,6 +321,7 @@ def AddEthernetDevice(self, device_name, iface_name, state):
 
     props = {'DeviceType': dbus.UInt32(1),
              'State': dbus.UInt32(state),
+             'StateReason': (dbus.UInt32(state), dbus.UInt32(0)),
              'Interface': iface_name,
              'ActiveConnection': dbus.ObjectPath('/'),
              'AvailableConnections': dbus.Array([], signature='o'),
@@ -389,6 +390,7 @@ def AddWiFiDevice(self, device_name, iface_name, state):
                               'Driver': 'dbusmock',
                               'DeviceType': dbus.UInt32(2),
                               'State': dbus.UInt32(state),
+                              'StateReason': (dbus.UInt32(state), dbus.UInt32(0)),
                               'Interface': iface_name,
                               'IpInterface': iface_name,
                           })


### PR DESCRIPTION
NetworkManager supports the "State" and "StateReason" properties for
a long time. The "StateReason" redundantly also contains the state
value (for historic reasons).

In the past, NMClient's cache in libnm looked at the "State" property
to get the state. This is going to change (in 1.22) and libnm will consider
only at the "StateReason" for both properties. This change in libnm would
break dbusmock.

Note that NetworkManager/libnm didn't break API. The only think that is going
to change is that libnm will require that "StateReason" property is
present. The breakage is caused by dbusmock not providing a perfect stub
implementation of NetworkManager's API.

See-also: https://gitlab.freedesktop.org/NetworkManager/NetworkManager/commit/ec39498fc6d70cf6887f08b4dfbc5cff021fc231