### PR TITLE
testcase: Throw an error when spawning a well-known name that exists

### DIFF
--- a/dbusmock/testcase.py
+++ b/dbusmock/testcase.py
@@ -222,6 +222,10 @@ class DBusTestCase(unittest.TestCase):
         argv.append(path)
         argv.append(interface)
 
+        bus = cls.get_dbus(system_bus)
+        if bus.name_has_owner(name):
+            raise AssertionError(f'Trying to spawn a server for name {name} but it is already owned!')
+
         # pylint: disable=consider-using-with
         daemon = subprocess.Popen(argv, stdout=stdout)
 


### PR DESCRIPTION
It is expected that the name is not yet owned. And if we continue, we'll
likely try to re-initialize an existing object that should have been
cleaned up. If this happens, the likely explanation is that a previous
test left the mock environment in a bad state, so error out immediately
with an error that is easier to understand.