### PR TITLE
logind: additions and improvements for Lock/Unlock/LockedHint

### DIFF
--- a/dbusmock/templates/logind.py
+++ b/dbusmock/templates/logind.py
@@ -268,11 +268,11 @@ def AddSession(self, session_id, seat, uid, username, active):
                    [
                        ('Activate', '', '', ''),
                        ('Kill', 'ss', '', ''),
-                       ('Lock', '', '', ''),
+                       ('Lock', '', '', 'self.EmitSignal("", "Lock", "", [])'),
                        ('SetIdleHint', 'b', '', ''),
                        ('SetLockedHint', 'b', '', 'self.UpdateProperties("", {"LockedHint": args[0]})'),
                        ('Terminate', '', '', ''),
-                       ('Unlock', '', '', ''),
+                       ('Unlock', '', '', 'self.EmitSignal("", "Unlock", "", [])'),
                    ])
 
     # add session to seat

--- a/dbusmock/templates/logind.py
+++ b/dbusmock/templates/logind.py
@@ -241,6 +241,7 @@ def AddSession(self, session_id, seat, uid, username, active):
                        'ResetControllers': dbus.Array([], signature='s'),
                        'Active': active,
                        'IdleHint': False,
+                       'LockedHint': False,
                        'KillProcesses': False,
                        'Remote': False,
                        'Class': 'user',
@@ -269,6 +270,7 @@ def AddSession(self, session_id, seat, uid, username, active):
                        ('Kill', 'ss', '', ''),
                        ('Lock', '', '', ''),
                        ('SetIdleHint', 'b', '', ''),
+                       ('SetLockedHint', 'b', '', 'self.UpdateProperties("", {"LockedHint": args[0]})'),
                        ('Terminate', '', '', ''),
                        ('Unlock', '', '', ''),
                    ])

--- a/tests/test_logind.py
+++ b/tests/test_logind.py
@@ -17,6 +17,7 @@ import sys
 import unittest
 import tracemalloc
 
+import dbus
 import dbusmock
 
 tracemalloc.start(25)
@@ -105,6 +106,17 @@ class TestLogind(dbusmock.DBusTestCase):
         self.assertRegex(out, 'Active=yes')
         self.assertRegex(out, 'State=active')
         self.assertRegex(out, 'Name=joe')
+        self.assertRegex(out, 'LockedHint=no')
+
+        session_mock = dbus.Interface(self.dbus_con.get_object(
+            'org.freedesktop.login1', '/org/freedesktop/login1/session/c1'),
+            'org.freedesktop.login1.Session')
+        session_mock.SetLockedHint(True)
+
+        out = subprocess.check_output(['loginctl', 'show-session', 'c1'],
+                                      universal_newlines=True)
+        self.assertRegex(out, 'Id=c1')
+        self.assertRegex(out, 'LockedHint=yes')
 
     def test_properties(self):
         (self.p_mock, obj_logind) = self.spawn_server_template('logind', {}, stdout=subprocess.PIPE)


### PR DESCRIPTION
The two commits add the `LockedHint`/`SetLockedHint()` property/method and
amend the `Lock()`/`Unlock()` methods to emit their respective signals, as
described in the interface documentation.