### PR TITLE
templates: Add systemd-user and systemd-system templates

### DIFF
--- a/dbusmock/templates/systemd.py
+++ b/dbusmock/templates/systemd.py
@@ -1,0 +1,106 @@
+'''systemd mock template
+'''
+
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 3 of the License, or (at your option) any
+# later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
+# of the license.
+
+__author__ = 'Jonas Ådahl'
+__copyright__ = '(c) 2021 Red Hat'
+
+from gi.repository import GLib
+import dbus
+
+from dbusmock import MOCK_IFACE, mockobject
+
+BUS_PREFIX = 'org.freedesktop.systemd1'
+PATH_PREFIX = '/org/freedesktop/systemd1'
+
+
+BUS_NAME = BUS_PREFIX
+MAIN_OBJ = PATH_PREFIX
+MAIN_IFACE = BUS_PREFIX + '.Manager'
+UNIT_IFACE = BUS_PREFIX + '.Unit'
+SYSTEM_BUS = True
+
+
+def load(mock, _parameters):
+    mock.next_job_id = 1
+    mock.units = {}
+
+    mock.AddProperties(MAIN_IFACE, {'Version': 'v246'})
+
+
+def escape_unit_name(name):
+    for s in ['.', '-']:
+        name = name.replace(s, '_')
+    return name
+
+
+def emit_job_new_remove(mock, job_id, job_path, name):
+    mock.EmitSignal(MAIN_IFACE, 'JobNew', 'uos', [job_id, job_path, name])
+    mock.EmitSignal(MAIN_IFACE, 'JobRemoved', 'uoss',
+                    [job_id, job_path, name, 'done'])
+
+
+@dbus.service.method(MAIN_IFACE, in_signature='ss', out_signature='o')
+def StartUnit(self, name, _mode):
+    job_id = self.next_job_id
+    self.next_job_id += 1
+
+    job_path = PATH_PREFIX + '/Job/{}'.format(job_id)
+    GLib.idle_add(lambda: emit_job_new_remove(self, job_id, job_path, name))
+
+    unit_path = self.units[str(name)]
+    unit = mockobject.objects[unit_path]
+    unit.UpdateProperties(UNIT_IFACE, {'ActiveState': 'active'})
+
+    return job_path
+
+
+@dbus.service.method(MAIN_IFACE, in_signature='ssa(sv)a(sa(sv))', out_signature='o')
+def StartTransientUnit(self, name, _mode, _properties, _aux):
+    job_id = self.next_job_id
+    self.next_job_id += 1
+
+    job_path = PATH_PREFIX + '/Job/%d' % (job_id)
+    GLib.idle_add(lambda: emit_job_new_remove(self, job_id, job_path, name))
+
+    return job_path
+
+
+@dbus.service.method(MAIN_IFACE, in_signature='ss', out_signature='o')
+def StopUnit(self, name, _mode):
+    job_id = self.next_job_id
+    self.next_job_id += 1
+
+    job_path = PATH_PREFIX + '/Job/%d' % (job_id)
+    GLib.idle_add(lambda: emit_job_new_remove(self, job_id, job_path, name))
+
+    unit_path = self.units[str(name)]
+    unit = mockobject.objects[unit_path]
+    unit.UpdateProperties(UNIT_IFACE, {'ActiveState': 'inactive'})
+    return job_path
+
+
+@dbus.service.method(MAIN_IFACE, in_signature='s', out_signature='o')
+def GetUnit(self, name):
+    unit_path = self.units[str(name)]
+    return unit_path
+
+
+@dbus.service.method(MOCK_IFACE, in_signature='s')
+def AddMockUnit(self, name):
+    unit_path = PATH_PREFIX + '/unit/%s' % (escape_unit_name(name))
+    self.units[str(name)] = unit_path
+    self.AddObject(unit_path,
+                   UNIT_IFACE,
+                   {
+                       'Id': name,
+                       'Names': [name],
+                       'LoadState': 'loaded',
+                       'ActiveState': 'inactive',
+                   },
+                   [])

