### PR TITLE
Fix inheritance issues and separate the mocked dbus into an object

### DIFF
--- a/dbusmock/__init__.py
+++ b/dbusmock/__init__.py
@@ -15,7 +15,7 @@ __copyright__ = '''
 
 
 from dbusmock.mockobject import MOCK_IFACE, OBJECT_MANAGER_IFACE, DBusMockObject, get_object, get_objects
-from dbusmock.testcase import BusType, DBusTestCase, PrivateDBus, spawn_server, spawn_server_template
+from dbusmock.testcase import BusType, DBusTestCase, PrivateDBus, SpawnedMock
 
 try:
     # created by setuptools_scm
@@ -25,4 +25,4 @@ except ImportError:
 
 
 __all__ = ['DBusMockObject', 'MOCK_IFACE', 'OBJECT_MANAGER_IFACE',
-           'DBusTestCase', 'PrivateDBus', 'BusType', 'get_object', 'get_objects', 'spawn_server', 'spawn_server_template']
+           'DBusTestCase', 'PrivateDBus', 'BusType', 'SpawnedMock', 'get_object', 'get_objects']

--- a/dbusmock/__init__.py
+++ b/dbusmock/__init__.py
@@ -15,7 +15,7 @@ __copyright__ = '''
 
 
 from dbusmock.mockobject import MOCK_IFACE, OBJECT_MANAGER_IFACE, DBusMockObject, get_object, get_objects
-from dbusmock.testcase import DBusTestCase
+from dbusmock.testcase import BusType, DBusTestCase, PrivateDBus, spawn_server, spawn_server_template
 
 try:
     # created by setuptools_scm
@@ -25,4 +25,4 @@ except ImportError:
 
 
 __all__ = ['DBusMockObject', 'MOCK_IFACE', 'OBJECT_MANAGER_IFACE',
-           'DBusTestCase', 'get_object', 'get_objects']
+           'DBusTestCase', 'PrivateDBus', 'BusType', 'get_object', 'get_objects', 'spawn_server', 'spawn_server_template']

--- a/dbusmock/pytest_fixtures.py
+++ b/dbusmock/pytest_fixtures.py
@@ -20,7 +20,10 @@ import dbusmock.testcase
 def fixture_dbusmock_test() -> Iterator[dbusmock.testcase.DBusTestCase]:
     '''Export the whole DBusTestCase as a fixture.'''
 
-    testcase = dbusmock.testcase.DBusTestCase()
+    class _MockFixture(dbusmock.testcase.DBusTestCase):
+        pass
+
+    testcase = _MockFixture()
     testcase.setUp()
     yield testcase
     testcase.tearDown()

--- a/dbusmock/pytest_fixtures.py
+++ b/dbusmock/pytest_fixtures.py
@@ -13,34 +13,20 @@ from typing import Iterator
 
 import pytest
 
-import dbusmock.testcase
-
-
-@pytest.fixture(name='dbusmock_test', scope='session')
-def fixture_dbusmock_test() -> Iterator[dbusmock.testcase.DBusTestCase]:
-    '''Export the whole DBusTestCase as a fixture.'''
-
-    class _MockFixture(dbusmock.testcase.DBusTestCase):
-        pass
-
-    testcase = _MockFixture()
-    testcase.setUp()
-    yield testcase
-    testcase.tearDown()
-    testcase.tearDownClass()
+from dbusmock.testcase import BusType, PrivateDBus
 
 
 @pytest.fixture(scope='session')
-def dbusmock_system(dbusmock_test) -> dbusmock.testcase.DBusTestCase:
+def dbusmock_system() -> Iterator[PrivateDBus]:
     '''Export the whole DBusTestCase as a fixture, with the system bus started'''
 
-    dbusmock_test.start_system_bus()
-    return dbusmock_test
+    with PrivateDBus(BusType.SYSTEM) as bus:
+        yield bus
 
 
 @pytest.fixture(scope='session')
-def dbusmock_session(dbusmock_test) -> dbusmock.testcase.DBusTestCase:
+def dbusmock_session() -> Iterator[PrivateDBus]:
     '''Export the whole DBusTestCase as a fixture, with the session bus started'''
 
-    dbusmock_test.start_session_bus()
-    return dbusmock_test
+    with PrivateDBus(BusType.SESSION) as bus:
+        yield bus

