### PR TITLE
Use setuptools_scm to determine version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /dist
+/dbusmock/_version.py
 __pycache__
 *.egg-info
 MANIFEST

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,0 @@
-include .fmf/version
-include plans/all.fmf
-include tests/*.py
-include tests/*.fmf
-include COPYING*
-include NEWS

--- a/dbusmock/__init__.py
+++ b/dbusmock/__init__.py
@@ -9,12 +9,18 @@
 
 __author__ = 'Martin Pitt'
 __copyright__ = '(c) 2012 Canonical Ltd.'
-__version__ = '0.28.4'
 
 
 from dbusmock.mockobject import (DBusMockObject, MOCK_IFACE,
                                  OBJECT_MANAGER_IFACE, get_object, get_objects)
 from dbusmock.testcase import DBusTestCase
+
+try:
+    # created by setuptools_scm
+    from dbusmock._version import __version__
+except ImportError:
+    __version__ = '0.git'
+
 
 __all__ = ['DBusMockObject', 'MOCK_IFACE', 'OBJECT_MANAGER_IFACE',
            'DBusTestCase', 'get_object', 'get_objects']

--- a/packit.yaml
+++ b/packit.yaml
@@ -16,6 +16,7 @@ actions:
 
 srpm_build_deps:
   - python3-setuptools
+  - python3-setuptools_scm
 
 jobs:
   - job: tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,11 @@ homepage = "https://github.com/martinpitt/python-dbusmock"
 packages = ["dbusmock", "dbusmock.templates"]
 
 [tool.setuptools_scm]
+write_to = "dbusmock/_version.py"
+# otherwise pylint complains about missing-module-docstring, and mypy about missing type
+write_to_template = """'''auto-generated version from setuptools_scm'''
+__version__: str = "{version}"
+"""
 version_scheme = 'post-release'
 
 [tool.pylint]

--- a/setup.py
+++ b/setup.py
@@ -4,4 +4,6 @@
 
 import setuptools
 
-setuptools.setup()
+setuptools.setup(
+    use_scm_version=True,
+    setup_requires=['setuptools_scm'])

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,4 @@
 
 import setuptools
 
-setuptools.setup(
-    use_scm_version=True,
-    setup_requires=['setuptools_scm'])
+setuptools.setup()

--- a/tests/run-debian
+++ b/tests/run-debian
@@ -12,7 +12,7 @@ eatmydata apt-get -y --purge dist-upgrade
 
 # install build dependencies
 eatmydata apt-get install --no-install-recommends -y git \
-    python3-all python3-setuptools python3-build python3-venv \
+    python3-all python3-setuptools python3-setuptools-scm python3-build python3-venv \
     python3-dbus python3-gi gir1.2-glib-2.0 \
     dbus libnotify-bin upower network-manager bluez ofono ofono-scripts
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -665,6 +665,9 @@ assert args[2] == 5
         obj1 = self.dbus_con.get_object('org.freedesktop.Test', '/obj1')
         self.assertRaises(dbus.exceptions.DBusException, obj1.GetAll, '')
 
+    def test_version(self):
+        self.assertGreater(dbusmock.__version__, "0.28.0")
+
 
 class TestTemplates(dbusmock.DBusTestCase):
     '''Test template API'''
@@ -1070,9 +1073,6 @@ class TestServiceAutostart(dbusmock.DBusTestCase):
         self.addCleanup(self.disable_service, 'org.TestSystem', system_bus=True)
 
         dbus_if.StartServiceByName('org.TestSystem', 0)
-
-    def test_version(self):
-        self.assertGreater(dbusmock.__version__, "0.28.0")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Determine dbusmock.__version__ from package metadata instead of
hardcoding it. With that, the release process is simply "push a signed
tag".

Drop MANIFEST.in. setuptools-scm automatically includes all git-tracked
files into the tarball.

See https://github.com/pypa/setuptools_scm