### PR TITLE
Ensure method calls from templates are logged

### DIFF
--- a/dbusmock/templates/ofono.py
+++ b/dbusmock/templates/ofono.py
@@ -45,7 +45,7 @@ def load(mock, parameters):
                    'ret = [(m, objects[m].GetAll("org.ofono.Modem")) for m in self.modems]')
 
     if not parameters.get('no_modem', False):
-        mock.AddModem(parameters.get('ModemName', 'ril_0'), {})
+        mock.AddModem(parameters.get('ModemName', 'ril_0'), dbus.Dictionary({}, signature='sv'))
 
 
 #  interface org.ofono.Modem {


### PR DESCRIPTION
For interfaces loaded via a template, calls to static methods were never
logged and the MethodCalled signal was never emitted. Fix this by
wrapping the function from the module in what is a "standard" Python
function debug decorator, except that it adds the calls to the log
instead.

This is a bit awkward since the first argument is always self - we need
to pass that on to the function but we don't want to log it.

*Note: not 100% sure that's the right approach but couldn't think of anything else*