### PR TITLE
Default to running static tests

### DIFF
--- a/tests/run
+++ b/tests/run
@@ -9,10 +9,10 @@ else
 fi
 
 # only run static code checks on a single release, too annoying to keep the code compatible with multiple versions
-if [ "${IMAGE%fedora:latest}" != "$IMAGE" ]; then
-    TEST_CODE="1"
+if [ "${IMAGE%fedora:latest}" = "$IMAGE" ]; then
+    SKIP_STATIC_CHECKS="1"
 fi
 
 OS=${IMAGE##*/}
 OS=${OS%:*}
-$RUNC run --interactive -e DEBUG=${DEBUG:-} -e TEST_CODE="${TEST_CODE:-}" --rm ${RUNC_OPTIONS:-} --volume `pwd`:/source:ro --workdir /source "$IMAGE" /bin/sh tests/run-$OS
+$RUNC run --interactive -e DEBUG=${DEBUG:-} -e SKIP_STATIC_CHECKS="${SKIP_STATIC_CHECKS:-}" --rm ${RUNC_OPTIONS:-} --volume `pwd`:/source:ro --workdir /source "$IMAGE" /bin/sh tests/run-$OS

--- a/tests/run-debian
+++ b/tests/run-debian
@@ -23,7 +23,7 @@ mkdir -p /run/systemd/system
 useradd build
 su -s /bin/sh - build << EOF || { [ -z "$DEBUG" ] || sleep infinity; exit 1; }
 set -ex
-export TEST_CODE="$TEST_CODE"
+export SKIP_STATIC_CHECKS="$SKIP_STATIC_CHECKS"
 cp -r $(pwd) /tmp/source
 cd /tmp/source
 python3 -m unittest -v

--- a/tests/run-fedora
+++ b/tests/run-fedora
@@ -9,7 +9,7 @@ if ! grep -q :el /etc/os-release; then
     dnf -y install power-profiles-daemon iio-sensor-proxy
 fi
 
-if [ -n "$TEST_CODE" ]; then
+if [ "$SKIP_STATIC_CHECKS" != "1" ]; then
     dnf -y install python3-pylint python3-mypy python3-pip
     pip install ruff
 fi
@@ -22,7 +22,7 @@ useradd build
 su -s /bin/sh - build << EOF || { [ -z "$DEBUG" ] || sleep infinity; exit 1; }
 set -ex
 cd /source
-export TEST_CODE="$TEST_CODE"
+export SKIP_STATIC_CHECKS="$SKIP_STATIC_CHECKS"
 
 python3 -m unittest -v
 python3 -m pytest -v

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -17,7 +17,7 @@ import sys
 import unittest
 
 
-@unittest.skipUnless(os.getenv("TEST_CODE", None), "$TEST_CODE not set, not running static code checks")
+@unittest.skipIf(os.getenv("SKIP_STATIC_CHECKS", "0") == "1", "$SKIP_STATIC_CHECKS set, not running static code checks")
 class StaticCodeTests(unittest.TestCase):
     def test_pylint(self):
         subprocess.check_call([sys.executable, '-m', 'pylint', *glob.glob('dbusmock/*.py')])

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -11,6 +11,7 @@ __copyright__ = '''
 '''
 
 import glob
+import importlib.util
 import os
 import subprocess
 import sys
@@ -19,6 +20,8 @@ import unittest
 
 @unittest.skipIf(os.getenv("SKIP_STATIC_CHECKS", "0") == "1", "$SKIP_STATIC_CHECKS set, not running static code checks")
 class StaticCodeTests(unittest.TestCase):
+
+    @unittest.skipUnless(importlib.util.find_spec("pylint"), "pylint not available, skipping")
     def test_pylint(self):
         subprocess.check_call([sys.executable, '-m', 'pylint', *glob.glob('dbusmock/*.py')])
         # signatures/arguments are not determined by us, docstrings are a bit pointless, and code repetition
@@ -33,11 +36,15 @@ class StaticCodeTests(unittest.TestCase):
                                '--disable=too-many-public-methods,too-many-lines,too-many-statements,R0801',
                                'tests/'])
 
+    @unittest.skipUnless(importlib.util.find_spec("mypy"), "mypy not available, skipping")
     def test_types(self):
         subprocess.check_call([sys.executable, '-m', 'mypy', 'dbusmock/', 'tests/'])
 
     def test_ruff(self):
-        subprocess.check_call(['ruff', 'check', '--no-cache', '.'])
+        try:
+            subprocess.check_call(['ruff', 'check', '--no-cache', '.'])
+        except FileNotFoundError:
+            self.skipTest("ruff not available, skipping")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
unittest and pytest may pass locally only to fail with
near-indecipherable logs in the CI - caused by TEST_CODE being set which
triggers the pylint, ruff and mypy checks.

Let's invert that check so local checks will run these by default unless
explicitly disabled and the CI disables it in the specific test runs.