### PR TITLE
If we don't have a child to wait for, stop

### DIFF
--- a/dbusmock/testcase.py
+++ b/dbusmock/testcase.py
@@ -159,7 +159,7 @@ class DBusTestCase(unittest.TestCase):
                 os.kill(pid, signal.SIGTERM)
                 os.waitpid(pid, os.WNOHANG)
             except ChildProcessError:
-                pass
+                break
             except OSError as e:
                 if e.errno == errno.ESRCH:
                     break


### PR DESCRIPTION
No need to try to os.kill() that same pid if it no longer exists. Worst case we may end up killing an unrelated process.