--- a/dbusmock/testcase.py
+++ b/dbusmock/testcase.py
@@ -66,12 +66,11 @@ class BusType(enum.Enum):
         dbus_if = dbus.Interface(dbus_obj, 'org.freedesktop.DBus')
         dbus_if.ReloadConfig()
 
-    def wait_for_bus_object(self, dest: str, path: str, timeout: int = 600):
+    def wait_for_bus_object(self, dest: str, path: str, timeout: float = 60.0):
         '''Wait for an object to appear on D-Bus
 
         Raise an exception if object does not appear within one minute. You can
-        change the timeout with the "timeout" keyword argument which specifies
-        deciseconds.
+        change the timeout in seconds with the "timeout" keyword argument.
         '''
         bus = self.get_connection()
 
@@ -91,7 +90,7 @@ class BusType(enum.Enum):
                     if '.UnknownInterface' in str(e):
                         break
 
-            timeout -= 1
+            timeout -= 0.1
             time.sleep(0.1)
         if timeout <= 0:
             assert timeout > 0, f'timed out waiting for D-Bus object {path}: {last_exc}'
@@ -380,7 +379,7 @@ class DBusTestCase(unittest.TestCase):
         BusType.wait_for_bus_object() instead.
         '''
         bustype = BusType.SYSTEM if system_bus else BusType.SESSION
-        bustype.wait_for_bus_object(dest, path, timeout)
+        bustype.wait_for_bus_object(dest, path, timeout / 10.0)
 
     @staticmethod
     def spawn_server(name: str, path: str, interface: str, system_bus: bool = False, stdout=None) -> subprocess.Popen:

--- a/dbusmock/testcase.py
+++ b/dbusmock/testcase.py
@@ -110,7 +110,8 @@ class DBusTestCase(unittest.TestCase):
 
         This gets stopped automatically at class teardown.
         '''
-        DBusTestCase.__start_bus('session')
+        assert cls.session_bus_pid is None
+        cls.__start_bus('session')
 
     @classmethod
     def start_system_bus(cls) -> None:
@@ -118,7 +119,8 @@ class DBusTestCase(unittest.TestCase):
 
         This gets stopped automatically at class teardown.
         '''
-        DBusTestCase.__start_bus('system')
+        assert cls.system_bus_pid is None
+        cls.__start_bus('system')
 
     @classmethod
     def start_dbus(cls, conf: Optional[str] = None) -> Tuple[int, str]:

--- a/dbusmock/testcase.py
+++ b/dbusmock/testcase.py
@@ -60,9 +60,9 @@ class DBusTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        if cls._DBusTestCase__datadir:
-            shutil.rmtree(cls._DBusTestCase__datadir)
-            cls._DBusTestCase__datadir = None
+        if DBusTestCase._DBusTestCase__datadir:
+            shutil.rmtree(DBusTestCase._DBusTestCase__datadir)
+            DBusTestCase._DBusTestCase__datadir = None
 
         for bus_type in ['system', 'session']:
             pid = getattr(cls, f'{bus_type}_bus_pid')
@@ -81,9 +81,9 @@ class DBusTestCase(unittest.TestCase):
         This gets stopped automatically at class teardown.
         '''
         cls.get_services_dir()
-        assert cls._DBusTestCase__datadir
+        assert DBusTestCase._DBusTestCase__datadir
 
