### PR TITLE
logind: Implement Inhibit and ListInhibitors

### DIFF
--- a/tests/test_logind.py
+++ b/tests/test_logind.py
@@ -113,6 +113,23 @@ class TestLogind(dbusmock.DBusTestCase):
         self.assertEqual(props['PreparingForSleep'], False)
         self.assertEqual(props['IdleSinceHint'], 0)
 
+    def test_inhibit(self):
+        (self.p_mock, obj_logind) = self.spawn_server_template('logind', {}, stdout=subprocess.PIPE)
+
+        # what, who, why, mode
+        fd = obj_logind.Inhibit('suspend', 'testcode', 'purpose', 'delay')
+
+        # Our inhibitor is held
+        out = subprocess.check_output(['systemd-inhibit'],
+                                      universal_newlines=True)
+        self.assertRegex(out, 'testcode +[0-9]+ +[^ ]* +[0-9]+ +[^ ]* +suspend purpose delay')
+
+        del fd
+        # No inhibitor is held
+        out = subprocess.check_output(['systemd-inhibit'],
+                                      universal_newlines=True)
+        self.assertRegex(out, 'No inhibitors')
+
 
 if __name__ == '__main__':
     # avoid writing to stderr


### PR DESCRIPTION
Properly track held inhibitors, replacing the previous dummy
implementation.

Note that previously the FD represented by the passed Inhibit_fd integer
would be passed back. This was never useful though, as it is impossible
to do anything interesting by setting the FD.