### PR TITLE
testcase: Wait for PID after killing it

### DIFF
--- a/dbusmock/testcase.py
+++ b/dbusmock/testcase.py
@@ -157,6 +157,9 @@ class DBusTestCase(unittest.TestCase):
         for _ in range(50):
             try:
                 os.kill(pid, signal.SIGTERM)
+                os.waitpid(pid, os.WNOHANG)
+            except ChildProcessError:
+                pass
             except OSError as e:
                 if e.errno == errno.ESRCH:
                     break
@@ -165,7 +168,10 @@ class DBusTestCase(unittest.TestCase):
         else:
             sys.stderr.write('ERROR: timed out waiting for bus process to terminate\n')
             os.kill(pid, signal.SIGKILL)
-            time.sleep(0.5)
+            try:
+                os.waitpid(pid, 0)
+            except ChildProcessError:
+                pass
         signal.signal(signal.SIGTERM, signal.SIG_DFL)
 
     @classmethod

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1068,6 +1068,7 @@ class TestServiceAutostart(dbusmock.DBusTestCase):
     @classmethod
     def tearDownClass(cls):
         shutil.rmtree(cls.xdg_data_dir)
+        dbusmock.DBusTestCase.tearDownClass()
 
     def test_session_service_function_raise(self):
         with self.assertRaises(AssertionError):


### PR DESCRIPTION
dbusmock may leave dbus-daemon zombie processes because nothing is
waiting for them, so use waitpid() to ensure we don't end up in such
state

/cc @jadahl 