### PR TITLE
ofono template: fix conversion to f-strings

### DIFF
--- a/dbusmock/templates/ofono.py
+++ b/dbusmock/templates/ofono.py
@@ -346,7 +346,7 @@ def add_simmanager_api(self, mock):
     mock.AddMethods(iface, [
         ('GetProperties', '', 'a{sv}', f'ret = self.GetAll("{iface}")'),
         ('SetProperty', 'sv', '', f'self.Set("{iface}", args[0], args[1]); '
-         'self.EmitSignal("{iface}", "PropertyChanged", "sv", [args[0], args[1]])'),
+         f'self.EmitSignal("{iface}", "PropertyChanged", "sv", [args[0], args[1]])'),
         ('ChangePin', 'sss', '', ''),
 
         ('EnterPin', 'ss', '',
@@ -419,7 +419,7 @@ def add_connectionmanager_api(mock):
     mock.AddMethods(iface, [
         ('GetProperties', '', 'a{sv}', f'ret = self.GetAll("{iface}")'),
         ('SetProperty', 'sv', '', f'self.Set("{iface}", args[0], args[1]); '
-         'self.EmitSignal("{iface}", "PropertyChanged", "sv", [args[0], args[1]])'),
+         f'self.EmitSignal("{iface}", "PropertyChanged", "sv", [args[0], args[1]])'),
         ('AddContext', 's', 'o', 'ret = "/"'),
         ('RemoveContext', 'o', '', ''),
         ('DeactivateAll', '', '', ''),


### PR DESCRIPTION
For the continued Python string, the f-string identifier has to be
re-specified again. Without this, tests of lomiri-indicator-network
breaks.

Fixes: 872a7e33 ("Move to f-strings")