--- a/tests/test_systemd.py
+++ b/tests/test_systemd.py
@@ -1,0 +1,112 @@
+#!/usr/bin/python3
+
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 3 of the License, or (at your option) any
+# later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
+# of the license.
+
+__author__ = 'Jonas Ådahl'
+__copyright__ = '(c) 2021 Red Hat'
+
+import subprocess
+import sys
+import unittest
+import dbus
+import dbus.mainloop.glib
+
+from gi.repository import GLib
+
+import dbusmock
+
+dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+
+
+class TestSystemd(dbusmock.DBusTestCase):
+    '''Test mocking systemd'''
+
+    @classmethod
+    def setUpClass(cls):
+        cls.start_session_bus()
+        cls.start_system_bus()
+        cls.session_bus = cls.get_dbus(False)
+        cls.system_bus = cls.get_dbus(True)
+
+    def setUp(self):
+        self.p_mock = None
+
+    def tearDown(self):
+        if self.p_mock:
+            self.p_mock.stdout.close()
+            self.p_mock.terminate()
+            self.p_mock.wait()
+
+    def _assert_unit_property(self, unit_obj, name, expect):
+        value = unit_obj.Get('org.freedesktop.systemd1.Unit', name)
+        self.assertEqual(str(value), expect)
+
+    def _test_base(self, bus, system_bus=True):
+        dummy_service = 'dummy-dbusmock.service'
+
+        (self.p_mock, obj_systemd) = self.spawn_server_template('systemd', {},
+                                                                subprocess.PIPE,
+                                                                system_bus=system_bus)
+
+        systemd_mock = dbus.Interface(obj_systemd, dbusmock.MOCK_IFACE)
+        systemd_mock.AddMockUnit(dummy_service)
+
+        main_loop = GLib.MainLoop()
+
+        removed_jobs = []
+
+        def catch_job_removed(*args, **kwargs):
+            if (kwargs['interface'] == 'org.freedesktop.systemd1.Manager' and
+                    kwargs['member'] == 'JobRemoved'):
+                job_path = str(args[1])
+                removed_jobs.append(job_path)
+                main_loop.quit()
+
+        def wait_for_job(path):
+            while True:
+                main_loop.run()
+                if path in removed_jobs:
+                    break
+
+        bus.add_signal_receiver(catch_job_removed,
+                                interface_keyword='interface',
+                                path_keyword='path',
+                                member_keyword='member')
+
+        unit_path = obj_systemd.GetUnit(dummy_service)
+
+        unit_obj = bus.get_object('org.freedesktop.systemd1', unit_path)
+
+        self._assert_unit_property(unit_obj, 'Id', dummy_service)
+        self._assert_unit_property(unit_obj, 'LoadState', 'loaded')
+        self._assert_unit_property(unit_obj, 'ActiveState', 'inactive')
+
+        job_path = obj_systemd.StartUnit(dummy_service, 'fail')
+
+        wait_for_job(job_path)
+        self._assert_unit_property(unit_obj, 'ActiveState', 'active')
+
+        job_path = obj_systemd.StopUnit(dummy_service, 'fail')
+
+        wait_for_job(job_path)
+        self._assert_unit_property(unit_obj, 'ActiveState', 'inactive')
+
+        self.p_mock.stdout.close()
+        self.p_mock.terminate()
+        self.p_mock.wait()
+        self.p_mock = None
+
+    def test_user(self):
+        self._test_base(self.session_bus, system_bus=False)
+
+    def test_system(self):
+        self._test_base(self.system_bus, system_bus=True)
+
+
+if __name__ == '__main__':
+    # avoid writing to stderr
+    unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout, verbosity=2))


### PR DESCRIPTION
The templates shares a common implementation, in systemd-base.py, that
implements mocked versions of StartUnit, StartTransientUnit and
StopUnit. It imitates systemd enough to make gnome-shell happy, thinking
it managed to launch the units it asked to have launched.