### PR TITLE
Revert "ofono template: Explicitly specify empty dict signature"

### DIFF
--- a/dbusmock/templates/ofono.py
+++ b/dbusmock/templates/ofono.py
@@ -45,7 +45,7 @@ def load(mock, parameters):
                    'ret = [(m, objects[m].GetAll("org.ofono.Modem")) for m in self.modems]')
 
     if not parameters.get('no_modem', False):
-        mock.AddModem(parameters.get('ModemName', 'ril_0'), dbus.Dictionary({}, signature='sv'))
+        mock.AddModem(parameters.get('ModemName', 'ril_0'), {})
 
 
 #  interface org.ofono.Modem {


### PR DESCRIPTION
This was fixed properly in commit 501d96249b8416.

This reverts commit e52f87e17e11285cc70752c053a9db7a2064e2d9.