### PR TITLE
templates/power_profiles: Fix Actions property type

### DIFF
--- a/dbusmock/templates/power_profiles_daemon.py
+++ b/dbusmock/templates/power_profiles_daemon.py
@@ -64,7 +64,7 @@ def load(mock, parameters):
             dbus.Dictionary({'Profile': 'balanced', 'Driver': 'dbusmock'}, signature='sv'),
             dbus.Dictionary({'Profile': 'performance', 'Driver': 'dbusmock'}, signature='sv')
         ],
-        'Actions': dbus.Array([], signature='(as)'),
+        'Actions': dbus.Array([], signature='s'),
         'ActiveProfileHolds': dbus.Array([], signature='(aa{sv})'),
     }
     mock.AddProperties(MAIN_IFACE, dbus.Dictionary(props, signature='sv'))


### PR DESCRIPTION
It should be an 'as' (array of strings), not an 'a(as)' (array of tuples containing an array of strings) which it is now.

For reference:

https://gitlab.freedesktop.org/hadess/power-profiles-daemon/-/blob/0.12/src/net.hadess.PowerProfiles.xml#L127