### PR TITLE
Fix missing __version__ attribute

### DIFF
--- a/dbusmock/__init__.py
+++ b/dbusmock/__init__.py
@@ -7,8 +7,11 @@
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
+from .version import version
+
 __author__ = 'Martin Pitt'
 __copyright__ = '(c) 2012 Canonical Ltd.'
+__version__ = version
 
 from dbusmock.mockobject import (DBusMockObject, MOCK_IFACE,
                                  OBJECT_MANAGER_IFACE, get_object, get_objects)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ packages = ["dbusmock", "dbusmock.templates"]
 
 [tool.setuptools_scm]
 version_scheme = 'post-release'
+write_to = "dbusmock/version.py"
 
 [tool.pylint]
 format = { max-line-length = 130 }


### PR DESCRIPTION
Without this autotools based version checking fails.

More specifically, checking the version with AX_PYTHON_MODULE_VERSION and version 0.28.2 installed will fail as it expects the '__version__' attribute to exist (this was removed in a6130f0490e95783619cd75d37e2e1e12364d51a when adding setuptools-scm): https://git.savannah.gnu.org/gitweb/?p=autoconf-archive.git;a=blob_plain;f=m4/ax_python_module_version.m4

This patch tells setuptools_scm to write the version out to a file, then imports the version from that file.