### PR TITLE
mockobject: Explicitly import importlib util module

### DIFF
--- a/dbusmock/mockobject.py
+++ b/dbusmock/mockobject.py
@@ -12,6 +12,7 @@ __copyright__ = '(c) 2012 Canonical Ltd.'
 
 import copy
 import importlib
+import importlib.util
 import os
 import sys
 import time


### PR DESCRIPTION
In some distributions it may not be possible to use the submodule
otherwise, as in current debian unstable:

Python 3.9.7 (default, Sep 24 2021, 09:43:00)
[GCC 10.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import importlib
>>> importlib.util
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'importlib' has no attribute 'util'