### PR TITLE
dbusmock: Disallow service activation on system bus

### DIFF
--- a/dbusmock/testcase.py
+++ b/dbusmock/testcase.py
@@ -60,7 +60,7 @@ class DBusTestCase(unittest.TestCase):
   <type>system</type>
   <keep_umask/>
   <listen>unix:tmpdir=/tmp</listen>
-  <standard_system_servicedirs />
+  <!-- We do not add standard_system_servicedirs (i.e. we have *no* service directory). -->
 
   <policy context="default">
     <allow send_destination="*" eavesdrop="true"/>


### PR DESCRIPTION
Even with standard_system_servicedirs empty, dbus-daemon will always add
the standard search directories in order to activate services. However,
in a test environment it is unexpected that a system service might be
started.

As such, disallow all calls to StartServiceByName, preventing any such
situation.