### PR TITLE
dbusmock: Allow creating/enabling .service files

### DIFF
--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -50,7 +50,7 @@ class StaticCodeTests(unittest.TestCase):
         subprocess.check_call(pylint +
                               ['--score=n',
                                '--disable=missing-module-docstring,missing-class-docstring,missing-function-docstring',
-                               '--disable=too-many-public-methods,R0801', 'tests/'])
+                               '--disable=too-many-public-methods,too-many-lines,R0801', 'tests/'])
 
     @unittest.skipUnless(mypy, 'mypy not installed')
     def test_types(self):  # pylint: disable=no-self-use


### PR DESCRIPTION
We now provide a classmethod to get the service directory of the dbus
server that will be launched. Also new is the enable_service function
which will symlink the service in order to enable it in the test
environment.

---

This is working great for the g-s-d tests. The attribute is a bit ugly, but `cls` can be either `DBusTestCase` or any subclass, making it unpredictable if it is first called with a derived class as an argument. As such, the code just hardcodes `DBusTestCase` (and manually mangles the name for the delattr).