### PR TITLE
setup.py: Fix ModuleNotFoundError

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+version = attr: dbusmock.__version__

--- a/setup.py
+++ b/setup.py
@@ -6,14 +6,11 @@
 
 import setuptools
 
-from dbusmock import __version__
-
 with open('README.md', encoding="UTF-8") as f:
     readme = f.read()
 
 setuptools.setup(
     name='python-dbusmock',
-    version=__version__,
     description='Mock D-Bus objects',
     long_description=readme,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Commit 842d2506fb71 broke `pip install` and also some variants of
PEP-517 build tools: `.` is not in their default `sys.path` any more.
Merely adding that to the search path is not sufficient: building an
sdist in a venv is tripping over the missing `import dbus`, as
dbus-python is just a runtime dependency, not a build-time one.

So instead of importing `dbusmock.__version__` in setup.py, ask
setuptools to dynamically generate the version in a declarative way, in
setup.cfg.

Many thanks to Michał Górny for analyzing this and proposing this
solution!

Fixes #142