-        conf = cls._DBusTestCase__datadir / f'dbusmock_{bus_type}_cfg'
+        conf = DBusTestCase._DBusTestCase__datadir / f'dbusmock_{bus_type}_cfg'
         conf.write_text(f'''<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>

--- a/dbusmock/testcase.py
+++ b/dbusmock/testcase.py
@@ -235,35 +235,6 @@ class PrivateDBus:
         if self._daemon:
             self.bustype.reload_configuration()
 
-    def spawn_server(self, name: str, path: str, interface: str, system_bus: bool = False, stdout=None) -> subprocess.Popen:
-        '''Wrapper around ``spawn_server`` for backwards compatibility'''
-        assert not system_bus or self.bustype == BusType.SYSTEM, "Mismatching bus types"
-        server = SpawnedMock.spawn_for_name(name, path, interface, bustype=self.bustype, stdout=stdout)
-        return server.process
-
-    def wait_for_bus_object(self, dest: str, path: str, system_bus: bool = False, timeout: int = 600):
-        '''Wrapper around ``BusType.wait_for_bus_object()`` for backwards compatibility'''
-        assert not system_bus or self.bustype == BusType.SYSTEM, "Mismatching bus types"
-        self.bustype.wait_for_bus_object(dest, path, timeout)
-
-    def spawn_server_template(self,
-                              template: str,
-                              parameters: Optional[Dict[str, Any]] = None,
-                              stdout=None,
-                              system_bus: Optional[bool] = None) -> Tuple[subprocess.Popen, dbus.proxies.ProxyObject]:
-        '''Wrapper around ``spawn_server_template`` for backwards compatibility'''
-        if system_bus is not None:  # noqa: SIM108
-            bustype = BusType.SYSTEM if system_bus else BusType.SESSION
-        else:
-            bustype = None
-        server = SpawnedMock.spawn_server_template(template=template, parameters=parameters, bustype=bustype, stdout=stdout)
-        return server.process, server.obj
-
-    def get_dbus(self, system_bus: bool = False) -> dbus.Bus:
-        '''Wrapper around ``BusType.get_connection()`` for backwards compatibility'''
-        assert not system_bus or self.bustype == BusType.SYSTEM, "Mismatching bus types"
-        return self.bustype.get_connection()
-
 
 class DBusTestCase(unittest.TestCase):
     '''Base class for D-Bus mock tests.

--- a/dbusmock/testcase.py
+++ b/dbusmock/testcase.py
@@ -103,6 +103,8 @@ class DBusTestCase(unittest.TestCase):
         (pid, addr) = cls.start_dbus(conf=str(conf))
         os.environ[f'DBUS_{bus_type.upper()}_BUS_ADDRESS'] = addr
         setattr(cls, f'{bus_type}_bus_pid', pid)
+        assert DBusTestCase.session_bus_pid is None
+        assert DBusTestCase.system_bus_pid is None
 
     @classmethod
     def start_session_bus(cls) -> None:

--- a/dbusmock/testcase.py
+++ b/dbusmock/testcase.py
@@ -60,9 +60,9 @@ class DBusTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls._DBusTestCase__datadir = None
         if cls._DBusTestCase__datadir:
             shutil.rmtree(cls._DBusTestCase__datadir)
+            cls._DBusTestCase__datadir = None
 
         for bus_type in ['system', 'session']:
             pid = getattr(cls, f'{bus_type}_bus_pid')

--- a/tests/test_api_pytest.py
+++ b/tests/test_api_pytest.py
@@ -34,7 +34,7 @@ def test_dbusmock_test_spawn_server(dbusmock_session):
 
 @pytest.fixture(name='upower_mock')
 def fixture_upower_mock(dbusmock_system):
-    p_mock, obj = dbusmock_system.spawn_server_template('upower', stdout=subprocess.DEVNULL)
+    p_mock, obj = dbusmock_system.spawn_with_template('upower', stdout=subprocess.DEVNULL)
     yield obj
     p_mock.terminate()
     p_mock.wait()
@@ -42,6 +42,30 @@ def fixture_upower_mock(dbusmock_system):
 
 def test_dbusmock_test_spawn_system_template(upower_mock):
     assert upower_mock
+    out = subprocess.check_output(['upower', '--dump'], universal_newlines=True)
+    assert 'version:' in out
+    assert '0.99' in out
+
+
+def test_dbusmock_test_spawnedserver(dbusmock_session):
+    assert dbusmock_session
+    test_iface = 'org.freedesktop.Test.Main'
+
+    with dbusmock.SpawnedMock.spawn_for_name('org.freedesktop.Test', '/', test_iface) as server:
+        obj_test = server.obj
+        obj_test.AddMethod('', 'Upper', 's', 's', 'ret = args[0].upper()', interface_name=dbusmock.MOCK_IFACE)
+        assert obj_test.Upper('hello', interface=test_iface) == 'HELLO'
+
+
+@pytest.fixture(name='upower_mock_spawned')
+def fixture_upower_mock_spawned(dbusmock_system):
+    assert dbusmock_system
+    with dbusmock.SpawnedMock.spawn_with_template('upower') as server:
+        yield server.obj
+
+
+def test_dbusmock_test_spawnedserver_template(upower_mock_spawned):
+    assert upower_mock_spawned
     out = subprocess.check_output(['upower', '--dump'], universal_newlines=True)
     assert 'version:' in out
     assert '0.99' in out

--- a/tests/test_api_pytest.py
+++ b/tests/test_api_pytest.py
@@ -10,44 +10,13 @@ __copyright__ = '''
 '''
 
 import subprocess
-import tempfile
 
 import pytest
 
 import dbusmock
 
 
-def test_dbusmock_test_spawn_server(dbusmock_session):
-    test_iface = 'org.freedesktop.Test.Main'
-
-    p_mock = dbusmock_session.spawn_server(
-        'org.freedesktop.Test', '/', test_iface, stdout=tempfile.TemporaryFile())
-
-    obj_test = dbusmock_session.get_dbus().get_object('org.freedesktop.Test', '/')
-
-    obj_test.AddMethod('', 'Upper', 's', 's', 'ret = args[0].upper()', interface_name=dbusmock.MOCK_IFACE)
-    assert obj_test.Upper('hello', interface=test_iface) == 'HELLO'
-
-    p_mock.terminate()
-    p_mock.wait()
-
-
-@pytest.fixture(name='upower_mock')
-def fixture_upower_mock(dbusmock_system):
-    p_mock, obj = dbusmock_system.spawn_with_template('upower', stdout=subprocess.DEVNULL)
-    yield obj
-    p_mock.terminate()
-    p_mock.wait()
-
-
-def test_dbusmock_test_spawn_system_template(upower_mock):
-    assert upower_mock
-    out = subprocess.check_output(['upower', '--dump'], universal_newlines=True)
-    assert 'version:' in out
-    assert '0.99' in out
-
-
-def test_dbusmock_test_spawnedserver(dbusmock_session):
+def test_dbusmock_test(dbusmock_session):
     assert dbusmock_session
     test_iface = 'org.freedesktop.Test.Main'
 
@@ -57,15 +26,15 @@ def test_dbusmock_test_spawnedserver(dbusmock_session):
         assert obj_test.Upper('hello', interface=test_iface) == 'HELLO'
 
 
-@pytest.fixture(name='upower_mock_spawned')
-def fixture_upower_mock_spawned(dbusmock_system):
+@pytest.fixture(name='upower_mock')
+def fixture_upower_mock(dbusmock_system):
     assert dbusmock_system
     with dbusmock.SpawnedMock.spawn_with_template('upower') as server:
         yield server.obj
 
 
-def test_dbusmock_test_spawnedserver_template(upower_mock_spawned):
-    assert upower_mock_spawned
+def test_dbusmock_test_template(upower_mock):
+    assert upower_mock
     out = subprocess.check_output(['upower', '--dump'], universal_newlines=True)
     assert 'version:' in out
     assert '0.99' in out


### PR DESCRIPTION
Filing as draft for now because the last commit *may* break backwards compat, see below.

I noticed that my dbus-daemons didn't get terminated when using dbusmock in the xdg-desktop-portal which led to a bit of a rabbit hole. So I figured "let's fix this properly" :smile: 

For (understandable) historical reasons, the `DBusTestCase` class handled everything as `@classmethod`. That causes a few issues though because the `cls` argument is mostly the real class but in some cases it's `DBusTestCase`. This can lead to a getter resolving to`DBusTestCase.somevar` but the setter resolving to `MyTestClass(DBusTestCase).somevar`.

The first few patches disentangle that to make sure we're always on the correct class instead of oscillating between `DBusTestCase` and the test class.

The last (and most interesting) patch is to add a new `MockedDBus` object that wraps the actually started daemon.

I've patched this so `DBusTestCase` wraps this new class but this *may* introduce some compatibility issues. Arguably we could leave `DBusTestCase` untouched and as legacy API and suggest using `MockedDBus` via pytest for the future. Since the pytests haven't been in a release yet we could also remove some of the wrappers from this new class and rely on callers to use the new `BusType`/`spawn_*` API directly.

Ironically, the last patch somewhat undoes the previous patches in that everything is now on the `DBusTestCase` class, but that shouldn't matter much.


It does pass the test suite here, so any incompatibilities introduced are not tested ;)