### PR TITLE
mockobject: Print the object path when manipulating properties

### DIFF
--- a/dbusmock/mockobject.py
+++ b/dbusmock/mockobject.py
@@ -202,7 +202,7 @@ class DBusMockObject(dbus.service.Object):  # pylint: disable=too-many-instance-
     def Get(self, interface_name: str, property_name: str) -> Any:
         '''Standard D-Bus API for getting a property value'''
 
-        self.log(f'Get {interface_name}.{property_name}')
+        self.log(f'Get {self.path} {interface_name}.{property_name}')
 
         if not interface_name:
             interface_name = self.interface
@@ -218,7 +218,7 @@ class DBusMockObject(dbus.service.Object):  # pylint: disable=too-many-instance-
     def GetAll(self, interface_name: str, *_, **__) -> PropsType:
         '''Standard D-Bus API for getting all property values'''
 
-        self.log('GetAll ' + interface_name)
+        self.log(f'GetAll {self.path} {interface_name}')
 
         if not interface_name:
             interface_name = self.interface
@@ -234,7 +234,7 @@ class DBusMockObject(dbus.service.Object):  # pylint: disable=too-many-instance-
     def Set(self, interface_name: str, property_name: str, value: Any, *_, **__) -> None:
         '''Standard D-Bus API for setting a property value'''
 
-        self.log(f'Set {interface_name}.{property_name}{_format_args((value,))}')
+        self.log(f'Set {self.path} {interface_name}.{property_name}{_format_args((value,))}')
 
         try:
             iface_props = self.props[interface_name]
@@ -578,7 +578,7 @@ class DBusMockObject(dbus.service.Object):  # pylint: disable=too-many-instance-
         m.append(signature=signature, *args)
         args = m.get_args_list()
 
-        fn = lambda self, *args: self.log(f'emit {interface}.{name}{_format_args(args)}')
+        fn = lambda self, *args: self.log(f'emit {self.path} {interface}.{name}{_format_args(args)}')
         fn.__name__ = str(name)
         dbus_fn = dbus.service.signal(interface)(fn)
         dbus_fn._dbus_signature = signature

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -318,10 +318,10 @@ assert args[2] == 5
         # check that the Get/Set calls get logged
         with open(self.mock_log.name, encoding="UTF-8") as f:
             contents = f.read()
-            self.assertRegex(contents, '\n[0-9.]+ Get org.freedesktop.Test.Main.version\n')
-            self.assertRegex(contents, '\n[0-9.]+ Get org.freedesktop.Test.Main.connected\n')
-            self.assertRegex(contents, '\n[0-9.]+ GetAll org.freedesktop.Test.Main\n')
-            self.assertRegex(contents, '\n[0-9.]+ Set org.freedesktop.Test.Main.version 4\n')
+            self.assertRegex(contents, '\n[0-9.]+ Get / org.freedesktop.Test.Main.version\n')
+            self.assertRegex(contents, '\n[0-9.]+ Get / org.freedesktop.Test.Main.connected\n')
+            self.assertRegex(contents, '\n[0-9.]+ GetAll / org.freedesktop.Test.Main\n')
+            self.assertRegex(contents, '\n[0-9.]+ Set / org.freedesktop.Test.Main.version 4\n')
 
         # add property to different interface
         self.dbus_mock.AddProperty('org.freedesktop.Test.Other',
@@ -512,10 +512,10 @@ assert args[2] == 5
         # check correct logging
         with open(self.mock_log.name, encoding="UTF-8") as f:
             log = f.read()
-        self.assertRegex(log, '[0-9.]+ emit org.freedesktop.Test.Main.SigNoArgs\n')
-        self.assertRegex(log, '[0-9.]+ emit org.freedesktop.Test.Sub.SigTwoArgs "hello" 42\n')
-        self.assertRegex(log, '[0-9.]+ emit org.freedesktop.Test.Sub.SigTypeTest -42 42')
-        self.assertRegex(log, r'[0-9.]+ emit org.freedesktop.Test.Sub.SigTypeTest -42 42 "hello" \["/a", "/b"\]\n')
+        self.assertRegex(log, '[0-9.]+ emit / org.freedesktop.Test.Main.SigNoArgs\n')
+        self.assertRegex(log, '[0-9.]+ emit / org.freedesktop.Test.Sub.SigTwoArgs "hello" 42\n')
+        self.assertRegex(log, '[0-9.]+ emit / org.freedesktop.Test.Sub.SigTypeTest -42 42')
+        self.assertRegex(log, r'[0-9.]+ emit / org.freedesktop.Test.Sub.SigTypeTest -42 42 "hello" \["/a", "/b"\]\n')
 
     def test_signals_type_mismatch(self):
         '''emitting signals with wrong arguments'''

--- a/tests/test_gnome_screensaver.py
+++ b/tests/test_gnome_screensaver.py
@@ -51,7 +51,7 @@ class TestGnomeScreensaver(dbusmock.DBusTestCase):
         self.assertGreater(self.obj_ss.GetActiveTime(), 0)
 
         self.assertRegex(self.p_mock.stdout.read(),
-                         b'emit org.gnome.ScreenSaver.ActiveChanged True\n')
+                         b'emit /org/gnome/ScreenSaver org.gnome.ScreenSaver.ActiveChanged True\n')
 
     def test_set_active(self):
         '''SetActive()'''
