### PR TITLE
template/accounts_service: Add accounts service mock implementation

### DIFF
--- a/dbusmock/templates/accounts_service.py
+++ b/dbusmock/templates/accounts_service.py
@@ -1,0 +1,388 @@
+'''Accounts Service D-Bus mock template'''
+
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 3 of the License, or (at your option) any
+# later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
+# of the license.
+
+__author__ = 'Marco Trevisan'
+__email__ = 'marco.trevisan@canonical.com'
+__copyright__ = '(c) 2021 Canonical Ltd.'
+__license__ = 'LGPL 3+'
+
+import sys
+import time
+
+import dbus
+from dbusmock import MOCK_IFACE, mockobject
+
+BUS_NAME = 'org.freedesktop.Accounts'
+MAIN_OBJ = '/org/freedesktop/Accounts'
+MAIN_IFACE = 'org.freedesktop.Accounts'
+USER_IFACE = MAIN_IFACE + '.User'
+SYSTEM_BUS = True
+
+DEFAULT_USER_PASSWORD = 'Pa$$wo0rd'
+
+
+def get_user_path(uid):
+    return '/org/freedesktop/Accounts/User{}'.format(uid)
+
+
+def load(mock, parameters=None):
+    parameters = parameters if parameters else {}
+    mock.mock_users = {}
+    mock.cached_users = []
+    mock.automatic_login_users = set()
+    mock.users_auto_uids = 2000
+
+    mock.AddProperties(MAIN_IFACE, mock.GetAll(MAIN_IFACE))
+
+    for uid, name in parameters.get('users', {}).items():
+        mock.AddUser(uid, name)
+
+
+def emit_properties_changed(mock, interface=MAIN_IFACE, properties=None):
+    if properties is None:
+        properties = mock.GetAll(interface)
+    elif isinstance(properties, str):
+        properties = [properties]
+
+    if isinstance(properties, (list, set)):
+        properties = {p: mock.Get(interface, p) for p in properties}
+    elif not isinstance(properties, dict):
+        raise TypeError('Unsupported properties type')
+
+    mock.EmitSignal(dbus.PROPERTIES_IFACE, 'PropertiesChanged', 'sa{sv}as', (
+        interface, properties, []))
+
+
+@dbus.service.method(MOCK_IFACE, in_signature='xssa{sv}a{sv}',
+                     out_signature='o')
+def AddUser(self, uid, username, password=DEFAULT_USER_PASSWORD,
+            overrides=None, password_policy_overrides=None):
+    '''Add user via uid and username and optionally overriding properties
+
+    Returns the new object path.
+   '''
+    path = get_user_path(uid)
+    default_props = {
+        'Uid': dbus.UInt64(uid),
+        'UserName': username,
+        'RealName': username[0].upper() + username[1:] + ' Fake',
+        'AccountType': dbus.Int32(1),
+        'AutomaticLogin': False,
+        'BackgroundFile': '',
+        'Email': '{}@python-dbusmock.org'.format(username),
+        'FormatsLocale': 'C',
+        'HomeDirectory': '/nonexisting/mock-home/{}'.format(username),
+        'IconFile': '',
+        'InputSources': dbus.Array([], signature='a{ss}'),
+        'Language': 'C',
+        'LocalAccount': True,
+        'Location': '',
+        'Locked': False,
+        'LoginFrequency': dbus.UInt64(0),
+        'LoginHistory': dbus.Array([], signature='(xxa{sv})'),
+        'LoginTime': dbus.Int64(0),
+        'PasswordHint': 'Remember it, come on!',
+        'PasswordMode': 0,
+        'Session': 'mock-session',
+        'SessionType': 'wayland',
+        'Shell': '/usr/bin/zsh',
+        'SystemAccount': False,
+        'XHasMessages': False,
+        'XKeyboardLayouts': dbus.Array([], signature='s'),
+        'XSession': 'mock-xsession',
+    }
+    default_props.update(overrides if overrides else {})
+    self.AddObject(path, USER_IFACE, default_props, [])
+
+    had_users = len(self.mock_users) != 0
+    had_multiple_users = len(self.mock_users) > 1
+    user = mockobject.objects[path]
+    user.password = password
+    user.properties = default_props
+    user.pwd_expiration_policy = {
+        'expiration_time': sys.maxsize,
+        'last_change_time': int(time.time()),
+        'min_days_between_changes': 0,
+        'max_days_between_changes': 0,
+        'days_to_warn': 0,
+        'days_after_expiration_until_lock': 0,
+    }
+    user.pwd_expiration_policy.update(
+        password_policy_overrides if password_policy_overrides else {})
+    self.mock_users[uid] = default_props
+
+    self.EmitSignal(MAIN_IFACE, 'UserAdded', 'o', [path])
+
+    if not had_users:
+        emit_properties_changed(self, MAIN_IFACE, 'HasNoUsers')
+    elif not had_multiple_users and len(self.mock_users) > 1:
+        emit_properties_changed(self, MAIN_IFACE, 'HasMultipleUsers')
+
+    return path
+
+
+@dbus.service.method(MOCK_IFACE, in_signature='', out_signature='ao')
+def ListMockUsers(self):
+    """ List the mock users that have been created """
+    return [get_user_path(uid) for uid in self.mock_users.keys()]
+
+
+@dbus.service.method(MOCK_IFACE, in_signature='s', out_signature='o')
+def AddAutoLoginUser(self, username):
+    """ Enable autologin for an user """
+    path = self.FindUserByName(username)
+    self.automatic_login_users.add(path)
+    user = mockobject.objects[path]
+    set_user_property(user, 'AutomaticLogin', True)
+    emit_properties_changed(self, MAIN_IFACE, 'AutomaticLoginUsers')
+    return path
+
+
+@dbus.service.method(MOCK_IFACE, in_signature='s', out_signature='o')
+def RemoveAutoLoginUser(self, username):
+    """ Disables autologin for an user """
+    path = self.FindUserByName(username)
+    self.automatic_login_users.remove(path)
+    user = mockobject.objects[path]
+    set_user_property(user, 'AutomaticLogin', False)
+    emit_properties_changed(self, MAIN_IFACE, 'AutomaticLoginUsers')
+    return path
+
+
+@dbus.service.method(MAIN_IFACE, in_signature='ssi', out_signature='o')
+def CreateUser(self, name, fullname, account_type):
+    """ Creates an user using the default API """
+    try:
+        self.FindUserByName(name)
+        found = True
+    except dbus.exceptions.DBusException:
+        found = False
+
+    if found:
+        raise dbus.exceptions.DBusException(
+            'User {} already exists'.format(name),
+            name='org.freedesktop.Accounts.Error.Failed')
+
+    self.users_auto_uids += 1
+
+    return self.AddUser(self.users_auto_uids, name, DEFAULT_USER_PASSWORD, {
+        'RealName': fullname, 'AccountType': account_type})
+
+
+@dbus.service.method(MAIN_IFACE, in_signature='xb')
+def DeleteUser(self, uid, _remove_files):
+    """ Removes a created user """
+    path = self.FindUserById(uid)
+
+    had_multiple_users = len(self.mock_users) > 1
+    self.RemoveObject(path)
+    self.mock_users.pop(uid)
+    self.automatic_login_users.discard(path)
+
+    self.EmitSignal(MAIN_IFACE, 'UserDeleted', 'o', [path])
+
+    if len(self.mock_users) == 0:
+        emit_properties_changed(self, MAIN_IFACE, 'HasNoUsers')
+    elif had_multiple_users and len(self.mock_users) < 2:
+        emit_properties_changed(self, MAIN_IFACE, 'HasMultipleUsers')
+
+
+@dbus.service.method(MAIN_IFACE, in_signature='s', out_signature='o')
+def CacheUser(self, username):
+    """ Cache an user """
+    path = self.FindUserByName(username)
+    self.cached_users.append(path)
+    return path
+
+
+@dbus.service.method(MAIN_IFACE, in_signature='s')
+def UncacheUser(self, username):
+    """ Removes an user from the cache """
+    path = self.FindUserByName(username)
+    self.cached_users.remove(path)
+
+
+@dbus.service.method(MAIN_IFACE, in_signature='', out_signature='ao')
+def ListCachedUsers(self):
+    """ Lists the cached users """
+    return self.cached_users
+
+
+@dbus.service.method(MAIN_IFACE, in_signature='x', out_signature='o')
+def FindUserById(_self, uid):
+    """ Finds an user by its user id """
+    user = mockobject.objects.get(get_user_path(uid), None)
+    if not user:
+        raise dbus.exceptions.DBusException(
+            'No such user exists',
+            name='org.freedesktop.Accounts.Error.Failed')
+    return get_user_path(uid)
+
+
+@dbus.service.method(MAIN_IFACE, in_signature='s', out_signature='o')
+def FindUserByName(self, username):
+    """ Finds an user form its name """
+    try:
+        [user_id] = [uid for uid, props in self.mock_users.items()
+                     if props['UserName'] == username]
+    except ValueError as e:
+        raise dbus.exceptions.DBusException(
+            'No such user exists: {}'.format(e),
+            name='org.freedesktop.Accounts.Error.Failed')
+    return get_user_path(user_id)
+
+
+@dbus.service.method(dbus.PROPERTIES_IFACE, in_signature='s',
+                     out_signature='a{sv}')
+def GetAll(self, interface):
+    """ Implements the GetAll dbus properties interface method.
+
+    This allows to override the getters using dynamic values.
+    """
+    if interface == MAIN_IFACE:
+        return {
+            'DaemonVersion': 'dbus-mock-0.1',
+            'HasNoUsers': len(self.mock_users) == 0,
+            'HasMultipleUsers': len(self.mock_users) > 1,
+            'AutomaticLoginUsers': dbus.Array(self.automatic_login_users,
+                                              signature='o'),
+        }
+    if interface == USER_IFACE:
+        return self.properties
+    return dbus.Dictionary({}, signature='sv')
+
+
+@dbus.service.method(dbus.PROPERTIES_IFACE, in_signature='ss',
+                     out_signature='v')
+def Get(self, interface, prop):
+    """ Implements the Get dbus properties interface method.
+
+    This allows to override the getters using dynamic values, via GetAll.
+    """
+    return self.GetAll(interface)[prop]
+
+
+def set_user_property(user, property_name, value):
+    """ Set an user property and emits the relative signals """
+    if user.properties[property_name] == value:
+        return
+    user.properties[property_name] = value
+    emit_properties_changed(user, USER_IFACE, property_name)
+    user.EmitSignal(USER_IFACE, 'Changed', '', [])
+
+
+@dbus.service.method(USER_IFACE, in_signature='s')
+def SetUserName(self, user_name):
+    set_user_property(self, 'UserName', user_name)
+
+
+@dbus.service.method(USER_IFACE, in_signature='s')
+def SetRealName(self, real_name):
+    set_user_property(self, 'RealName', real_name)
+
+
+@dbus.service.method(USER_IFACE, in_signature='s')
+def SetEmail(self, email):
+    set_user_property(self, 'Email', email)
+
+
+@dbus.service.method(USER_IFACE, in_signature='s')
+def SetLanguage(self, language):
+    set_user_property(self, 'Language', language)
+
+
+@dbus.service.method(USER_IFACE, in_signature='s')
+def SetXSession(self, x_session):
+    set_user_property(self, 'XSession', x_session)
+
+
+@dbus.service.method(USER_IFACE, in_signature='s')
+def SetSession(self, session):
+    set_user_property(self, 'Session', session)
+
+
+@dbus.service.method(USER_IFACE, in_signature='s')
+def SetSessionType(self, session_type):
+    set_user_property(self, 'SessionType', session_type)
+
+
+@dbus.service.method(USER_IFACE, in_signature='s')
+def SetLocation(self, location):
+    set_user_property(self, 'Location', location)
+
+
+@dbus.service.method(USER_IFACE, in_signature='s')
+def SetHomeDirectory(self, home_directory):
+    set_user_property(self, 'HomeDirectory', home_directory)
+
+
+@dbus.service.method(USER_IFACE, in_signature='s')
+def SetShell(self, shell):
+    set_user_property(self, 'Shell', shell)
+
+
+@dbus.service.method(USER_IFACE, in_signature='s')
+def SetIconFile(self, icon_file):
+    set_user_property(self, 'IconFile', icon_file)
+
+
+@dbus.service.method(USER_IFACE, in_signature='s')
+def SetLocked(self, locked):
+    set_user_property(self, 'Locked', locked)
+
+
+@dbus.service.method(USER_IFACE, in_signature='i')
+def SetAccountType(self, account_type):
+    set_user_property(self, 'AccountType', account_type)
+
+
+@dbus.service.method(USER_IFACE, in_signature='i')
+def SetPasswordMode(self, password_mode):
+    set_user_property(self, 'PasswordMode', password_mode)
+
+
+@dbus.service.method(USER_IFACE, in_signature='s')
+def SetPasswordHint(self, hint):
+    set_user_property(self, 'PasswordHint', hint)
+
+
+@dbus.service.method(USER_IFACE, in_signature='ss')
+def SetPassword(self, password, hint):
+    self.password = password
+    self.SetPasswordHint(hint)
+
+
+@dbus.service.method(USER_IFACE, in_signature='b')
+def SetAutomaticLogin(self, automatic_login):
+    manager = mockobject.objects[MAIN_OBJ]
+    if automatic_login:
+        manager.AddAutoLoginUser(self.properties['UserName'])
+    else:
+        manager.RemoveAutoLoginUser(self.properties['UserName'])
+
+
+@dbus.service.method(MOCK_IFACE, in_signature='xxxxxxx')
+def SetUserPasswordExpirationPolicy(self, uid, expiration_time,
+                                    last_change_time, min_days_between_changes,
+                                    max_days_between_changes, days_to_warn,
+                                    days_after_expiration_until_lock):
+    user = mockobject.objects[self.FindUserById(uid)]
+    user.pwd_expiration_policy = {
+        'expiration_time': expiration_time,
+        'last_change_time': last_change_time,
+        'min_days_between_changes': min_days_between_changes,
+        'max_days_between_changes': max_days_between_changes,
+        'days_to_warn': days_to_warn,
+        'days_after_expiration_until_lock': days_after_expiration_until_lock,
+    }
+    user.EmitSignal(USER_IFACE, 'Changed', '', [])
+
+
+@dbus.service.method(USER_IFACE, in_signature='', out_signature='xxxxxx')
+def GetPasswordExpirationPolicy(self):
+    return tuple(self.pwd_expiration_policy.values())

