### PR TITLE
Use setuptools_scm to determine version

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+ignore=
+    # line break after binary operator
+    W504
+    # closing bracket does not match visual indentation
+    E124
+max-line-length = 130

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,12 +15,9 @@ jobs:
           - docker.io/ubuntu:devel
           - docker.io/ubuntu:rolling
           - docker.io/ubuntu:latest
+          - registry.fedoraproject.org/fedora:latest
           - registry.fedoraproject.org/fedora:rawhide
           - quay.io/centos/centos:stream8
-        include:
-          # only run static code tests on a single release, to avoid contradicting requirements from e.g. different pylint releases
-          - scenario: registry.fedoraproject.org/fedora:latest
-            env: TEST_CODE=1
 
     timeout-minutes: 30
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /dist
+/dbusmock/_version.py
 __pycache__
 *.egg-info
 MANIFEST

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,0 @@
-include .fmf/version
-include plans/all.fmf
-include tests/*.py
-include tests/*.fmf
-include COPYING*
-include NEWS

--- a/dbusmock/__init__.py
+++ b/dbusmock/__init__.py
@@ -9,12 +9,18 @@
 
 __author__ = 'Martin Pitt'
 __copyright__ = '(c) 2012 Canonical Ltd.'
-__version__ = '0.28.4'
 
 
 from dbusmock.mockobject import (DBusMockObject, MOCK_IFACE,
                                  OBJECT_MANAGER_IFACE, get_object, get_objects)
 from dbusmock.testcase import DBusTestCase
+
+try:
+    # created by setuptools_scm
+    from dbusmock._version import __version__
+except ImportError:
+    __version__ = '0.git'
+
 
 __all__ = ['DBusMockObject', 'MOCK_IFACE', 'OBJECT_MANAGER_IFACE',
            'DBusTestCase', 'get_object', 'get_objects']

--- a/dbusmock/mockobject.py
+++ b/dbusmock/mockobject.py
@@ -454,7 +454,7 @@ class DBusMockObject(dbus.service.Object):  # pylint: disable=too-many-instance-
         # mock_method(); using message_keyword with this dynamic approach fails
         # because inspect cannot handle those, so pass on interface and method
         # name as first positional arguments
-        method = lambda self, *args, **kwargs: DBusMockObject.mock_method(
+        method = lambda self, *args, **kwargs: DBusMockObject.mock_method(  # noqa: E731
             self, interface, name, in_sig, *args, **kwargs)
 
         # we cannot specify in_signature here, as that trips over a consistency

--- a/packit.yaml
+++ b/packit.yaml
@@ -16,6 +16,7 @@ actions:
 
 srpm_build_deps:
   - python3-setuptools
+  - python3-setuptools_scm
 
 jobs:
   - job: tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,11 @@ homepage = "https://github.com/martinpitt/python-dbusmock"
 packages = ["dbusmock", "dbusmock.templates"]
 
 [tool.setuptools_scm]
+write_to = "dbusmock/_version.py"
+# otherwise pylint complains about missing-module-docstring
+write_to_template = """'''auto-generated version from setuptools_scm'''
+__version__ = "{version}"
+"""
 version_scheme = 'post-release'
 
 [tool.pylint]
@@ -45,5 +50,5 @@ design = { max-args = 7, max-locals = 25,  max-public-methods = 25 }
 [tool.mypy]
 warn_unused_configs = true
 [[tool.mypy.overrides]]
-module = ["dbus.*", "gi.repository"]
+module = ["dbus.*", "gi.repository", "dbusmock._version"]
 ignore_missing_imports = true

--- a/tests/run
+++ b/tests/run
@@ -10,9 +10,9 @@ fi
 
 # only run pylint on a single release, too annoying to keep the code compatible with multiple versions
 if [ "${IMAGE%fedora:latest}" != "$IMAGE" ]; then
-    PYLINT="-e PYLINT=1"
+    TEST_CODE="1"
 fi
 
 OS=${IMAGE##*/}
 OS=${OS%:*}
-$RUNC run --interactive -e DEBUG=${DEBUG:-} -e TEST_CODE="${TEST_CODE:-}" --rm ${RUNC_OPTIONS:-} ${PYLINT:-} --volume `pwd`:/source:ro --workdir /source "$IMAGE" /bin/sh tests/run-$OS
+$RUNC run --interactive -e DEBUG=${DEBUG:-} -e TEST_CODE="${TEST_CODE:-}" --rm ${RUNC_OPTIONS:-} --volume `pwd`:/source:ro --workdir /source "$IMAGE" /bin/sh tests/run-$OS

--- a/tests/run-debian
+++ b/tests/run-debian
@@ -12,7 +12,7 @@ eatmydata apt-get -y --purge dist-upgrade
 
 # install build dependencies
 eatmydata apt-get install --no-install-recommends -y git \
-    python3-all python3-setuptools python3-build python3-venv \
+    python3-all python3-setuptools python3-setuptools-scm python3-build python3-venv \
     python3-dbus python3-gi gir1.2-glib-2.0 \
     dbus libnotify-bin upower network-manager bluez ofono ofono-scripts
 

--- a/tests/run-fedora
+++ b/tests/run-fedora
@@ -6,7 +6,7 @@ dnf -y install python3-setuptools python3 python3-gobject-base \
     upower NetworkManager bluez libnotify polkit
 
 if ! grep -q :el8 /etc/os-release; then
-    dnf -y install python3-pycodestyle python3-pylint python3-pyflakes python3-mypy \
+    dnf -y install python3-flake8 python3-pylint python3-mypy \
         power-profiles-daemon iio-sensor-proxy
 fi
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -665,6 +665,9 @@ assert args[2] == 5
         obj1 = self.dbus_con.get_object('org.freedesktop.Test', '/obj1')
         self.assertRaises(dbus.exceptions.DBusException, obj1.GetAll, '')
 
+    def test_version(self):
+        self.assertGreater(dbusmock.__version__, "0.28.0")
+
 
 class TestTemplates(dbusmock.DBusTestCase):
     '''Test template API'''
@@ -1070,9 +1073,6 @@ class TestServiceAutostart(dbusmock.DBusTestCase):
         self.addCleanup(self.disable_service, 'org.TestSystem', system_bus=True)
 
         dbus_if.StartServiceByName('org.TestSystem', 0)
-
-    def test_version(self):
-        self.assertGreater(dbusmock.__version__, "0.28.0")
 
 
 if __name__ == '__main__':

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -18,12 +18,8 @@ import unittest
 
 @unittest.skipUnless(os.getenv("TEST_CODE", None), "$TEST_CODE not set, not running static code checks")
 class StaticCodeTests(unittest.TestCase):
-    def test_pyflakes(self):  # pylint: disable=no-self-use
-        subprocess.check_call([sys.executable, '-m', 'pyflakes', '.'])
-
-    def test_codestyle(self):  # pylint: disable=no-self-use
-        subprocess.check_call([sys.executable, '-m', 'pycodestyle',
-                               '--max-line-length=130', '--ignore=E124,E402,E731,W504', '.'])
+    def test_flake8(self):  # pylint: disable=no-self-use
+        subprocess.check_call(['flake8'])
 
     def test_pylint(self):  # pylint: disable=no-self-use
         subprocess.check_call([sys.executable, '-m', 'pylint'] + glob.glob('dbusmock/*.py'))


### PR DESCRIPTION
Determine dbusmock.__version__ from package metadata instead of
hardcoding it. With that, the release process is simply "push a signed
tag".

Drop MANIFEST.in. setuptools-scm automatically includes all git-tracked
files into the tarball.

See https://github.com/pypa/setuptools_scm