### PR TITLE
templates: Add power-profiles-daemon template

### DIFF
--- a/dbusmock/templates/power_profiles_daemon.py
+++ b/dbusmock/templates/power_profiles_daemon.py
@@ -1,0 +1,73 @@
+'''power-profiles-daemon mock template
+
+This creates the expected methods and properties of the main
+net.hadess.PowerProfiles object.
+
+This provides only the non-deprecated D-Bus API as of version 0.9.
+'''
+
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 3 of the License, or (at your option) any
+# later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
+# of the license.
+
+__author__ = 'Bastien Nocera'
+__copyright__ = '(c) 2021, Red Hat Inc.'
+
+import dbus
+
+BUS_NAME = 'net.hadess.PowerProfiles'
+MAIN_OBJ = '/net/hadess/PowerProfiles'
+MAIN_IFACE = 'net.hadess.PowerProfiles'
+SYSTEM_BUS = True
+
+
+def hold_profile(self, profile, reason, application_id):
+    self.cookie += 1
+    element = {'Profile': profile,
+               'Reason': reason,
+               'ApplicationId': application_id}
+    self.holds[self.cookie] = element
+    self.props[MAIN_IFACE]['ActiveProfileHolds'] = []
+    for value in self.holds.values():
+        self.props[MAIN_IFACE]['ActiveProfileHolds'].append(value)
+    return self.cookie
+
+
+def release_profile(self, cookie):
+    self.holds.pop(cookie)
+    self.props[MAIN_IFACE]['ActiveProfileHolds'] = []
+    for value in self.holds.values():
+        self.props[MAIN_IFACE]['ActiveProfileHolds'].append(value)
+    if len(self.props[MAIN_IFACE]['ActiveProfileHolds']) == 0:
+        self.props[MAIN_IFACE]['ActiveProfileHolds'] = \
+            dbus.Array([], signature='(aa{sv})')
+
+
+def load(mock, parameters):
+    # Loaded!
+    mock.loaded = True
+    mock.cookie = 0
+    mock.hold_profile = hold_profile
+    mock.release_profile = release_profile
+    mock.holds = {}
+
+    props = {
+        'ActiveProfile': parameters.get('ActiveProfile', 'balanced'),
+        'PerformanceDegraded': parameters.get('PerformanceDegraded', ''),
+        'Profiles': [
+            {'Profile': 'power-saver', 'Driver': 'dbusmock'},
+            {'Profile': 'balanced', 'Driver': 'dbusmock'},
+            {'Profile': 'performance', 'Driver': 'dbusmock'},
+        ],
+        'Actions': dbus.Array([], signature='(as)'),
+        'ActiveProfileHolds': dbus.Array([], signature='(aa{sv})'),
+    }
+    mock.AddProperties(MAIN_IFACE, dbus.Dictionary(props, signature='sv'))
+
+    mock.AddMethods(MAIN_IFACE, [
+        ('HoldProfile', 'sss', 'u',
+         'ret = self.hold_profile(self, args[0], args[1], args[2])'),
+        ('ReleaseProfile', 'u', '', 'self.release_profile(self, args[0])'),
+    ])

--- a/tests/run-fedora
+++ b/tests/run-fedora
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -eux
 # install build dependencies
+source /etc/os-release
+if [ $VERSION_ID == 34 ]; then
+    dnf -y install dnf-plugins-core
+    dnf -y copr enable hadess/power-profiles-daemon # FIXME remove when using Fedora 35 or newer
+fi
 dnf -y install python3-setuptools python3-gobject-base \
     python3-dbus dbus-x11 python3-pycodestyle python3-pyflakes python3-pylint python3-pip \
     upower NetworkManager bluez libnotify polkit power-profiles-daemon

--- a/tests/run-fedora
+++ b/tests/run-fedora
@@ -3,7 +3,7 @@ set -eux
 # install build dependencies
 dnf -y install python3-setuptools python3-gobject-base \
     python3-dbus dbus-x11 python3-pycodestyle python3-pyflakes python3-pylint python3-pip \
-    upower NetworkManager bluez libnotify polkit
+    upower NetworkManager bluez libnotify polkit power-profiles-daemon
 
 # systemd's tools otherwise fail on "not been booted with systemd"
 mkdir -p /run/systemd/system

