### PR TITLE
Fix OBEX PullAll after pathlib conversion

### DIFF
--- a/dbusmock/templates/bluez5-obex.py
+++ b/dbusmock/templates/bluez5-obex.py
@@ -225,7 +225,7 @@ def PullAll(self, target_file, filters):
 
     # Emit a behind-the-scenes signal that a new transfer has been created.
     manager.EmitSignal(OBEX_MOCK_IFACE, 'TransferCreated', 'sa{sv}s',
-                       [transfer_path, filters, filename])
+                       [transfer_path, filters, str(filename)])
 
     return (transfer_path, props)
 


### PR DESCRIPTION
The OBEX tests in folks fail with:

    (/build/folks/src/build/tests/bluez/bluez-individual-retrieval:3488):
    folks-WARNING **: 17:30:47.981:
    Error preparing persona store ‘bluez:00:00:00:00:00:00’:
    The OBEX address book transfer from device ‘My Phone’ failed:
    GDBus.Error:org.freedesktop.DBus.Error.InvalidArgs:
    Invalid arguments: Expected a string or unicode object

`PullAll` passes a `pathlib.Path` to `manager.EmitSignal`. Converting it to a `str` fixes the issue.