### PR TITLE
Fix sys.path for loading dbusmock in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,11 @@
 
 '''python-dbusmock - Mock D-Bus objects for testing'''
 
+import sys
+
 import setuptools
+
+sys.path.insert(0, ".")
 
 from dbusmock import __version__
 


### PR DESCRIPTION
Ensure that "." is inserted into sys.path prior to importing dbusmock.
This path may not be added implicitly when using the PEP517 backend
to perform the build, e.g. via gpep517.

Fixes #142