### PR TITLE
Explicitly opt into static code tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,9 +15,12 @@ jobs:
           - docker.io/ubuntu:devel
           - docker.io/ubuntu:rolling
           - docker.io/ubuntu:latest
-          - registry.fedoraproject.org/fedora:latest
           - registry.fedoraproject.org/fedora:rawhide
           - quay.io/centos/centos:stream8
+        include:
+          # only run static code tests on a single release, to avoid contradicting requirements from e.g. different pylint releases
+          - scenario: registry.fedoraproject.org/fedora:latest
+            env: TEST_CODE=1
 
     timeout-minutes: 30
     steps:
@@ -32,4 +35,4 @@ jobs:
           dpkg -s podman docker || true
           cat /etc/apt/sources.list
           cat /etc/apt/sources.list.d/*
-          tests/run ${{ matrix.scenario }}
+          ${{ matrix.env }} tests/run ${{ matrix.scenario }}

--- a/tests/run
+++ b/tests/run
@@ -15,4 +15,4 @@ fi
 
 OS=${IMAGE##*/}
 OS=${OS%:*}
-$RUNC run --interactive -e DEBUG=${DEBUG:-} --rm ${RUNC_OPTIONS:-} ${PYLINT:-} --volume `pwd`:/source:ro --workdir /source "$IMAGE" /bin/sh tests/run-$OS
+$RUNC run --interactive -e DEBUG=${DEBUG:-} -e TEST_CODE="${TEST_CODE:-}" --rm ${RUNC_OPTIONS:-} ${PYLINT:-} --volume `pwd`:/source:ro --workdir /source "$IMAGE" /bin/sh tests/run-$OS

--- a/tests/run-debian
+++ b/tests/run-debian
@@ -14,7 +14,6 @@ eatmydata apt-get -y --purge dist-upgrade
 eatmydata apt-get install --no-install-recommends -y git \
     python3-all python3-setuptools python3-build python3-venv \
     python3-dbus python3-gi gir1.2-glib-2.0 \
-    pyflakes3 pycodestyle \
     dbus libnotify-bin upower network-manager bluez ofono ofono-scripts
 
 # systemd's tools otherwise fail on "not been booted with systemd"
@@ -24,6 +23,7 @@ mkdir -p /run/systemd/system
 useradd build
 su -s /bin/sh - build << EOF || { [ -z "$DEBUG" ] || sleep infinity; exit 1; }
 set -ex
+export TEST_CODE="$TEST_CODE"
 cp -r $(pwd) /tmp/source
 cd /tmp/source
 python3 -m unittest -v

--- a/tests/run-fedora
+++ b/tests/run-fedora
@@ -6,11 +6,9 @@ dnf -y install python3-setuptools python3 python3-gobject-base \
     upower NetworkManager bluez libnotify polkit
 
 if ! grep -q :el8 /etc/os-release; then
-    dnf -y install python3-pycodestyle python3-pyflakes python3-mypy \
+    dnf -y install python3-pycodestyle python3-pylint python3-pyflakes python3-mypy \
         power-profiles-daemon iio-sensor-proxy
 fi
-
-[ -z "${PYLINT:-}" ] || dnf -y install python3-pylint
 
 # systemd's tools otherwise fail on "not been booted with systemd"
 mkdir -p /run/systemd/system
@@ -20,6 +18,7 @@ useradd build
 su -s /bin/sh - build << EOF
 set -ex
 cd /source
+export TEST_CODE="$TEST_CODE"
 python3 -m unittest -v || {
   [ -z "$DEBUG" ] || sleep infinity
   exit 1

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -10,31 +10,21 @@ __author__ = 'Martin Pitt'
 __copyright__ = '(c) 2012 Canonical Ltd.'
 
 import glob
+import os
 import subprocess
 import sys
 import unittest
 
 
-checkers = {}
-for checker in ['pycodestyle', 'pyflakes', 'pylint', 'mypy']:
-    try:
-        checkers[checker] = subprocess.check_output(
-                [sys.executable, '-m', checker, '--version'], stderr=subprocess.DEVNULL)
-    except subprocess.CalledProcessError:
-        pass
-
-
+@unittest.skipUnless(os.getenv("TEST_CODE", None), "$TEST_CODE not set, not running static code checks")
 class StaticCodeTests(unittest.TestCase):
-    @unittest.skipUnless('pyflakes' in checkers, 'pyflakes3 not installed')
     def test_pyflakes(self):  # pylint: disable=no-self-use
         subprocess.check_call([sys.executable, '-m', 'pyflakes', '.'])
 
-    @unittest.skipUnless('pycodestyle' in checkers, 'pycodestyle not installed')
     def test_codestyle(self):  # pylint: disable=no-self-use
         subprocess.check_call([sys.executable, '-m', 'pycodestyle',
                                '--max-line-length=130', '--ignore=E124,E402,E731,W504', '.'])
 
-    @unittest.skipUnless('pylint' in checkers, 'pylint not installed')
     def test_pylint(self):  # pylint: disable=no-self-use
         subprocess.check_call([sys.executable, '-m', 'pylint'] + glob.glob('dbusmock/*.py'))
         # signatures/arguments are not determined by us, docstrings are a bit pointless, and code repetition
@@ -49,7 +39,6 @@ class StaticCodeTests(unittest.TestCase):
                                '--disable=too-many-public-methods,too-many-lines,too-many-statements,R0801',
                                'tests/'])
 
-    @unittest.skipUnless('mypy' in checkers, 'mypy not installed')
     def test_types(self):  # pylint: disable=no-self-use
         subprocess.check_call([sys.executable, '-m', 'mypy', 'dbusmock/', 'tests/'])
 


### PR DESCRIPTION
Running them merely when they are installed is a trap: We know that our
code does not satisfy the latest pylint release. The static code tests
are for upstream development, not for downstream or user-side testing.

So only run them when `$TEST_CODE` is set. Plumb that through the
container and the script, and set it in our GitHub workflow.

Fixes #155