### PR TITLE
Bring back dbusmock.__version__, revert sdist build to setup.py

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - '[0-9]*'
 jobs:
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -17,18 +17,10 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y python3-build python3-setuptools python3-venv
-
-      - name: Hack around https://bugs.debian.org/1009916
-        run: |
-          if dpkg --compare-versions $(dpkg-query -f '${Version}' --show python3-build) '<<' 0.7.0-3; then
-              cd /tmp/
-              wget https://launchpad.net/ubuntu/+source/python-build/0.7.0-3/+build/23584797/+files/python3-build_0.7.0-3_all.deb
-              sudo dpkg -i python3-build_0.7.0-3_all.deb
-          fi
+          sudo apt-get install -y python3-setuptools
 
       - name: Build release tarball
-        run: python3 -m build --sdist
+        run: ./setup.py sdist
 
       - name: Create GitHub release
         uses: eloquent/github-release-action@v2

--- a/dbusmock/__init__.py
+++ b/dbusmock/__init__.py
@@ -9,6 +9,8 @@
 
 __author__ = 'Martin Pitt'
 __copyright__ = '(c) 2012 Canonical Ltd.'
+__version__ = '0.28.2'
+
 
 from dbusmock.mockobject import (DBusMockObject, MOCK_IFACE,
                                  OBJECT_MANAGER_IFACE, get_object, get_objects)

--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,14 @@
 
 import setuptools
 
+from dbusmock import __version__
+
 with open('README.md', encoding="UTF-8") as f:
     readme = f.read()
 
 setuptools.setup(
     name='python-dbusmock',
-    version="0.28.2",
+    version=__version__,
     description='Mock D-Bus objects',
     long_description=readme,
     long_description_content_type='text/markdown',

--- a/tests/run-debian
+++ b/tests/run-debian
@@ -12,7 +12,7 @@ eatmydata apt-get -y --purge dist-upgrade
 
 # install build dependencies
 eatmydata apt-get install --no-install-recommends -y git \
-    python3-all python3-setuptools python3-build python3-venv \
+    python3-all python3-setuptools \
     python3-dbus python3-gi gir1.2-glib-2.0 \
     pyflakes3 pycodestyle \
     dbus libnotify-bin upower network-manager bluez ofono ofono-scripts
@@ -34,10 +34,5 @@ done
 wait
 [ ! -e /tmp/fail ]
 
-# check sdist; note https://bugs.debian.org/1009916
-if dpkg --compare-versions \$(dpkg-query -f '\${Version}' --show python3-build) '>=' 0.7.0-3; then
-    my_version=\$(git describe --abbrev=0)
-    python3 -m build --sdist
-    tar --wildcards -xOf dist/python-dbusmock-\${my_version}*.tar.gz '*/PKG-INFO' | grep "^Version: \${my_version}"
-fi
+./setup.py sdist
 EOF

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1073,6 +1073,9 @@ class TestServiceAutostart(dbusmock.DBusTestCase):
 
         dbus_if.StartServiceByName('org.TestSystem', 0)
 
+    def test_version(self):
+        self.assertGreater(dbusmock.__version__, "0.28.0")
+
 
 if __name__ == '__main__':
     # avoid writing to stderr


### PR DESCRIPTION
autotools's version checks or upower's test suite rely on this, so this
is API. Add a unit test to ensure it exists.

This should ideally be generated automatically [1], but that does not
work as long as packit, rpm builds etc. don't get along with pyproject.

So for the time being, move the static version back to
dbusmock/__init__.py, and read it from setup.py instead.

[1] https://github.com/martinpitt/python-dbusmock/pull/140


----

See [0.28.2 Debian regression](https://tracker.debian.org/pkg/python-dbusmock), breaks upower. Also thanks to @benjamb for his attempt in #140!