### PR TITLE
Allow setting the destination on signals

### DIFF
--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -50,7 +50,8 @@ class StaticCodeTests(unittest.TestCase):
         subprocess.check_call(pylint +
                               ['--score=n',
                                '--disable=missing-module-docstring,missing-class-docstring,missing-function-docstring',
-                               '--disable=too-many-public-methods,too-many-lines,R0801', 'tests/'])
+                               '--disable=too-many-public-methods,too-many-lines,too-many-statements,R0801',
+                               'tests/'])
 
     @unittest.skipUnless(mypy, 'mypy not installed')
     def test_types(self):  # pylint: disable=no-self-use


### PR DESCRIPTION
Sits on top of ~~#128~~ #130 

~~Requires dbus-python to update first: https://gitlab.freedesktop.org/dbus/dbus-python/-/merge_requests/13~~

Switch to use dbus-python's `SignalMessage` directly for our signal emission instead of wrapping the `@signal` decorator.

Add a new DBus method EmitSignalDetailed that also takes an a{sv} of
magic keywords for details to be passed down.

The only supported detail right now is "destination" for the destination ~~, using
the new destination_keyword from dbus-python, see
https://gitlab.freedesktop.org/dbus/dbus-python/-/merge_requests/18~~

This allows us to send signals to one specific target even if they don't
have a match rule setup (used by libportal for example).