--- a/tests/test_power_profiles_daemon.py
+++ b/tests/test_power_profiles_daemon.py
@@ -1,0 +1,148 @@
+#!/usr/bin/python3
+
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 3 of the License, or (at your option) any
+# later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
+# of the license.
+
+__author__ = 'Bastien Nocera'
+__copyright__ = '(c) 2021 Red Hat Inc.'
+
+import fcntl
+import os
+import shutil
+import subprocess
+import sys
+import unittest
+import time
+
+import dbus
+import dbus.mainloop.glib
+
+import dbusmock
+
+dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+
+have_powerprofilesctl = shutil.which('powerprofilesctl')
+
+
+@unittest.skipUnless(have_powerprofilesctl, 'powerprofilesctl not installed')
+class TestPowerProfilesDaemon(dbusmock.DBusTestCase):
+    '''Test mocking power-profiles-daemon'''
+    @classmethod
+    def setUpClass(cls):
+        cls.start_system_bus()
+        cls.dbus_con = cls.get_dbus(True)
+
+    def setUp(self):
+        (self.p_mock, self.obj_ppd) = self.spawn_server_template(
+            'power_profiles_daemon', {}, stdout=subprocess.PIPE)
+        # set log to nonblocking
+        flags = fcntl.fcntl(self.p_mock.stdout, fcntl.F_GETFL)
+        fcntl.fcntl(self.p_mock.stdout, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+        self.dbusmock = dbus.Interface(self.obj_ppd, dbusmock.MOCK_IFACE)
+
+    def tearDown(self):
+        self.p_mock.stdout.close()
+        self.p_mock.terminate()
+        self.p_mock.wait()
+
+    def test_list_profiles(self):
+        '''List Profiles and check active profile'''
+
+        out = subprocess.check_output(['powerprofilesctl'],
+                                      universal_newlines=True)
+
+        self.assertIn('performance:\n', out)
+        self.assertIn('\n* balanced:\n', out)
+
+    def test_change_profile(self):
+        '''Change ActiveProfile'''
+
+        subprocess.check_output(['powerprofilesctl', 'set', 'performance'],
+                                universal_newlines=True)
+        out = subprocess.check_output(['powerprofilesctl', 'get'],
+                                      universal_newlines=True)
+        self.assertEqual(out, 'performance\n')
+
+    def run_powerprofilesctl_list_holds(self):  # pylint: disable=no-self-use
+        return subprocess.check_output(['powerprofilesctl', 'list-holds'],
+                                       universal_newlines=True)
+
+    def test_list_holds(self):
+        '''Test holds'''
+
+        # No holds
+        out = self.run_powerprofilesctl_list_holds()
+        self.assertEqual(out, '')
+
+        # 1 hold
+        cmd = subprocess.Popen(['powerprofilesctl', 'launch', '-p',
+                                'power-saver', '-r', 'g-s-d mock test',
+                                '-i', 'org.gnome.SettingsDaemon.Power',
+                                'sleep', '60'],
+                               stdout=subprocess.PIPE)
+        time.sleep(0.3)
+
+        out = self.run_powerprofilesctl_list_holds()
+        self.assertEqual(out, 'Hold:\n'
+                              '  Profile:         power-saver\n'
+                              '  Application ID:'
+                              '  org.gnome.SettingsDaemon.Power\n'
+                              '  Reason:          g-s-d mock test\n')
+
+        # 2 holds
+        cmd2 = subprocess.Popen(['powerprofilesctl', 'launch', '-p',
+                                 'performance', '-r', 'running some game',
+                                 '-i', 'com.game.Game', 'sleep', '60'],
+                                stdout=subprocess.PIPE)
+        time.sleep(0.3)
+
+        out = self.run_powerprofilesctl_list_holds()
+        self.assertEqual(out, 'Hold:\n'
+                              '  Profile:         power-saver\n'
+                              '  Application ID:'
+                              '  org.gnome.SettingsDaemon.Power\n'
+                              '  Reason:          g-s-d mock test\n\n'
+                              'Hold:\n'
+                              '  Profile:         performance\n'
+                              '  Application ID:  com.game.Game\n'
+                              '  Reason:          running some game\n')
+
+        cmd.stdout.close()
+        cmd.terminate()
+        cmd.wait()
+
+        cmd2.stdout.close()
+        cmd2.terminate()
+        cmd2.wait()
+
+    def test_release_hold(self):
+        '''Test release holds'''
+
+        # No holds
+        out = self.run_powerprofilesctl_list_holds()
+        self.assertEqual(out, '')
+
+        # hold profile
+        cookie = self.obj_ppd.HoldProfile('performance',
+                                          'release test',
+                                          'com.test.Test')
+        out = self.run_powerprofilesctl_list_holds()
+        self.assertEqual(out, 'Hold:\n'
+                              '  Profile:         performance\n'
+                              '  Application ID:  com.test.Test\n'
+                              '  Reason:          release test\n')
+
+        # release profile
+        self.obj_ppd.ReleaseProfile(cookie)
+        time.sleep(0.3)
+        out = self.run_powerprofilesctl_list_holds()
+        self.assertEqual(out, '')
+
+
+if __name__ == '__main__':
+    # avoid writing to stderr
+    unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout,
+                                                     verbosity=2))


### PR DESCRIPTION
My Python-fu is weak, so I couldn't figure out how to append to the `ActiveProfileHolds` property (which is supposed to be an array), or how I could reference that recently appended "hold" to a separate store for `ReleaseHold` to use.

This is the error I get when I try to use the `.append()` path:
```
ERROR:dbus.service:Unable to append (dbus.Array([{'Profile': dbus.String('power-saver'), 'Reason': dbus.String('"g-s-d mock test"'), 'ApplicationId': dbus.String('org.gnome.SettingsDaemon.Power')}], signature=dbus.Signature('(aa{sv})')),) to message with signature v: <class 'TypeError'>: string indices must be integers
Traceback (most recent call last):
  File "/home/hadess/Projects/gnome-install/bin/powerprofilesctl", line 124, in get_profiles_property
    profiles = proxy.Get('(ss)', 'net.hadess.PowerProfiles', prop)
  File "/usr/lib/python3.9/site-packages/gi/overrides/Gio.py", line 349, in __call__
    result = self.dbus_proxy.call_sync(self.method_name, arg_variant,
gi.repository.GLib.Error: g-io-error-quark: GDBus.Error:org.freedesktop.DBus.Python.TypeError: Traceback (most recent call last):
  File "/usr/lib64/python3.9/site-packages/dbus/service.py", line 755, in _message_cb
    _method_reply_return(connection, message, method_name, signature, *retval)
  File "/usr/lib64/python3.9/site-packages/dbus/service.py", line 256, in _method_reply_return
    reply.append(signature=signature, *retval)
TypeError: string indices must be integers
 (36)
```