### PR TITLE
tests: disable the "too many statements" error in pylint

### DIFF
--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -50,7 +50,8 @@ class StaticCodeTests(unittest.TestCase):
         subprocess.check_call(pylint +
                               ['--score=n',
                                '--disable=missing-module-docstring,missing-class-docstring,missing-function-docstring',
-                               '--disable=too-many-public-methods,too-many-lines,R0801', 'tests/'])
+                               '--disable=too-many-public-methods,too-many-lines,too-many-statements,R0801',
+                               'tests/'])
 
     @unittest.skipUnless(mypy, 'mypy not installed')
     def test_types(self):  # pylint: disable=no-self-use


### PR DESCRIPTION
For tests, we can easily run past the limit of 50 and it doesn't
necessarily indicate bad code quality.