@@ -59,12 +59,12 @@ class TestGnomeScreensaver(dbusmock.DBusTestCase):
         self.obj_ss.SetActive(True)
         self.assertEqual(self.obj_ss.GetActive(), True)
         self.assertRegex(self.p_mock.stdout.read(),
-                         b'emit org.gnome.ScreenSaver.ActiveChanged True\n')
+                         b'emit /org/gnome/ScreenSaver org.gnome.ScreenSaver.ActiveChanged True\n')
 
         self.obj_ss.SetActive(False)
         self.assertEqual(self.obj_ss.GetActive(), False)
         self.assertRegex(self.p_mock.stdout.read(),
-                         b'emit org.gnome.ScreenSaver.ActiveChanged False\n')
+                         b'emit /org/gnome/ScreenSaver org.gnome.ScreenSaver.ActiveChanged False\n')
 
 
 if __name__ == '__main__':

--- a/tests/test_upower.py
+++ b/tests/test_upower.py
@@ -76,7 +76,7 @@ class TestUPower(dbusmock.DBusTestCase):
         self.assertEqual(path, '/org/freedesktop/UPower/devices/mock_AC')
 
         self.assertRegex(self.p_mock.stdout.read(),
-                         b'emit org.freedesktop.UPower.DeviceAdded '
+                         b'emit /org/freedesktop/UPower org.freedesktop.UPower.DeviceAdded '
                          b'"/org/freedesktop/UPower/devices/mock_AC"\n')
 
         out = subprocess.check_output(['upower', '--dump'],
@@ -107,7 +107,7 @@ class TestUPower(dbusmock.DBusTestCase):
         self.assertEqual(path, '/org/freedesktop/UPower/devices/mock_BAT')
 
         self.assertRegex(self.p_mock.stdout.read(),
-                         b'emit org.freedesktop.UPower.DeviceAdded '
+                         b'emit /org/freedesktop/UPower org.freedesktop.UPower.DeviceAdded '
                          b'"/org/freedesktop/UPower/devices/mock_BAT"\n')
 
         out = subprocess.check_output(['upower', '--dump'],
@@ -127,7 +127,7 @@ class TestUPower(dbusmock.DBusTestCase):
         self.assertEqual(path, '/org/freedesktop/UPower/devices/mock_BAT')
 
         self.assertRegex(self.p_mock.stdout.read(),
-                         b'emit org.freedesktop.UPower.DeviceAdded '
+                         b'emit /org/freedesktop/UPower org.freedesktop.UPower.DeviceAdded '
                          b'"/org/freedesktop/UPower/devices/mock_BAT"\n')
 
         out = subprocess.check_output(['upower', '--dump'],


### PR DESCRIPTION
This is invaluable when debugging property changes with multiple object
paths involved, such as bluez with multiple Bluetooth adapters.