### PR TITLE
NetworkManager template: AddConnectionUnsaved

### DIFF
--- a/dbusmock/templates/networkmanager.py
+++ b/dbusmock/templates/networkmanager.py
@@ -258,6 +258,7 @@ def load(mock, parameters):
     settings_methods = [('ListConnections', '', 'ao', "ret = self.Get('%s', 'Connections')" % SETTINGS_IFACE),
                         ('GetConnectionByUuid', 's', 'o', 'ret = self.SettingsGetConnectionByUuid(args[0])'),
                         ('AddConnection', 'a{sa{sv}}', 'o', 'ret = self.SettingsAddConnection(args[0])'),
+                        ('AddConnectionUnsaved', 'a{sa{sv}}', 'o', 'ret = self.SettingsAddConnection(args[0])'),
                         ('SaveHostname', 's', '', '')]
     mock.AddObject(SETTINGS_OBJ,
                    SETTINGS_IFACE,


### PR DESCRIPTION
[AddConnectionUnsave](https://developer.gnome.org/NetworkManager/stable/gdbus-org.freedesktop.NetworkManager.Settings.html#gdbus-method-org-freedesktop-NetworkManager-Settings.AddConnectionUnsaved) method has been added to [org.freedesktop.NetworkManager.Settings](https://developer.gnome.org/NetworkManager/stable/gdbus-org.freedesktop.NetworkManager.Settings.html). The method has the same signature, and the same behavior as [AddConnection](https://developer.gnome.org/NetworkManager/stable/gdbus-org.freedesktop.NetworkManager.Settings.html#gdbus-method-org-freedesktop-NetworkManager-Settings.AddConnection) except the first one doesn't save a key-file on the disk, but for mocking, it doesn't matter. Therefore, the previously implemented `SettingsAddConnection` has been utilized.