### PR TITLE
mockobject: Wrap dbus.types.Array as is when changing properties

### DIFF
--- a/dbusmock/mockobject.py
+++ b/dbusmock/mockobject.py
@@ -92,7 +92,6 @@ def _format_args(args):
 
 def _wrap_in_dbus_variant(value):
     dbus_types = [
-        dbus.types.Array,
         dbus.types.ByteArray,
         dbus.types.Int16,
         dbus.types.ObjectPath,
@@ -112,6 +111,8 @@ def _wrap_in_dbus_variant(value):
     ]
     if isinstance(value, dbus.String):
         return dbus.String(str(value), variant_level=1)
+    if isinstance(value, dbus.types.Array):
+        return value
     if type(value) in dbus_types:
         return type(value)(value.conjugate(), variant_level=1)
     if isinstance(value, str):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -372,6 +372,20 @@ assert args[2] == 5
         self.assertEqual(changed_props,
                          [{'version': 5, 'connected': False}])
 
+        # test adding properties with the array type
+        self.dbus_mock.AddProperty('org.freedesktop.Test.Main',
+                                   'array',
+                                   dbus.Array(['first'], signature='s'))
+        self.assertEqual(self.dbus_props.Get('org.freedesktop.Test.Main', 'array'),
+                         ['first'])
+
+        # test updating properties with the array type
+        self.dbus_mock.UpdateProperties('org.freedesktop.Test.Main',
+                                        {'array': dbus.Array(['second', 'third'],
+                                                             signature='s')})
+        self.assertEqual(self.dbus_props.Get('org.freedesktop.Test.Main', 'array'),
+                         ['second', 'third'])
+
     def test_introspection_methods(self):
         '''dynamically added methods appear in introspection'''
 


### PR DESCRIPTION
This allows changing property with array as type. It's up to the caller
to make sure the array is populated properly. Not having this results in

    AttributeError: 'dbus.Array' object has no attribute 'conjugate'

when trying to update array properties.