### PR TITLE
power_profiles_daemon: Update signature for Profiles array

### DIFF
--- a/dbusmock/templates/power_profiles_daemon.py
+++ b/dbusmock/templates/power_profiles_daemon.py
@@ -57,9 +57,9 @@ def load(mock, parameters):
         'ActiveProfile': parameters.get('ActiveProfile', 'balanced'),
         'PerformanceDegraded': parameters.get('PerformanceDegraded', ''),
         'Profiles': [
-            {'Profile': 'power-saver', 'Driver': 'dbusmock'},
-            {'Profile': 'balanced', 'Driver': 'dbusmock'},
-            {'Profile': 'performance', 'Driver': 'dbusmock'},
+            dbus.Dictionary({'Profile': 'power-saver', 'Driver': 'dbusmock'}, signature='sv'),
+            dbus.Dictionary({'Profile': 'balanced', 'Driver': 'dbusmock'}, signature='sv'),
+            dbus.Dictionary({'Profile': 'performance', 'Driver': 'dbusmock'}, signature='sv')
         ],
         'Actions': dbus.Array([], signature='(as)'),
         'ActiveProfileHolds': dbus.Array([], signature='(aa{sv})'),


### PR DESCRIPTION
It's declared as an array of a{sv} in the D-Bus interface, but the lack
of annotation means that it's exported as a{ss} instead.