### PR TITLE
setup.py: list our dbus-python dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,9 @@ setuptools.setup(
     download_url='https://pypi.python.org/pypi/python-dbusmock/',
     license='LGPL 3+',
     packages=['dbusmock', 'dbusmock.templates'],
+    install_requires=[
+        'dbus-python',
+    ],
 
     classifiers=[
         'Programming Language :: Python',


### PR DESCRIPTION
This is a direct dependency required to import dbusmock itself.  This
lets `import dbusmock` work after `pip install python-dbusmock` in a
clean venv.

Unfortunately, tests don't run yet.  Dealing with our dependency on
`gi.repository` is going to be a lot more complicated.

Fixes #133