### PR TITLE
Revert "test: Drop power-profiles-daemon from Rawhide"

### DIFF
--- a/tests/run-fedora
+++ b/tests/run-fedora
@@ -6,11 +6,7 @@ dnf -y install python3-setuptools python3 python3-gobject-base \
     upower NetworkManager bluez libnotify polkit
 
 if ! grep -q :el /etc/os-release; then
-    dnf -y install iio-sensor-proxy
-fi
-# HACK: powerprofilectl started to SIGTRAP in Fedora Rawhide https://github.com/martinpitt/python-dbusmock/issues/177
-if [ -n "$TEST_CODE" ]; then
-    dnf -y install power-profiles-daemon
+    dnf -y install power-profiles-daemon iio-sensor-proxy
 fi
 
 if [ -n "$TEST_CODE" ]; then


### PR DESCRIPTION
The root cause for this got fixed in glib 2.77.1:
https://gitlab.gnome.org/GNOME/glib/-/issues/3054

This reverts commit 0b4c5d9b858a54aacd87dc7b1138cc3742947768.

Fixes #177