--- a/tests/test_accounts_service.py
+++ b/tests/test_accounts_service.py
@@ -1,0 +1,341 @@
+#!/usr/bin/python3
+""" Tests for accounts service """
+
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 3 of the License, or (at your option) any
+# later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
+# of the license.
+
+__author__ = 'Marco Trevisan'
+__copyright__ = '(c) 2021 Canonical Ltd.'
+
+import subprocess
+import sys
+import time
+import unittest
+
+import dbus
+import dbusmock
+
+try:
+    import gi  # type: ignore
+    gi.require_version('AccountsService', '1.0')
+    from gi.repository import AccountsService, GLib
+    have_accounts_service = True
+except (ImportError, ValueError):
+    have_accounts_service = False
+
+
+@unittest.skipUnless(have_accounts_service,
+                     'AccountsService gi introspection not available')
+class TestAccountsService(dbusmock.DBusTestCase):
+    '''Test mocking AccountsService'''
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.start_system_bus()
+        cls.dbus_con = cls.get_dbus(True)
+        cls.ctx = GLib.main_context_default()
+
+    def setUp(self):
+        super().setUp()
+        (self.p_mock, self.p_obj) = self.spawn_server_template(
+            'accounts_service', {}, stdout=subprocess.PIPE)
+        self.p_manager = AccountsService.UserManager.get_default()
+        while not self.p_manager.props.is_loaded:
+            self.ctx.iteration(True)
+        self.assertFalse(self.p_manager.no_service())
+        self.assertTrue(self.p_manager.props.is_loaded)
+
+    def get_property(self, name):
+        return self.p_obj.Get('org.freedesktop.Accounts', name,
+                              dbus_interface=dbus.PROPERTIES_IFACE)
+
+    def tearDown(self):
+        for user in self.p_manager.list_users():
+            self.p_manager.delete_user(user, False)
+
+        while self.p_manager.list_users():
+            self.ctx.iteration(True)
+
+        if self.p_mock:
+            self.p_mock.stdout.close()
+            self.p_mock.terminate()
+            self.p_mock.wait()
+
+        while self.p_manager.props.is_loaded:
+            self.ctx.iteration(True)
+
+        self.assertFalse(self.p_manager.props.is_loaded)
+        del self.p_manager
+        super().tearDown()
+
+    def wait_changed(self, user):
+        changed = False
+
+        def on_changed(u):
+            nonlocal changed
+            changed = u is user
+        conn_id = user.connect('changed', on_changed)
+        while not changed:
+            self.ctx.iteration(True)
+        user.disconnect(conn_id)
+
+    def test_empty(self):
+        self.assertTrue(self.p_manager.props.is_loaded)
+        self.assertFalse(self.p_manager.list_users())
+        self.assertFalse(self.p_manager.props.has_multiple_users)
+        self.assertFalse(self.p_obj.ListMockUsers())
+        self.assertTrue(self.get_property('HasNoUsers'))
+        self.assertFalse(self.get_property('HasMultipleUsers'))
+        self.assertFalse(self.get_property('AutomaticLoginUsers'))
+        self.assertEqual(self.get_property('DaemonVersion'), 'dbus-mock-0.1')
+
+    def test_create_users(self):
+        self.p_manager.create_user(
+            'pizza', 'I Love Pizza',
+            AccountsService.UserAccountType.ADMINISTRATOR)
+        creation_time = int(time.time())
+        self.assertFalse(self.p_manager.props.has_multiple_users)
+        self.assertFalse(self.get_property('HasNoUsers'))
+
+        [user] = self.p_manager.list_users()
+        self.assertEqual([user.get_object_path()], self.p_obj.ListMockUsers())
+        self.assertEqual(user.get_account_type(),
+                         AccountsService.UserAccountType.ADMINISTRATOR)
+        self.assertFalse(user.get_automatic_login())
+        self.assertEqual(user.get_email(), 'pizza@python-dbusmock.org')
+        self.assertEqual(user.get_home_dir(), '/nonexisting/mock-home/pizza')
+        self.assertEqual(user.get_icon_file(), '')
+        self.assertEqual(user.get_language(), 'C')
+        self.assertEqual(user.get_location(), '')
+        self.assertFalse(user.get_locked())
+        self.assertEqual(user.get_login_frequency(), 0)
+        self.assertEqual(user.get_login_history().unpack(), [])
+        self.assertEqual(user.get_login_time(), 0)
+        self.assertEqual(user.get_num_sessions(), 0)
+        self.assertEqual(user.get_num_sessions_anywhere(), 0)
+        self.assertEqual(user.get_object_path(),
+                         '/org/freedesktop/Accounts/User2001')
+        self.assertEqual(user.get_password_expiration_policy(),
+                         (sys.maxsize, creation_time, 0, 0, 0, 0))
+        self.assertEqual(user.get_password_hint(), 'Remember it, come on!')
+        self.assertEqual(user.get_password_mode(),
+                         AccountsService.UserPasswordMode.REGULAR)
+        self.assertIsNone(user.get_primary_session_id())
+        self.assertEqual(user.get_real_name(), 'I Love Pizza')
+        self.assertFalse(user.get_saved())
+        self.assertEqual(user.get_session(), 'mock-session')
+        self.assertEqual(user.get_session_type(), 'wayland')
+        self.assertEqual(user.get_shell(), '/usr/bin/zsh')
+        self.assertEqual(user.get_uid(), 2001)
+        self.assertEqual(user.get_user_name(), 'pizza')
+        self.assertEqual(user.get_x_session(), 'mock-xsession')
+        self.assertTrue(user.is_loaded())
+        self.assertTrue(user.is_local_account())
+        self.assertFalse(user.is_logged_in())
+        self.assertFalse(user.is_logged_in_anywhere())
+        self.assertFalse(user.is_nonexistent())
+        self.assertFalse(user.is_system_account())
+
+        other = self.p_manager.create_user(
+            'schiacciata', 'I Love Schiacciata too',
+            AccountsService.UserAccountType.STANDARD)
+
+        while not self.p_manager.props.has_multiple_users:
+            self.ctx.iteration(True)
+
+        self.assertTrue(self.p_manager.props.has_multiple_users)
+        self.assertFalse(self.get_property('HasNoUsers'))
+
+        self.assertIn(other, self.p_manager.list_users())
+        self.assertEqual(other.get_uid(), 2002)
+        self.assertEqual(other.get_user_name(), 'schiacciata')
+        self.assertEqual(other.get_real_name(), 'I Love Schiacciata too')
+        self.assertEqual(other.get_account_type(),
+                         AccountsService.UserAccountType.STANDARD)
+
+        self.assertEqual(
+            [u.get_object_path()
+             for u in self.p_manager.list_users()], self.p_obj.ListMockUsers())
+
+    def test_recreate_user(self):
+        self.p_manager.create_user(
+            'pizza', 'I Love Pizza',
+            AccountsService.UserAccountType.ADMINISTRATOR)
+        self.assertFalse(self.p_manager.props.has_multiple_users)
+        self.assertFalse(self.get_property('HasNoUsers'))
+
+        with self.assertRaises(GLib.Error) as error:
+            self.p_manager.create_user(
+                'pizza', 'More and more',
+                AccountsService.UserAccountType.STANDARD)
+        self.assertTrue(error.exception.matches(
+            AccountsService.UserManagerError.quark(),
+            AccountsService.UserManagerError.FAILED))
+        self.assertFalse(self.p_manager.props.has_multiple_users)
+
+    def test_set_user_properties(self):
+        # pylint: disable=too-many-statements
+        user = self.p_manager.create_user(
+            'test-user', 'I am a Test user',
+            AccountsService.UserAccountType.STANDARD)
+
+        user.set_account_type(
+            AccountsService.UserAccountType.ADMINISTRATOR)
+        self.wait_changed(user)
+        self.assertEqual(user.get_account_type(),
+                         AccountsService.UserAccountType.ADMINISTRATOR)
+
+        user.set_account_type(
+            AccountsService.UserAccountType.STANDARD)
+        self.wait_changed(user)
+        self.assertEqual(user.get_account_type(),
+                         AccountsService.UserAccountType.STANDARD)
+
+        user.set_automatic_login(True)
+        self.wait_changed(user)
+        self.assertTrue(user.get_automatic_login())
+
+        user.set_automatic_login(False)
+        self.wait_changed(user)
+        self.assertFalse(user.get_automatic_login())
+
+        user.set_email('test@email.org')
+        self.wait_changed(user)
+        self.assertEqual(user.get_email(), 'test@email.org')
+
+        user.set_icon_file('/nonexistant/home/icon.png')
+        self.wait_changed(user)
+        self.assertEqual(user.get_icon_file(), '/nonexistant/home/icon.png')
+
+        user.set_language('Test Language')
+        self.wait_changed(user)
+        self.assertEqual(user.get_language(), 'Test Language')
+
+        user.set_location('Test Location')
+        self.wait_changed(user)
+        self.assertEqual(user.get_location(), 'Test Location')
+
+        user.set_locked(True)
+        self.wait_changed(user)
+        self.assertTrue(user.get_locked())
+
+        user.set_locked(False)
+        self.wait_changed(user)
+        self.assertFalse(user.get_locked())
+
+        user.set_password('Test Password', 'Test PasswordHint')
+        self.wait_changed(user)
+        self.assertEqual(user.get_password_hint(), 'Test PasswordHint')
+
+        user.set_password_mode(AccountsService.UserPasswordMode.NONE)
+        self.wait_changed(user)
+        self.assertEqual(user.get_password_mode(),
+                         AccountsService.UserPasswordMode.NONE)
+
+        user.set_password_mode(AccountsService.UserPasswordMode.REGULAR)
+        self.wait_changed(user)
+        self.assertEqual(user.get_password_mode(),
+                         AccountsService.UserPasswordMode.REGULAR)
+
+        user.set_password_mode(AccountsService.UserPasswordMode.SET_AT_LOGIN)
+        self.wait_changed(user)
+        self.assertEqual(user.get_password_mode(),
+                         AccountsService.UserPasswordMode.SET_AT_LOGIN)
+
+        user.set_real_name('Test RealName')
+        self.wait_changed(user)
+        self.assertEqual(user.get_real_name(), 'Test RealName')
+
+        user.set_session('Test Session')
+        self.wait_changed(user)
+        self.assertEqual(user.get_session(), 'Test Session')
+
+        user.set_session_type('Test SessionType')
+        self.wait_changed(user)
+        self.assertEqual(user.get_session_type(), 'Test SessionType')
+
+        user.set_user_name('new-test-user')
+        self.wait_changed(user)
+        self.assertEqual(user.get_user_name(), 'new-test-user')
+
+        user.set_x_session('Test XSession')
+        self.wait_changed(user)
+        self.assertEqual(user.get_x_session(), 'Test XSession')
+
+    def test_automatic_login_users(self):
+        user = self.p_manager.create_user(
+            'test-user', 'I am a Test user',
+            AccountsService.UserAccountType.STANDARD)
+
+        user.set_automatic_login(True)
+        self.wait_changed(user)
+        self.assertTrue(user.get_automatic_login())
+        self.assertEqual(
+            [user.get_object_path()],
+            self.get_property('AutomaticLoginUsers'))
+        self.assertCountEqual(self.p_obj.ListMockUsers(),
+                              self.get_property('AutomaticLoginUsers'))
+
+        user2 = self.p_manager.create_user(
+            'another-test-user', 'I am another Test user',
+            AccountsService.UserAccountType.STANDARD)
+        self.assertNotIn(user2.get_object_path(),
+                         self.get_property('AutomaticLoginUsers'))
+
+        user2.set_automatic_login(True)
+        self.assertIn(user2.get_object_path(),
+                      self.get_property('AutomaticLoginUsers'))
+        self.assertEqual(len(self.get_property('AutomaticLoginUsers')), 2)
+        self.assertCountEqual(self.p_obj.ListMockUsers(),
+                              self.get_property('AutomaticLoginUsers'))
+
+        user.set_automatic_login(False)
+        self.wait_changed(user)
+        self.assertFalse(user.get_automatic_login())
+        self.assertNotIn(user.get_object_path(),
+                         self.get_property('AutomaticLoginUsers'))
+        self.assertEqual(len(self.get_property('AutomaticLoginUsers')), 1)
+
+        self.p_manager.delete_user(user2, False)
+        while user2 in self.p_manager.list_users():
+            self.ctx.iteration(True)
+        self.assertFalse(self.get_property('AutomaticLoginUsers'))
+
+    def test_automatic_login_users_via_mock(self):
+        with self.assertRaises(dbus.exceptions.DBusException):
+            self.p_obj.AddAutoLoginUser('non-existant')
+
+        with self.assertRaises(dbus.exceptions.DBusException):
+            self.p_obj.RemoveAutoLoginUser('non-existant')
+
+        user = self.p_manager.create_user(
+            'test-user', 'I am a Test user',
+            AccountsService.UserAccountType.STANDARD)
+
+        self.p_obj.AddAutoLoginUser(user.get_user_name())
+        self.wait_changed(user)
+        self.assertTrue(user.get_automatic_login())
+        self.assertIn(user.get_object_path(),
+                      self.get_property('AutomaticLoginUsers'))
+
+        #  Adding again to check we don't get confused!
+        self.p_obj.AddAutoLoginUser(user.get_user_name())
+        self.assertTrue(user.get_automatic_login())
+        self.assertCountEqual([user.get_object_path()],
+                              self.get_property('AutomaticLoginUsers'))
+
+        self.p_obj.RemoveAutoLoginUser(user.get_user_name())
+        self.wait_changed(user)
+        self.assertFalse(user.get_automatic_login())
+        self.assertNotIn(user.get_object_path(),
+                         self.get_property('AutomaticLoginUsers'))
+
+
+if __name__ == '__main__':
+    # avoid writing to stderr
+    unittest.main(testRunner=unittest.TextTestRunner(
+        stream=sys.stdout, verbosity=2))


### PR DESCRIPTION
template/accounts_service: add accounts service mock implementation

it allows to create fake users to be added to the accountsservice,
implementing all the service methods.

all the user properties can be simply mocked calling the adduser mock method or
during initialization via parameters.

---

Added unit tests, however I've not added the required dependency (`gir1.2-accountsservice-1.0`) because there are two issues blocking such tests: (mainly [!61](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/merge_requests/65) and [!65](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/merge_requests/65))