### PR TITLE
Add initial pytest support

### DIFF
--- a/dbusmock/pytest_fixtures.py
+++ b/dbusmock/pytest_fixtures.py
@@ -1,0 +1,43 @@
+'''pytest fixtures for DBusMock'''
+
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 3 of the License, or (at your option) any
+# later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
+# of the license.
+
+__author__ = 'Martin Pitt'
+__copyright__ = '(c) 2023 Martin Pitt <martin@piware.de>'
+
+from typing import Iterator
+
+import pytest
+
+import dbusmock.testcase
+
+
+@pytest.fixture(name='dbusmock_test', scope='session')
+def fixture_dbusmock_test() -> Iterator[dbusmock.testcase.DBusTestCase]:
+    '''Export the whole DBusTestCase as a fixture.'''
+
+    testcase = dbusmock.testcase.DBusTestCase()
+    testcase.setUp()
+    yield testcase
+    testcase.tearDown()
+    testcase.tearDownClass()
+
+
+@pytest.fixture(scope='session')
+def dbusmock_system(dbusmock_test) -> dbusmock.testcase.DBusTestCase:
+    '''Export the whole DBusTestCase as a fixture, with the system bus started'''
+
+    dbusmock_test.start_system_bus()
+    return dbusmock_test
+
+
+@pytest.fixture(scope='session')
+def dbusmock_session(dbusmock_test) -> dbusmock.testcase.DBusTestCase:
+    '''Export the whole DBusTestCase as a fixture, with the session bus started'''
+
+    dbusmock_test.start_session_bus()
+    return dbusmock_test

--- a/packaging/python-dbusmock.spec
+++ b/packaging/python-dbusmock.spec
@@ -15,6 +15,7 @@ BuildRequires:    python3-dbus
 BuildRequires:    python3-devel
 BuildRequires:    python3-setuptools
 BuildRequires:    python3-gobject
+BuildRequires:    python3-pytest
 BuildRequires:    dbus-x11
 BuildRequires:    upower
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = "dbusmock.pytest_fixtures"

--- a/tests/run-debian
+++ b/tests/run-debian
@@ -13,7 +13,7 @@ eatmydata apt-get -y --purge dist-upgrade
 # install build dependencies
 eatmydata apt-get install --no-install-recommends -y git \
     python3-all python3-setuptools python3-setuptools-scm python3-build python3-venv \
-    python3-dbus python3-gi gir1.2-glib-2.0 \
+    python3-dbus python3-pytest python3-gi gir1.2-glib-2.0 \
     dbus libnotify-bin upower network-manager bluez ofono ofono-scripts
 
 # systemd's tools otherwise fail on "not been booted with systemd"
@@ -27,6 +27,7 @@ export TEST_CODE="$TEST_CODE"
 cp -r $(pwd) /tmp/source
 cd /tmp/source
 python3 -m unittest -v
+python3 -m pytest -vv -k 'test_pytest or TestAPI'
 # massively parallel test to check for races
 for i in \$(seq 100); do
     ( PYTHONPATH=. python3 tests/test_api.py TestTemplates || touch /tmp/fail ) &

--- a/tests/run-fedora
+++ b/tests/run-fedora
@@ -2,7 +2,7 @@
 set -eux
 # install build dependencies
 dnf -y install python3-setuptools python3 python3-gobject-base \
-    python3-dbus dbus-x11 util-linux \
+    python3-dbus python3-pytest dbus-x11 util-linux \
     upower NetworkManager bluez libnotify polkit
 
 if ! grep -q :el /etc/os-release; then
@@ -19,12 +19,11 @@ mkdir -p /run/systemd/system
 
 # run build and test as user
 useradd build
-su -s /bin/sh - build << EOF
+su -s /bin/sh - build << EOF || { [ -z "$DEBUG" ] || sleep infinity; exit 1; }
 set -ex
 cd /source
 export TEST_CODE="$TEST_CODE"
-python3 -m unittest -v || {
-  [ -z "$DEBUG" ] || sleep infinity
-  exit 1
-}
+
+python3 -m unittest -v
+python3 -m pytest -v
 EOF

--- a/tests/test_api_pytest.py
+++ b/tests/test_api_pytest.py
@@ -1,0 +1,47 @@
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 3 of the License, or (at your option) any
+# later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
+# of the license.
+
+__author__ = 'Martin Pitt'
+__copyright__ = '''
+(c) 2023 Martin Pitt <martin@piware.de>
+'''
+
+import subprocess
+import tempfile
+
+import pytest
+
+import dbusmock
+
+
+def test_dbusmock_test_spawn_server(dbusmock_session):
+    test_iface = 'org.freedesktop.Test.Main'
+
+    p_mock = dbusmock_session.spawn_server(
+        'org.freedesktop.Test', '/', test_iface, stdout=tempfile.TemporaryFile())
+
+    obj_test = dbusmock_session.get_dbus().get_object('org.freedesktop.Test', '/')
+
+    obj_test.AddMethod('', 'Upper', 's', 's', 'ret = args[0].upper()', interface_name=dbusmock.MOCK_IFACE)
+    assert obj_test.Upper('hello', interface=test_iface) == 'HELLO'
+
+    p_mock.terminate()
+    p_mock.wait()
+
+
+@pytest.fixture(name='upower_mock')
+def fixture_upower_mock(dbusmock_system):
+    p_mock, obj = dbusmock_system.spawn_server_template('upower', stdout=subprocess.DEVNULL)
+    yield obj
+    p_mock.terminate()
+    p_mock.wait()
+
+
+def test_dbusmock_test_spawn_system_template(upower_mock):
+    assert upower_mock
+    out = subprocess.check_output(['upower', '--dump'], universal_newlines=True)
+    assert 'version:' in out
+    assert '0.99' in out


### PR DESCRIPTION
Add a new dbusmock.pytest_fixtures module which exports an initial set of fixtures. These mostly just wrap DbusTestCase into a fixture, plus some convenience functions for starting a system or session bus. In the future we may have more fixtures to spawn templates, etc.

Ensure that all of our unit tests run with pytest. As that is expensive, only run it for TEST_CODE=1 in Fedora stable. On the others, only run the basic TestAPI checks and the fixtures checks.

This was co-developed with Peter Hutterer @whot, thank you!

---

I took some inspiration from https://gitlab.freedesktop.org/libinput/libei/-/merge_requests/243 and https://github.com/flatpak/xdg-desktop-portal/pull/1062

 - [x] fix unit tests
 - [x] implicitly do the template process cleanup (see below)
 - [x] add documentation to README