### PR TITLE
tests: Fix previous commit for RPM package builds

### DIFF
--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -22,6 +22,7 @@ try:
     pylint_version = subprocess.check_output(['python3', '-m', 'pylint', '--version'], stderr=subprocess.DEVNULL)
     pylint = [sys.executable, '-m', 'pylint']
 except subprocess.CalledProcessError:
+    pylint_version = b''
     pylint = []
 
 if subprocess.call(['python3', '-m', 'mypy', '--version'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) == 0:


### PR DESCRIPTION
We need to define `pylint_version` for the uninstalled case as well.

---

See [failed rawhide build](https://download.copr.fedorainfracloud.org/results/packit/martinpitt-python-dbusmock-134/fedora-rawhide-x86_64/04569851-python-dbusmock/builder-live.log.gz) from #134