### PR TITLE
Use black as code formatter

### DIFF
--- a/dbusmock/__init__.py
+++ b/dbusmock/__init__.py
@@ -1,5 +1,5 @@
 # coding: UTF-8
-'''Mock D-Bus objects for test suites.'''
+"""Mock D-Bus objects for test suites."""
 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -7,11 +7,11 @@
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Martin Pitt'
-__copyright__ = '''
+__author__ = "Martin Pitt"
+__copyright__ = """
 (c) 2012 Canonical Ltd.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 
 from dbusmock.mockobject import MOCK_IFACE, OBJECT_MANAGER_IFACE, DBusMockObject, get_object, get_objects
@@ -21,8 +21,17 @@ try:
     # created by setuptools_scm
     from dbusmock._version import __version__
 except ImportError:
-    __version__ = '0.git'
+    __version__ = "0.git"
 
 
-__all__ = ['DBusMockObject', 'MOCK_IFACE', 'OBJECT_MANAGER_IFACE',
-           'DBusTestCase', 'PrivateDBus', 'BusType', 'SpawnedMock', 'get_object', 'get_objects']
+__all__ = [
+    "DBusMockObject",
+    "MOCK_IFACE",
+    "OBJECT_MANAGER_IFACE",
+    "DBusTestCase",
+    "PrivateDBus",
+    "BusType",
+    "SpawnedMock",
+    "get_object",
+    "get_objects",
+]

--- a/dbusmock/__main__.py
+++ b/dbusmock/__main__.py
@@ -1,5 +1,5 @@
 # coding: UTF-8
-'''Main entry point for running mock server.'''
+"""Main entry point for running mock server."""
 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -7,11 +7,11 @@
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Martin Pitt'
-__copyright__ = '''
+__author__ = "Martin Pitt"
+__copyright__ = """
 (c) 2012 Canonical Ltd.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 import argparse
 import json
@@ -24,46 +24,84 @@ import dbusmock.testcase
 
 
 def parse_args():
-    '''Parse command line arguments'''
+    """Parse command line arguments"""
 
-    parser = argparse.ArgumentParser(description='mock D-Bus object')
-    parser.add_argument('-s', '--system', action='store_true',
-                        help="put object(s) on system bus (default: session bus or template's SYSTEM_BUS flag)")
-    parser.add_argument('--session', action='store_true',
-                        help="put object(s) on session bus (default without template; overrides template's SYSTEM_BUS flag)")
-    parser.add_argument('-l', '--logfile', metavar='PATH',
-                        help='path of log file')
-    parser.add_argument('-t', '--template', metavar='NAME',
-                        help='template to load (instead of specifying name, path, interface)')
-    parser.add_argument('name', metavar='NAME', nargs='?',
-                        help='D-Bus name to claim (e. g. "com.example.MyService") (if not using -t)')
-    parser.add_argument('path', metavar='PATH', nargs='?',
-                        help='D-Bus object path for initial/main object (if not using -t)')
-    parser.add_argument('interface', metavar='INTERFACE', nargs='?',
-                        help='main D-Bus interface name for initial object (if not using -t)')
-    parser.add_argument('-m', '--is-object-manager', action='store_true',
-                        help='automatically implement the org.freedesktop.DBus.ObjectManager interface')
-    parser.add_argument('-p', '--parameters',
-                        help='JSON dictionary of parameters to pass to the template')
-    parser.add_argument('-e', '--exec', nargs=argparse.REMAINDER,
-                        help='Command to run in the mock environment')
+    parser = argparse.ArgumentParser(description="mock D-Bus object")
+    parser.add_argument(
+        "-s",
+        "--system",
+        action="store_true",
+        help="put object(s) on system bus (default: session bus or template's SYSTEM_BUS flag)",
+    )
+    parser.add_argument(
+        "--session",
+        action="store_true",
+        help="put object(s) on session bus (default without template; overrides template's SYSTEM_BUS flag)",
+    )
+    parser.add_argument(
+        "-l",
+        "--logfile",
+        metavar="PATH",
+        help="path of log file",
+    )
+    parser.add_argument(
+        "-t",
+        "--template",
+        metavar="NAME",
+        help="template to load (instead of specifying name, path, interface)",
+    )
+    parser.add_argument(
+        "name",  # fmt: off
+        metavar="NAME",
+        nargs="?",
+        help='D-Bus name to claim (e. g. "com.example.MyService") (if not using -t)',
+    )
+    parser.add_argument(
+        "path",
+        metavar="PATH",
+        nargs="?",
+        help="D-Bus object path for initial/main object (if not using -t)",
+    )
+    parser.add_argument(
+        "interface",
+        metavar="INTERFACE",
+        nargs="?",
+        help="main D-Bus interface name for initial object (if not using -t)",
+    )
+    parser.add_argument(
+        "-m",
+        "--is-object-manager",
+        action="store_true",
+        help="automatically implement the org.freedesktop.DBus.ObjectManager interface",
+    )
+    parser.add_argument(
+        "-p",
+        "--parameters",
+        help="JSON dictionary of parameters to pass to the template",
+    )
+    parser.add_argument(
+        "-e",
+        "--exec",
+        nargs=argparse.REMAINDER,
+        help="Command to run in the mock environment",
+    )
 
     arguments = parser.parse_args()
 
     if arguments.template:
         if arguments.name or arguments.path or arguments.interface:
-            parser.error('--template and specifying NAME/PATH/INTERFACE are mutually exclusive')
+            parser.error("--template and specifying NAME/PATH/INTERFACE are mutually exclusive")
     else:
         if not arguments.name or not arguments.path or not arguments.interface:
-            parser.error('Not using a template, you must specify NAME, PATH, and INTERFACE')
+            parser.error("Not using a template, you must specify NAME, PATH, and INTERFACE")
 
     if arguments.system and arguments.session:
-        parser.error('--system and --session are mutually exclusive')
+        parser.error("--system and --session are mutually exclusive")
 
     return arguments
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import ctypes
 
     import dbus.mainloop.glib
@@ -80,12 +118,12 @@ if __name__ == '__main__':
         if not args.session and not args.system:
             system_bus = module.SYSTEM_BUS
 
-        if hasattr(module, 'IS_OBJECT_MANAGER'):
+        if hasattr(module, "IS_OBJECT_MANAGER"):
             args.is_object_manager = module.IS_OBJECT_MANAGER
         else:
             args.is_object_manager = False
 
-        if args.is_object_manager and not hasattr(module, 'MAIN_IFACE'):
+        if args.is_object_manager and not hasattr(module, "MAIN_IFACE"):
             args.interface = dbusmock.mockobject.OBJECT_MANAGER_IFACE
         else:
             args.interface = module.MAIN_IFACE
@@ -94,37 +132,35 @@ if __name__ == '__main__':
 
     # quit mock when the bus is going down
     should_run = {True}
-    bus.add_signal_receiver(should_run.pop, signal_name='Disconnected',
-                            path='/org/freedesktop/DBus/Local',
-                            dbus_interface='org.freedesktop.DBus.Local')
+    bus.add_signal_receiver(
+        should_run.pop,
+        signal_name="Disconnected",
+        path="/org/freedesktop/DBus/Local",
+        dbus_interface="org.freedesktop.DBus.Local",
+    )
 
-    bus_name = dbus.service.BusName(args.name,
-                                    bus,
-                                    allow_replacement=True,
-                                    replace_existing=True,
-                                    do_not_queue=True)
+    bus_name = dbus.service.BusName(args.name, bus, allow_replacement=True, replace_existing=True, do_not_queue=True)
 
-    main_object = dbusmock.mockobject.DBusMockObject(bus_name, args.path,
-                                                     args.interface, {},
-                                                     args.logfile,
-                                                     args.is_object_manager)
+    main_object = dbusmock.mockobject.DBusMockObject(
+        bus_name, args.path, args.interface, {}, args.logfile, args.is_object_manager
+    )
 
     parameters = None
     if args.parameters:
         try:
             parameters = json.loads(args.parameters)
         except ValueError as detail:
-            sys.stderr.write(f'Malformed JSON given for parameters: {detail}\n')
+            sys.stderr.write(f"Malformed JSON given for parameters: {detail}\n")
             sys.exit(2)
 
         if not isinstance(parameters, dict):
-            sys.stderr.write('JSON parameters must be a dictionary\n')
+            sys.stderr.write("JSON parameters must be a dictionary\n")
             sys.exit(2)
 
     if args.template:
         main_object.AddTemplate(args.template, parameters)
 
-    libglib = ctypes.cdll.LoadLibrary('libglib-2.0.so.0')
+    libglib = ctypes.cdll.LoadLibrary("libglib-2.0.so.0")
 
     dbusmock.mockobject.objects[args.path] = main_object
 
@@ -134,7 +170,7 @@ if __name__ == '__main__':
 
             @ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_int)
             def on_process_watch(_pid, status):
-                """ Check if the launched process is still alive """
+                """Check if the launched process is still alive"""
                 if os.WIFEXITED(status):
                     exit_status.add(os.WEXITSTATUS(status))
                 else:

--- a/dbusmock/mockobject.py
+++ b/dbusmock/mockobject.py
@@ -1,5 +1,5 @@
 # coding: UTF-8
-'''Mock D-Bus objects for test suites.'''
+"""Mock D-Bus objects for test suites."""
 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -7,11 +7,11 @@
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Martin Pitt'
-__copyright__ = '''
+__author__ = "Martin Pitt"
+__copyright__ = """
 (c) 2012 Canonical Ltd.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 import copy
 import functools
@@ -32,10 +32,10 @@ import dbus.service
 os  # pyflakes pylint: disable=pointless-statement  # noqa: B018
 
 # global path -> DBusMockObject mapping
-objects: Dict[str, 'DBusMockObject'] = {}
+objects: Dict[str, "DBusMockObject"] = {}
 
-MOCK_IFACE = 'org.freedesktop.DBus.Mock'
-OBJECT_MANAGER_IFACE = 'org.freedesktop.DBus.ObjectManager'
+MOCK_IFACE = "org.freedesktop.DBus.Mock"
+OBJECT_MANAGER_IFACE = "org.freedesktop.DBus.ObjectManager"
 
 
 PropsType = Dict[str, Any]
@@ -46,7 +46,7 @@ CallLogType = Tuple[int, str, Sequence[Any]]
 
 
 def load_module_from_path(path: Path, template_name: str):
-    '''Load a mock template from a file path'''
+    """Load a mock template from a file path"""
     spec = importlib.util.spec_from_file_location(template_name, path)
     assert spec
     mod = importlib.util.module_from_spec(spec)
@@ -55,29 +55,29 @@ def load_module_from_path(path: Path, template_name: str):
 
 
 def load_module(name: str):
-    '''Load a mock template Python module
+    """Load a mock template Python module
 
     This can be a path to the template's .py file, a bare module name in
     ``$XDG_DATA_DIRS/python-dbusmock/templates/``, or a bare module name in dbusmock's shipped templates.
-    '''
+    """
     # specified by path
     pname = Path(name)
-    if pname.exists() and pname.suffix == '.py':
+    if pname.exists() and pname.suffix == ".py":
         return load_module_from_path(pname, pname.stem)
 
     # XDG_DATA_DIRS
-    xdg_data_dirs = os.environ.get('XDG_DATA_DIRS') or '/usr/local/share/:/usr/share/'
-    for d in xdg_data_dirs.split(':'):
-        src = Path(d, 'python-dbusmock', 'templates', name + '.py')
+    xdg_data_dirs = os.environ.get("XDG_DATA_DIRS") or "/usr/local/share/:/usr/share/"
+    for d in xdg_data_dirs.split(":"):
+        src = Path(d, "python-dbusmock", "templates", name + ".py")
         if src.exists():
             return load_module_from_path(src, name)
 
     # shipped inside dbusmock package
-    return importlib.import_module('dbusmock.templates.' + name)
+    return importlib.import_module("dbusmock.templates." + name)
 
 
 def _format_args(args):
-    '''Format a D-Bus argument tuple into an appropriate logging string'''
+    """Format a D-Bus argument tuple into an appropriate logging string"""
 
     def format_arg(a):
         if isinstance(a, dbus.Boolean):
@@ -87,28 +87,28 @@ def _format_args(args):
         if isinstance(a, str):
             return '"' + str(a) + '"'
         if isinstance(a, list):
-            return '[' + ', '.join([format_arg(x) for x in a]) + ']'
+            return "[" + ", ".join([format_arg(x) for x in a]) + "]"
         if isinstance(a, dict):
-            fmta = '{'
+            fmta = "{"
             first = True
             for k, v in a.items():
                 if first:
                     first = False
                 else:
-                    fmta += ', '
-                fmta += format_arg(k) + ': ' + format_arg(v)
-            return fmta + '}'
+                    fmta += ", "
+                fmta += format_arg(k) + ": " + format_arg(v)
+            return fmta + "}"
 
         # fallback
         return repr(a)
 
-    s = ''
+    s = ""
     for a in args:
         if s:
-            s += ' '
+            s += " "
         s += format_arg(a)
     if s:
-        s = ' ' + s
+        s = " " + s
     return s
 
 
@@ -139,7 +139,7 @@ def _wrap_in_dbus_variant(value):
         return type(value)(value.conjugate(), variant_level=1)
     if isinstance(value, str):
         return dbus.String(value, variant_level=1)
-    raise dbus.exceptions.DBusException(f'could not wrap type {type(value)}')
+    raise dbus.exceptions.DBusException(f"could not wrap type {type(value)}")
 
 
 def _convert_args(signature: str, args: Tuple[Any, ...]) -> List[Any]:
@@ -149,14 +149,15 @@ def _convert_args(signature: str, args: Tuple[Any, ...]) -> List[Any]:
     checks, except for the case of an empty signature
     """
     try:
-        if signature == '' and len(args) > 0:
-            raise TypeError('Fewer items found in D-Bus signature than in Python arguments')
-        m = dbus.connection.MethodCallMessage('a.b', '/a', 'a.b', 'a')
+        if signature == "" and len(args) > 0:
+            raise TypeError("Fewer items found in D-Bus signature than in Python arguments")
+        m = dbus.connection.MethodCallMessage("a.b", "/a", "a.b", "a")
         m.append(*args, signature=signature)
         return m.get_args_list()
     except Exception as e:
-        raise dbus.exceptions.DBusException(f'Invalid arguments: {e!s}',
-                                            name='org.freedesktop.DBus.Error.InvalidArgs') from e
+        raise dbus.exceptions.DBusException(
+            f"Invalid arguments: {e!s}", name="org.freedesktop.DBus.Error.InvalidArgs"
+        ) from e
 
 
 def loggedmethod(self, func):
@@ -167,7 +168,7 @@ def loggedmethod(self, func):
         fname = func.__name__
         self_arg, args = args[0], args[1:]
 
-        in_signature = getattr(func, '_dbus_in_signature', '')
+        in_signature = getattr(func, "_dbus_in_signature", "")
         args = _convert_args(in_signature, args)
 
         self.log(fname + _format_args(args))
@@ -180,7 +181,7 @@ def loggedmethod(self, func):
 
 
 class DBusMockObject(dbus.service.Object):  # pylint: disable=too-many-instance-attributes
-    '''Mock D-Bus object
+    """Mock D-Bus object
 
     This can be configured to have arbitrary methods (including code execution)
     and properties via methods on the org.freedesktop.DBus.Mock interface, so
@@ -188,11 +189,18 @@ class DBusMockObject(dbus.service.Object):  # pylint: disable=too-many-instance-
 
     Beyond that "remote control" API, this is a standard
     `dbus-python service object <https://dbus.freedesktop.org/doc/dbus-python/tutorial.html#exporting-objects>`_.
-    '''
+    """
 
-    def __init__(self, bus_name: str, path: str, interface: str, props: PropsType,
-                 logfile: Optional[str] = None, is_object_manager: bool = False) -> None:
-        '''Create a new DBusMockObject
+    def __init__(
+        self,
+        bus_name: str,
+        path: str,
+        interface: str,
+        props: PropsType,
+        logfile: Optional[str] = None,
+        is_object_manager: bool = False,
+    ) -> None:
+        """Create a new DBusMockObject
 
         :param bus_name: A dbus.service.BusName instance where the object will be put on
         :param path: D-Bus object path
@@ -210,7 +218,7 @@ class DBusMockObject(dbus.service.Object):  # pylint: disable=too-many-instance-
                         theirs. Note that the InterfacesAdded and
                         InterfacesRemoved signals will not be automatically
                         emitted.
-        '''
+        """
         dbus.service.Object.__init__(self, bus_name, path)
 
         self.bus_name = bus_name
@@ -223,7 +231,7 @@ class DBusMockObject(dbus.service.Object):  # pylint: disable=too-many-instance-
         self._template_parameters: Optional[PropsType] = None
 
         # pylint: disable=consider-using-with
-        self.logfile = open(logfile, 'wb') if logfile else None  # noqa: SIM115
+        self.logfile = open(logfile, "wb") if logfile else None  # noqa: SIM115
         self.is_logfile_owner = True
         self.call_log: List[CallLogType] = []
 
@@ -240,11 +248,11 @@ class DBusMockObject(dbus.service.Object):  # pylint: disable=too-many-instance-
             pass
 
     def _set_up_object_manager(self) -> None:
-        '''Set up this mock object as a D-Bus ObjectManager.'''
+        """Set up this mock object as a D-Bus ObjectManager."""
         cond = "k != '/'" if self.path == "/" else f"k.startswith('{self.path}/')"
 
-        code = f'ret = {{dbus.ObjectPath(k): objects[k].props for k in objects.keys() if {cond} }}'
-        self.AddMethod(OBJECT_MANAGER_IFACE, 'GetManagedObjects', '', 'a{oa{sa{sv}}}', code)
+        code = f"ret = {{dbus.ObjectPath(k): objects[k].props for k in objects.keys() if {cond} }}"
+        self.AddMethod(OBJECT_MANAGER_IFACE, "GetManagedObjects", "", "a{oa{sa{sv}}}", code)
         self.object_manager = self
 
     def _reset(self, props: PropsType) -> None:
@@ -257,12 +265,11 @@ class DBusMockObject(dbus.service.Object):  # pylint: disable=too-many-instance-
         if self.is_object_manager:
             self._set_up_object_manager()
 
-    @dbus.service.method(dbus.PROPERTIES_IFACE,
-                         in_signature='ss', out_signature='v')
+    @dbus.service.method(dbus.PROPERTIES_IFACE, in_signature="ss", out_signature="v")
     def Get(self, interface_name: str, property_name: str) -> Any:
-        '''Standard D-Bus API for getting a property value'''
+        """Standard D-Bus API for getting a property value"""
 
-        self.log(f'Get {self.path} {interface_name}.{property_name}')
+        self.log(f"Get {self.path} {interface_name}.{property_name}")
 
         if not interface_name:
             interface_name = self.interface
@@ -270,15 +277,14 @@ class DBusMockObject(dbus.service.Object):  # pylint: disable=too-many-instance-
             return self.GetAll(interface_name)[property_name]
         except KeyError as e:
             raise dbus.exceptions.DBusException(
-                'no such property ' + property_name,
-                name=self.interface + '.UnknownProperty') from e
+                "no such property " + property_name, name=self.interface + ".UnknownProperty"
+            ) from e
 
-    @dbus.service.method(dbus.PROPERTIES_IFACE,
-                         in_signature='s', out_signature='a{sv}')
+    @dbus.service.method(dbus.PROPERTIES_IFACE, in_signature="s", out_signature="a{sv}")
     def GetAll(self, interface_name: str, *_, **__) -> PropsType:
-        '''Standard D-Bus API for getting all property values'''
+        """Standard D-Bus API for getting all property values"""
 
-        self.log(f'GetAll {self.path} {interface_name}')
+        self.log(f"GetAll {self.path} {interface_name}")
 
         if not interface_name:
             interface_name = self.interface
@@ -286,43 +292,39 @@ class DBusMockObject(dbus.service.Object):  # pylint: disable=too-many-instance-
             return self.props[interface_name]
         except KeyError as e:
             raise dbus.exceptions.DBusException(
-                'no such interface ' + interface_name,
-                name=self.interface + '.UnknownInterface') from e
+                "no such interface " + interface_name, name=self.interface + ".UnknownInterface"
+            ) from e
 
-    @dbus.service.method(dbus.PROPERTIES_IFACE,
-                         in_signature='ssv', out_signature='')
+    @dbus.service.method(dbus.PROPERTIES_IFACE, in_signature="ssv", out_signature="")
     def Set(self, interface_name: str, property_name: str, value: Any, *_, **__) -> None:
-        '''Standard D-Bus API for setting a property value'''
+        """Standard D-Bus API for setting a property value"""
 
-        self.log(f'Set {self.path} {interface_name}.{property_name}{_format_args((value,))}')
+        self.log(f"Set {self.path} {interface_name}.{property_name}{_format_args((value,))}")
 
         try:
             iface_props = self.props[interface_name]
         except KeyError as e:
             raise dbus.exceptions.DBusException(
-                'no such interface ' + interface_name,
-                name=self.interface + '.UnknownInterface') from e
+                "no such interface " + interface_name, name=self.interface + ".UnknownInterface"
+            ) from e
 
         if property_name not in iface_props:
             raise dbus.exceptions.DBusException(
-                'no such property ' + property_name,
-                name=self.interface + '.UnknownProperty')
+                "no such property " + property_name, name=self.interface + ".UnknownProperty"
+            )
 
         iface_props[property_name] = value
 
-        self.EmitSignal('org.freedesktop.DBus.Properties',
-                        'PropertiesChanged',
-                        'sa{sv}as',
-                        [interface_name,
-                         dbus.Dictionary({property_name: value}, signature='sv'),
-                         dbus.Array([], signature='s')
-                        ])
+        self.EmitSignal(
+            "org.freedesktop.DBus.Properties",
+            "PropertiesChanged",
+            "sa{sv}as",
+            [interface_name, dbus.Dictionary({property_name: value}, signature="sv"), dbus.Array([], signature="s")],
+        )
 
-    @dbus.service.method(MOCK_IFACE,
-                         in_signature='ssa{sv}a(ssss)',
-                         out_signature='')
+    @dbus.service.method(MOCK_IFACE, in_signature="ssa{sv}a(ssss)", out_signature="")
     def AddObject(self, path: str, interface: str, properties: PropsType, methods: List[MethodType]) -> None:
-        '''Dynamically add a new D-Bus object to the mock
+        """Dynamically add a new D-Bus object to the mock
 
         :param path: D-Bus object path
         :param interface: Primary D-Bus interface name of this object (where
@@ -350,14 +352,13 @@ class DBusMockObject(dbus.service.Object):  # pylint: disable=too-many-instance-
                                      ('EchoInt', 'i', 'i', 'ret = args[0]'),
                                      ('GetClients', '', 'ao', 'ret = ["/com/example/Foo/Client1"]'),
                                  ])
-        '''
+        """
         if path in objects:
-            raise dbus.exceptions.DBusException(f'object {path} already exists', name='org.freedesktop.DBus.Mock.NameError')
+            raise dbus.exceptions.DBusException(
+                f"object {path} already exists", name="org.freedesktop.DBus.Mock.NameError"
+            )
 
-        obj = DBusMockObject(self.bus_name,
-                             path,
-                             interface,
-                             properties)
+        obj = DBusMockObject(self.bus_name, path, interface, properties)
         # make sure created objects inherit the log file stream
         obj.logfile = self.logfile
         obj.object_manager = self.object_manager
@@ -366,34 +367,31 @@ class DBusMockObject(dbus.service.Object):  # pylint: disable=too-many-instance-
 
         objects[path] = obj
 
-    @dbus.service.method(MOCK_IFACE,
-                         in_signature='s',
-                         out_signature='')
+    @dbus.service.method(MOCK_IFACE, in_signature="s", out_signature="")
     def RemoveObject(self, path: str) -> None:
-        '''Remove a D-Bus object from the mock
+        """Remove a D-Bus object from the mock
 
         As with AddObject, this will *not* emit the InterfacesRemoved signal if
         it's an ObjectManager instance.
-        '''
+        """
         try:
             objects[path].remove_from_connection()
             del objects[path]
         except KeyError as e:
             raise dbus.exceptions.DBusException(
-                f'object {path} does not exist',
-                name='org.freedesktop.DBus.Mock.NameError') from e
+                f"object {path} does not exist", name="org.freedesktop.DBus.Mock.NameError"
+            ) from e
 
-    @dbus.service.method(MOCK_IFACE,
-                         in_signature='', out_signature='')
+    @dbus.service.method(MOCK_IFACE, in_signature="", out_signature="")
     def Reset(self) -> None:
-        '''Reset the mock object state.
+        """Reset the mock object state.
 
         Remove all mock objects from the bus and tidy up so the state is as if
         python-dbusmock had just been restarted. If the mock object was
         originally created with a template (from the command line, the Python
         API or by calling AddTemplate over D-Bus), it will be
         re-instantiated with that template.
-        '''
+        """
         # Clear other existing objects.
         for obj_name, obj in objects.items():
             if obj_name != self.path:
@@ -416,11 +414,9 @@ class DBusMockObject(dbus.service.Object):  # pylint: disable=too-many-instance-
 
         objects[self.path] = self
 
-    @dbus.service.method(MOCK_IFACE,
-                         in_signature='sssss',
-                         out_signature='')
+    @dbus.service.method(MOCK_IFACE, in_signature="sssss", out_signature="")
     def AddMethod(self, interface, name: str, in_sig: str, out_sig: str, code: str) -> None:
-        '''Dynamically add a method to this object
+        """Dynamically add a method to this object
 
         :param interface: D-Bus interface to add this to. For convenience you can
                           specify '' here to add the method to the object's main
@@ -457,7 +453,7 @@ class DBusMockObject(dbus.service.Object):  # pylint: disable=too-many-instance-
         For implementing non-trivial and static methods in templates, it is recommended to
         implement them in the normal dbus-python way with using the @dbus.service.method
         decorator instead.
-        '''
+        """
         # pylint: disable=protected-access
 
         if not interface:
@@ -470,15 +466,15 @@ class DBusMockObject(dbus.service.Object):  # pylint: disable=too-many-instance-
         # name as first positional arguments
         # pylint: disable=unnecessary-lambda-assignment
         method = lambda self, *args, **kwargs: DBusMockObject.mock_method(  # noqa: E731
-            self, interface, name, in_sig, *args, **kwargs)
+            self, interface, name, in_sig, *args, **kwargs
+        )
 
         # we cannot specify in_signature here, as that trips over a consistency
         # check in dbus-python; we need to set it manually instead
-        dbus_method = dbus.service.method(interface,
-                                          out_signature=out_sig)(method)
+        dbus_method = dbus.service.method(interface, out_signature=out_sig)(method)
         dbus_method.__name__ = str(name)
         dbus_method._dbus_in_signature = in_sig
-        dbus_method._dbus_args = [f'arg{i}' for i in range(1, n_args + 1)]
+        dbus_method._dbus_args = [f"arg{i}" for i in range(1, n_args + 1)]
 
         # for convenience, add mocked methods on the primary interface as
         # callable methods
@@ -487,18 +483,16 @@ class DBusMockObject(dbus.service.Object):  # pylint: disable=too-many-instance-
 
         self.methods.setdefault(interface, {})[str(name)] = (in_sig, out_sig, code, dbus_method)
 
-    @dbus.service.method(MOCK_IFACE,
-                         in_signature='sa(ssss)',
-                         out_signature='')
+    @dbus.service.method(MOCK_IFACE, in_signature="sa(ssss)", out_signature="")
     def AddMethods(self, interface: str, methods: List[MethodType]) -> None:
-        '''Add several methods to this object
+        """Add several methods to this object
 
         :param interface: D-Bus interface to add this to. For convenience you can
                           specify '' here to add the method to the object's main
                           interface (as specified on construction).
         :param methods: list of 4-tuples (name, in_sig, out_sig, code) describing one
                         method each. See AddMethod() for details of the tuple values.
-        '''
+        """
         for method in methods:
             self.AddMethod(interface, *method)
 
@@ -511,69 +505,62 @@ class DBusMockObject(dbus.service.Object):  # pylint: disable=too-many-instance-
 
         self.props.setdefault(interface, {})[name] = value
 
-    @dbus.service.method(MOCK_IFACE,
-                         in_signature='sa{sv}',
-                         out_signature='')
+    @dbus.service.method(MOCK_IFACE, in_signature="sa{sv}", out_signature="")
     def UpdateProperties(self, interface: str, properties: PropsType) -> None:
-        '''Update properties on this object and send a PropertiesChanged signal
+        """Update properties on this object and send a PropertiesChanged signal
 
         :param interface: D-Bus interface to update this to. For convenience you can
                           specify '' here to add the property to the object's main
                           interface (as specified on construction).
         :param properties: A property_name (string) → value map
-        '''
+        """
         changed_props = {}
 
         for name, value in properties.items():
             if not interface:
                 interface = self.interface
             if name not in self.props.get(interface, {}):
-                raise dbus.exceptions.DBusException(f'property {name} not found', name=interface + '.NoSuchProperty')
+                raise dbus.exceptions.DBusException(f"property {name} not found", name=interface + ".NoSuchProperty")
 
             self._set_property(interface, name, value)
             changed_props[name] = _wrap_in_dbus_variant(value)
 
-        self.EmitSignal(dbus.PROPERTIES_IFACE, 'PropertiesChanged', 'sa{sv}as', [
-            interface, changed_props, []])
+        self.EmitSignal(dbus.PROPERTIES_IFACE, "PropertiesChanged", "sa{sv}as", [interface, changed_props, []])
 
-    @dbus.service.method(MOCK_IFACE,
-                         in_signature='ssv',
-                         out_signature='')
+    @dbus.service.method(MOCK_IFACE, in_signature="ssv", out_signature="")
     def AddProperty(self, interface: str, name: str, value: Any) -> None:
-        '''Add property to this object
+        """Add property to this object
 
         :param interface: D-Bus interface to add this to. For convenience you can
                            specify '' here to add the property to the object's main
                            interface (as specified on construction).
         :param name: Property name.
         :param value: Property value.
-        '''
+        """
         if not interface:
             interface = self.interface
         if name in self.props.get(interface, {}):
-            raise dbus.exceptions.DBusException(f'property {name} already exists', name=self.interface + '.PropertyExists')
+            raise dbus.exceptions.DBusException(
+                f"property {name} already exists", name=self.interface + ".PropertyExists"
+            )
 
         self._set_property(interface, name, value)
 
-    @dbus.service.method(MOCK_IFACE,
-                         in_signature='sa{sv}',
-                         out_signature='')
+    @dbus.service.method(MOCK_IFACE, in_signature="sa{sv}", out_signature="")
     def AddProperties(self, interface: str, properties: PropsType) -> None:
-        '''Add several properties to this object
+        """Add several properties to this object
 
         :param interface: D-Bus interface to add this to. For convenience you can
                           specify '' here to add the property to the object's main
                           interface (as specified on construction).
         :param properties: A property_name (string) → value map
-        '''
+        """
         for k, v in properties.items():
             self.AddProperty(interface, k, v)
 
-    @dbus.service.method(MOCK_IFACE,
-                         in_signature='sa{sv}',
-                         out_signature='')
+    @dbus.service.method(MOCK_IFACE, in_signature="sa{sv}", out_signature="")
     def AddTemplate(self, template: str, parameters: PropsType) -> None:
-        '''Load a template into the mock.
+        """Load a template into the mock.
 
         python-dbusmock ships a set of standard mocks for common system
         services such as UPower and NetworkManager. With these the actual tests
@@ -590,29 +577,32 @@ class DBusMockObject(dbus.service.Object):  # pylint: disable=too-many-instance-
                            parameterizing templates. Each template can define their
                            own, see documentation of that particular template for
                            details.
-        '''
+        """
         try:
             module = load_module(template)
         except ImportError as e:
-            raise dbus.exceptions.DBusException(f'Cannot add template {template}: {e!s}',
-                                                name='org.freedesktop.DBus.Mock.TemplateError') from e
+            raise dbus.exceptions.DBusException(
+                f"Cannot add template {template}: {e!s}", name="org.freedesktop.DBus.Mock.TemplateError"
+            ) from e
 
         # If the template specifies this is an ObjectManager, set that up
-        if hasattr(module, 'IS_OBJECT_MANAGER') and module.IS_OBJECT_MANAGER:
+        if hasattr(module, "IS_OBJECT_MANAGER") and module.IS_OBJECT_MANAGER:
             self._set_up_object_manager()
 
         # pick out all D-Bus service methods and add them to our interface
         for symbol in dir(module):
             # pylint: disable=protected-access
             fn = getattr(module, symbol)
-            if ('_dbus_interface' in dir(fn) and ('_dbus_is_signal' not in dir(fn) or not fn._dbus_is_signal)):
+            if "_dbus_interface" in dir(fn) and ("_dbus_is_signal" not in dir(fn) or not fn._dbus_is_signal):
                 fn = loggedmethod(self, fn)
 
                 # for dbus-python compatibility, add methods as callables
                 setattr(self.__class__, symbol, fn)
                 self.methods.setdefault(fn._dbus_interface, {})[str(symbol)] = (
                     fn._dbus_in_signature,
-                    fn._dbus_out_signature, '', fn
+                    fn._dbus_out_signature,
+                    "",
+                    fn,
                 )
 
         if parameters is None:
@@ -624,7 +614,9 @@ class DBusMockObject(dbus.service.Object):  # pylint: disable=too-many-instance-
         self._template = template
         self._template_parameters = parameters
 
-    def _emit_signal(self, interface: str, name: str, signature: str, sigargs: Tuple[Any, ...], details: PropsType) -> None:
+    def _emit_signal(
+        self, interface: str, name: str, signature: str, sigargs: Tuple[Any, ...], details: PropsType
+    ) -> None:
         # pylint: disable=protected-access
         if not interface:
             interface = self.interface
@@ -641,13 +633,11 @@ class DBusMockObject(dbus.service.Object):  # pylint: disable=too-many-instance-
         for location in self.locations:
             conn = location[0]
             conn.send_message(sig)
-        self.log(f'emit {path} {interface}.{name}{_format_args(args)}')
+        self.log(f"emit {path} {interface}.{name}{_format_args(args)}")
 
-    @dbus.service.method(MOCK_IFACE,
-                         in_signature='sssav',
-                         out_signature='')
+    @dbus.service.method(MOCK_IFACE, in_signature="sssav", out_signature="")
     def EmitSignal(self, interface: str, name: str, signature: str, sigargs: Tuple[Any, ...]) -> None:
-        '''Emit a signal from the object.
+        """Emit a signal from the object.
 
         :param interface: D-Bus interface to send the signal from. For convenience you
                           can specify '' here to add the method to the object's main
@@ -658,14 +648,14 @@ class DBusMockObject(dbus.service.Object):  # pylint: disable=too-many-instance-
                           http://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-signatures
         :param args: variant array with signal arguments; must match order and type in
                      "signature"
-        '''
+        """
         self._emit_signal(interface, name, signature, sigargs, {})
 
-    @dbus.service.method(MOCK_IFACE,
-                         in_signature='sssava{sv}',
-                         out_signature='')
-    def EmitSignalDetailed(self, interface: str, name: str, signature: str, sigargs: Tuple[Any, ...], details: PropsType) -> None:
-        '''Emit a signal from the object with extra details.
+    @dbus.service.method(MOCK_IFACE, in_signature="sssava{sv}", out_signature="")
+    def EmitSignalDetailed(
+        self, interface: str, name: str, signature: str, sigargs: Tuple[Any, ...], details: PropsType
+    ) -> None:
+        """Emit a signal from the object with extra details.
 
         :param interface: D-Bus interface to send the signal from. For convenience you
                           can specify '' here to add the method to the object's main
@@ -679,68 +669,62 @@ class DBusMockObject(dbus.service.Object):  # pylint: disable=too-many-instance-
         :param details: dictionary with a string key/value entries. Supported keys are:
                    "destination": for the signal destination
                    "path": for the object path to send the signal from
-        '''
+        """
         self._emit_signal(interface, name, signature, sigargs, details)
 
-    @dbus.service.method(MOCK_IFACE,
-                         in_signature='',
-                         out_signature='a(tsav)')
+    @dbus.service.method(MOCK_IFACE, in_signature="", out_signature="a(tsav)")
     def GetCalls(self) -> List[CallLogType]:
-        '''List all the logged calls since the last call to ClearCalls().
+        """List all the logged calls since the last call to ClearCalls().
 
         Return a list of (timestamp, method_name, args_list) tuples.
-        '''
+        """
         return self.call_log
 
-    @dbus.service.method(MOCK_IFACE,
-                         in_signature='s',
-                         out_signature='a(tav)')
+    @dbus.service.method(MOCK_IFACE, in_signature="s", out_signature="a(tav)")
     def GetMethodCalls(self, method: str) -> List[Tuple[int, Sequence[Any]]]:
-        '''List all the logged calls of a particular method.
+        """List all the logged calls of a particular method.
 
         Return a list of (timestamp, args_list) tuples.
-        '''
+        """
         return [(row[0], row[2]) for row in self.call_log if row[1] == method]
 
-    @dbus.service.method(MOCK_IFACE,
-                         in_signature='',
-                         out_signature='')
+    @dbus.service.method(MOCK_IFACE, in_signature="", out_signature="")
     def ClearCalls(self) -> None:
-        '''Empty the log of mock call signatures.'''
+        """Empty the log of mock call signatures."""
 
         self.call_log = []
 
-    @dbus.service.signal(MOCK_IFACE, signature='sav')
+    @dbus.service.signal(MOCK_IFACE, signature="sav")
     def MethodCalled(self, name, args):
-        '''Signal emitted for every called mock method.
+        """Signal emitted for every called mock method.
 
         This is emitted for all mock method calls.  This can be used to confirm
         that a particular method was called with particular arguments, as an
         alternative to reading the mock's log or GetCalls().
-        '''
+        """
 
     def object_manager_emit_added(self, path: str) -> None:
-        '''Emit ObjectManager.InterfacesAdded signal'''
+        """Emit ObjectManager.InterfacesAdded signal"""
 
         if self.object_manager is not None:
-            self.object_manager.EmitSignal(OBJECT_MANAGER_IFACE, 'InterfacesAdded',
-                                           'oa{sa{sv}}', [dbus.ObjectPath(path),
-                                                          objects[path].props])
+            self.object_manager.EmitSignal(
+                OBJECT_MANAGER_IFACE, "InterfacesAdded", "oa{sa{sv}}", [dbus.ObjectPath(path), objects[path].props]
+            )
 
     def object_manager_emit_removed(self, path: str) -> None:
-        '''Emit ObjectManager.InterfacesRemoved signal'''
+        """Emit ObjectManager.InterfacesRemoved signal"""
 
         if self.object_manager is not None:
-            self.object_manager.EmitSignal(OBJECT_MANAGER_IFACE, 'InterfacesRemoved',
-                                           'oas', [dbus.ObjectPath(path),
-                                                   objects[path].props])
+            self.object_manager.EmitSignal(
+                OBJECT_MANAGER_IFACE, "InterfacesRemoved", "oas", [dbus.ObjectPath(path), objects[path].props]
+            )
 
     def mock_method(self, interface: str, dbus_method: str, in_signature: str, *m_args, **_) -> Any:
-        '''Master mock method.
+        """Master mock method.
 
         This gets "instantiated" in AddMethod(). Execute the code snippet of
         the method and return the "ret" variable if it was set.
-        '''
+        """
         # print('mock_method', dbus_method, self, in_signature, args, _, file=sys.stderr)
 
         try:
@@ -759,40 +743,42 @@ class DBusMockObject(dbus.service.Object):  # pylint: disable=too-many-instance-
             if code:
                 loc = locals().copy()
                 exec(code, globals(), loc)  # pylint: disable=exec-used
-                if 'ret' in loc:
-                    return loc['ret']
+                if "ret" in loc:
+                    return loc["ret"]
         except Exception as e:
-            self.log(dbus_method + ' raised: ' + str(e))
+            self.log(dbus_method + " raised: " + str(e))
             raise e
 
         return None
 
     def log(self, msg: str) -> None:
-        '''Log a message, prefixed with a timestamp.
+        """Log a message, prefixed with a timestamp.
 
         If a log file was specified in the constructor, it is written there,
         otherwise it goes to stdout.
-        '''
+        """
         fd = self.logfile.fileno() if self.logfile else sys.stdout.fileno()
 
-        os.write(fd, f'{time.time():.3f} {msg}\n'.encode())
+        os.write(fd, f"{time.time():.3f} {msg}\n".encode())
 
-    @dbus.service.method(dbus.INTROSPECTABLE_IFACE,
-                         in_signature='',
-                         out_signature='s',
-                         path_keyword='object_path',
-                         connection_keyword='connection')
+    @dbus.service.method(
+        dbus.INTROSPECTABLE_IFACE,
+        in_signature="",
+        out_signature="s",
+        path_keyword="object_path",
+        connection_keyword="connection",
+    )
     def Introspect(self, object_path: str, connection: dbus.connection.Connection) -> str:
-        '''Return XML description of this object's interfaces, methods and signals.
+        """Return XML description of this object's interfaces, methods and signals.
 
         This wraps dbus-python's Introspect() method to include the dynamic
         methods and properties.
-        '''
+        """
         # _dbus_class_table is an indirect private member of dbus.service.Object that pylint fails to see
         # pylint: disable=no-member
 
         # temporarily add our dynamic methods
-        cls = self.__class__.__module__ + '.' + self.__class__.__name__
+        cls = self.__class__.__module__ + "." + self.__class__.__name__
         orig_interfaces = self._dbus_class_table[cls]
 
         mock_interfaces = orig_interfaces.copy()
@@ -818,15 +804,19 @@ class DBusMockObject(dbus.service.Object):  # pylint: disable=too-many-instance-
                 if val is None:
                     # can't guess type from None, skip
                     continue
-                elem = ElementTree.Element("property", {
-                    "name": prop,
-                    # We don't store the signature anywhere, so guess it.
-                    "type": dbus.lowlevel.Message.guess_signature(val),
-                    "access": "readwrite"})
+                elem = ElementTree.Element(
+                    "property",
+                    {
+                        "name": prop,
+                        # We don't store the signature anywhere, so guess it.
+                        "type": dbus.lowlevel.Message.guess_signature(val),
+                        "access": "readwrite",
+                    },
+                )
 
                 interface.append(elem)
 
-        xml = ElementTree.tostring(tree, encoding='utf8', method='xml').decode('utf8')
+        xml = ElementTree.tostring(tree, encoding="utf8", method="xml").decode("utf8")
 
         # restore original class table
         self._dbus_class_table[cls] = orig_interfaces
@@ -856,12 +846,12 @@ dbus.service._method_lookup = _dbusmock_method_lookup  # pylint: disable=protect
 
 
 def get_objects() -> KeysView[str]:
-    '''Return all existing object paths'''
+    """Return all existing object paths"""
 
     return objects.keys()
 
 
 def get_object(path) -> DBusMockObject:
-    '''Return object for a given object path'''
+    """Return object for a given object path"""
 
     return objects[path]

--- a/dbusmock/pytest_fixtures.py
+++ b/dbusmock/pytest_fixtures.py
@@ -1,4 +1,4 @@
-'''pytest fixtures for DBusMock'''
+"""pytest fixtures for DBusMock"""
 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -6,8 +6,8 @@
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Martin Pitt'
-__copyright__ = '(c) 2023 Martin Pitt <martin@piware.de>'
+__author__ = "Martin Pitt"
+__copyright__ = "(c) 2023 Martin Pitt <martin@piware.de>"
 
 from typing import Iterator
 
@@ -16,17 +16,17 @@ import pytest
 from dbusmock.testcase import BusType, PrivateDBus
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def dbusmock_system() -> Iterator[PrivateDBus]:
-    '''Export the whole DBusTestCase as a fixture, with the system bus started'''
+    """Export the whole DBusTestCase as a fixture, with the system bus started"""
 
     with PrivateDBus(BusType.SYSTEM) as bus:
         yield bus
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def dbusmock_session() -> Iterator[PrivateDBus]:
-    '''Export the whole DBusTestCase as a fixture, with the session bus started'''
+    """Export the whole DBusTestCase as a fixture, with the session bus started"""
 
     with PrivateDBus(BusType.SESSION) as bus:
         yield bus

--- a/dbusmock/templates/__init__.py
+++ b/dbusmock/templates/__init__.py
@@ -1,4 +1,4 @@
-'''Mock templates for common D-Bus services'''
+"""Mock templates for common D-Bus services"""
 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free

--- a/dbusmock/templates/bluez5.py
+++ b/dbusmock/templates/bluez5.py
@@ -1,11 +1,11 @@
-'''bluetoothd mock template
+"""bluetoothd mock template
 
 This creates the expected methods and properties of the object manager
 org.bluez object (/), the manager object (/org/bluez), but no adapters or
 devices.
 
 This supports BlueZ 5 only.
-'''
+"""
 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -13,11 +13,11 @@ This supports BlueZ 5 only.
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Philip Withnall'
-__copyright__ = '''
+__author__ = "Philip Withnall"
+__copyright__ = """
 (c) 2013 Collabora Ltd.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 from pathlib import Path
 
@@ -25,38 +25,36 @@ import dbus
 
 from dbusmock import OBJECT_MANAGER_IFACE, mockobject
 
-BUS_NAME = 'org.bluez'
-MAIN_OBJ = '/'
+BUS_NAME = "org.bluez"
+MAIN_OBJ = "/"
 SYSTEM_BUS = True
 IS_OBJECT_MANAGER = True
 
-BLUEZ_MOCK_IFACE = 'org.bluez.Mock'
-AGENT_MANAGER_IFACE = 'org.bluez.AgentManager1'
-PROFILE_MANAGER_IFACE = 'org.bluez.ProfileManager1'
-ADAPTER_IFACE = 'org.bluez.Adapter1'
-MEDIA_IFACE = 'org.bluez.Media1'
-NETWORK_SERVER_IFACE = 'org.bluez.Network1'
-DEVICE_IFACE = 'org.bluez.Device1'
+BLUEZ_MOCK_IFACE = "org.bluez.Mock"
+AGENT_MANAGER_IFACE = "org.bluez.AgentManager1"
+PROFILE_MANAGER_IFACE = "org.bluez.ProfileManager1"
+ADAPTER_IFACE = "org.bluez.Adapter1"
+MEDIA_IFACE = "org.bluez.Media1"
+NETWORK_SERVER_IFACE = "org.bluez.Network1"
+DEVICE_IFACE = "org.bluez.Device1"
 
 # The device class of some arbitrary Android phone.
 MOCK_PHONE_CLASS = 5898764
 
 
-@dbus.service.method(AGENT_MANAGER_IFACE,
-                     in_signature='os', out_signature='')
+@dbus.service.method(AGENT_MANAGER_IFACE, in_signature="os", out_signature="")
 def RegisterAgent(manager, agent_path, capability):
-    all_caps = ['DisplayOnly', 'DisplayYesNo', 'KeyboardOnly',
-                'NoInputNoOutput', 'KeyboardDisplay']
+    all_caps = ["DisplayOnly", "DisplayYesNo", "KeyboardOnly", "NoInputNoOutput", "KeyboardDisplay"]
 
     if agent_path in manager.agent_paths:
         raise dbus.exceptions.DBusException(
-            'Another agent is already registered ' + manager.agent_path,
-            name='org.bluez.Error.AlreadyExists')
+            "Another agent is already registered " + manager.agent_path, name="org.bluez.Error.AlreadyExists"
+        )
 
     if capability not in all_caps:
         raise dbus.exceptions.DBusException(
-            'Unsupported capability ' + capability,
-            name='org.bluez.Error.InvalidArguments')
+            "Unsupported capability " + capability, name="org.bluez.Error.InvalidArguments"
+        )
 
     if not manager.default_agent:
         manager.default_agent = agent_path
@@ -64,13 +62,10 @@ def RegisterAgent(manager, agent_path, capability):
     manager.capabilities[str(agent_path)] = capability
 
 
-@dbus.service.method(AGENT_MANAGER_IFACE,
-                     in_signature='o', out_signature='')
+@dbus.service.method(AGENT_MANAGER_IFACE, in_signature="o", out_signature="")
 def UnregisterAgent(manager, agent_path):
     if agent_path not in manager.agent_paths:
-        raise dbus.exceptions.DBusException(
-            'Agent not registered ' + agent_path,
-            name='org.bluez.Error.DoesNotExist')
+        raise dbus.exceptions.DBusException("Agent not registered " + agent_path, name="org.bluez.Error.DoesNotExist")
 
     manager.agent_paths.remove(agent_path)
     del manager.capabilities[agent_path]
@@ -81,267 +76,307 @@ def UnregisterAgent(manager, agent_path):
             manager.default_agent = None
 
 
-@dbus.service.method(AGENT_MANAGER_IFACE,
-                     in_signature='o', out_signature='')
+@dbus.service.method(AGENT_MANAGER_IFACE, in_signature="o", out_signature="")
 def RequestDefaultAgent(manager, agent_path):
     if agent_path not in manager.agent_paths:
-        raise dbus.exceptions.DBusException(
-            'Agent not registered ' + agent_path,
-            name='org.bluez.Error.DoesNotExist')
+        raise dbus.exceptions.DBusException("Agent not registered " + agent_path, name="org.bluez.Error.DoesNotExist")
     manager.default_agent = agent_path
 
 
 def load(mock, _parameters):
-    mock.AddObject('/org/bluez', AGENT_MANAGER_IFACE, {}, [
-        ('RegisterAgent', 'os', '', RegisterAgent),
-        ('RequestDefaultAgent', 'o', '', RequestDefaultAgent),
-        ('UnregisterAgent', 'o', '', UnregisterAgent),
-    ])
+    mock.AddObject(
+        "/org/bluez",
+        AGENT_MANAGER_IFACE,
+        {},
+        [
+            ("RegisterAgent", "os", "", RegisterAgent),
+            ("RequestDefaultAgent", "o", "", RequestDefaultAgent),
+            ("UnregisterAgent", "o", "", UnregisterAgent),
+        ],
+    )
 
-    bluez = mockobject.objects['/org/bluez']
-    bluez.AddMethods(PROFILE_MANAGER_IFACE, [
-        ('RegisterProfile', 'osa{sv}', '', ''),
-        ('UnregisterProfile', 'o', '', ''),
-    ])
+    bluez = mockobject.objects["/org/bluez"]
+    bluez.AddMethods(
+        PROFILE_MANAGER_IFACE,
+        [
+            ("RegisterProfile", "osa{sv}", "", ""),
+            ("UnregisterProfile", "o", "", ""),
+        ],
+    )
     bluez.agent_paths = []
     bluez.capabilities = {}
     bluez.default_agent = None
 
 
-@dbus.service.method(ADAPTER_IFACE,
-                     in_signature='o', out_signature='')
+@dbus.service.method(ADAPTER_IFACE, in_signature="o", out_signature="")
 def RemoveDevice(adapter, path):
     adapter.RemoveObject(path)
 
-    manager = mockobject.objects['/']
-    manager.EmitSignal(OBJECT_MANAGER_IFACE, 'InterfacesRemoved',
-                       'oas', [
-                           dbus.ObjectPath(path),
-                           [DEVICE_IFACE],
-                       ])
+    manager = mockobject.objects["/"]
+    manager.EmitSignal(
+        OBJECT_MANAGER_IFACE,
+        "InterfacesRemoved",
+        "oas",
+        [
+            dbus.ObjectPath(path),
+            [DEVICE_IFACE],
+        ],
+    )
 
 
-@dbus.service.method(ADAPTER_IFACE,
-                     in_signature='', out_signature='')
+@dbus.service.method(ADAPTER_IFACE, in_signature="", out_signature="")
 def StartDiscovery(adapter):
-    adapter.props[ADAPTER_IFACE]['Discovering'] = True
+    adapter.props[ADAPTER_IFACE]["Discovering"] = True
     # NOTE: discovery filter support is minimal to mock
     # the Discoverable discovery filter
-    if adapter.props[ADAPTER_IFACE]['DiscoveryFilter'] is not None:
-        adapter.props[ADAPTER_IFACE]['Discoverable'] = True
-    adapter.EmitSignal(dbus.PROPERTIES_IFACE, 'PropertiesChanged', 'sa{sv}as', [
-        ADAPTER_IFACE,
-        {
-            'Discoverable': dbus.Boolean(adapter.props[ADAPTER_IFACE]['Discoverable'], variant_level=1),
-            'Discovering': dbus.Boolean(adapter.props[ADAPTER_IFACE]['Discovering'], variant_level=1),
-        },
-        [],
-    ])
+    if adapter.props[ADAPTER_IFACE]["DiscoveryFilter"] is not None:
+        adapter.props[ADAPTER_IFACE]["Discoverable"] = True
+    adapter.EmitSignal(
+        dbus.PROPERTIES_IFACE,
+        "PropertiesChanged",
+        "sa{sv}as",
+        [
+            ADAPTER_IFACE,
+            {
+                "Discoverable": dbus.Boolean(adapter.props[ADAPTER_IFACE]["Discoverable"], variant_level=1),
+                "Discovering": dbus.Boolean(adapter.props[ADAPTER_IFACE]["Discovering"], variant_level=1),
+            },
+            [],
+        ],
+    )
 
 
-@dbus.service.method(ADAPTER_IFACE,
-                     in_signature='', out_signature='')
+@dbus.service.method(ADAPTER_IFACE, in_signature="", out_signature="")
 def StopDiscovery(adapter):
-    adapter.props[ADAPTER_IFACE]['Discovering'] = False
+    adapter.props[ADAPTER_IFACE]["Discovering"] = False
     # NOTE: discovery filter support is minimal to mock
     # the Discoverable discovery filter
-    if adapter.props[ADAPTER_IFACE]['DiscoveryFilter'] is not None:
-        adapter.props[ADAPTER_IFACE]['Discoverable'] = False
-    adapter.EmitSignal(dbus.PROPERTIES_IFACE, 'PropertiesChanged', 'sa{sv}as', [
-        ADAPTER_IFACE,
-        {
-            'Discoverable': dbus.Boolean(adapter.props[ADAPTER_IFACE]['Discoverable'], variant_level=1),
-            'Discovering': dbus.Boolean(adapter.props[ADAPTER_IFACE]['Discovering'], variant_level=1),
-        },
-        [],
-    ])
+    if adapter.props[ADAPTER_IFACE]["DiscoveryFilter"] is not None:
+        adapter.props[ADAPTER_IFACE]["Discoverable"] = False
+    adapter.EmitSignal(
+        dbus.PROPERTIES_IFACE,
+        "PropertiesChanged",
+        "sa{sv}as",
+        [
+            ADAPTER_IFACE,
+            {
+                "Discoverable": dbus.Boolean(adapter.props[ADAPTER_IFACE]["Discoverable"], variant_level=1),
+                "Discovering": dbus.Boolean(adapter.props[ADAPTER_IFACE]["Discovering"], variant_level=1),
+            },
+            [],
+        ],
+    )
 
 
-@dbus.service.method(ADAPTER_IFACE,
-                     in_signature='a{sv}', out_signature='')
+@dbus.service.method(ADAPTER_IFACE, in_signature="a{sv}", out_signature="")
 def SetDiscoveryFilter(adapter, discovery_filter):
-    adapter.props[ADAPTER_IFACE]['DiscoveryFilter'] = discovery_filter
+    adapter.props[ADAPTER_IFACE]["DiscoveryFilter"] = discovery_filter
 
 
-@dbus.service.method(BLUEZ_MOCK_IFACE,
-                     in_signature='ss', out_signature='s')
+@dbus.service.method(BLUEZ_MOCK_IFACE, in_signature="ss", out_signature="s")
 def AddAdapter(self, device_name, system_name):
-    '''Convenience method to add a Bluetooth adapter
+    """Convenience method to add a Bluetooth adapter
 
     You have to specify a device name which must be a valid part of an object
     path, e. g. "hci0", and an arbitrary system name (pretty hostname).
 
     Returns the new object path.
-    '''
-    path = '/org/bluez/' + device_name
+    """
+    path = "/org/bluez/" + device_name
     address_start = int(device_name[-1])
-    address = (f"{address_start:02d}:{address_start + 1:02d}:{address_start + 2:02d}:"
-               f"{address_start + 3:02d}:{address_start + 4:02d}:{address_start + 5:02d}")
+    address = (
+        f"{address_start:02d}:{address_start + 1:02d}:{address_start + 2:02d}:"
+        f"{address_start + 3:02d}:{address_start + 4:02d}:{address_start + 5:02d}"
+    )
     adapter_properties = {
-        'UUIDs': dbus.Array([
-            # Reference:
-            # http://git.kernel.org/cgit/bluetooth/bluez.git/tree/lib/uuid.h
-            # PNP
-            '00001200-0000-1000-8000-00805f9b34fb',
-            # Generic Access Profile
-            '00001800-0000-1000-8000-00805f9b34fb',
-            # Generic Attribute Profile
-            '00001801-0000-1000-8000-00805f9b34fb',
-            # Audio/Video Remote Control Profile (remote)
-            '0000110e-0000-1000-8000-00805f9b34fb',
-            # Audio/Video Remote Control Profile (target)
-            '0000110c-0000-1000-8000-00805f9b34fb',
-        ], variant_level=1),
-        'Discoverable': dbus.Boolean(False, variant_level=1),
-        'Discovering': dbus.Boolean(False, variant_level=1),
-        'Pairable': dbus.Boolean(True, variant_level=1),
-        'Powered': dbus.Boolean(True, variant_level=1),
-        'Address': dbus.String(address, variant_level=1),
-        'AddressType': dbus.String('public', variant_level=1),
-        'Alias': dbus.String(system_name, variant_level=1),
-        'Modalias': dbus.String('usb:v1D6Bp0245d050A', variant_level=1),
-        'Name': dbus.String(system_name, variant_level=1),
+        "UUIDs": dbus.Array(
+            [
+                # Reference:
+                # http://git.kernel.org/cgit/bluetooth/bluez.git/tree/lib/uuid.h
+                # PNP
+                "00001200-0000-1000-8000-00805f9b34fb",
+                # Generic Access Profile
+                "00001800-0000-1000-8000-00805f9b34fb",
+                # Generic Attribute Profile
+                "00001801-0000-1000-8000-00805f9b34fb",
+                # Audio/Video Remote Control Profile (remote)
+                "0000110e-0000-1000-8000-00805f9b34fb",
+                # Audio/Video Remote Control Profile (target)
+                "0000110c-0000-1000-8000-00805f9b34fb",
+            ],
+            variant_level=1,
+        ),
+        "Discoverable": dbus.Boolean(False, variant_level=1),
+        "Discovering": dbus.Boolean(False, variant_level=1),
+        "Pairable": dbus.Boolean(True, variant_level=1),
+        "Powered": dbus.Boolean(True, variant_level=1),
+        "Address": dbus.String(address, variant_level=1),
+        "AddressType": dbus.String("public", variant_level=1),
+        "Alias": dbus.String(system_name, variant_level=1),
+        "Modalias": dbus.String("usb:v1D6Bp0245d050A", variant_level=1),
+        "Name": dbus.String(system_name, variant_level=1),
         # Reference:
         # http://bluetooth-pentest.narod.ru/software/
         # bluetooth_class_of_device-service_generator.html
-        'Class': dbus.UInt32(268, variant_level=1),  # Computer, Laptop
-        'DiscoverableTimeout': dbus.UInt32(180, variant_level=1),
-        'PairableTimeout': dbus.UInt32(0, variant_level=1),
+        "Class": dbus.UInt32(268, variant_level=1),  # Computer, Laptop
+        "DiscoverableTimeout": dbus.UInt32(180, variant_level=1),
+        "PairableTimeout": dbus.UInt32(0, variant_level=1),
     }
 
-    self.AddObject(path,
-                   ADAPTER_IFACE,
-                   # Properties
-                   adapter_properties,
-                   # Methods
-                   [
-                       ('RemoveDevice', 'o', '', RemoveDevice),
-                       ('StartDiscovery', '', '', StartDiscovery),
-                       ('StopDiscovery', '', '', StopDiscovery),
-                       ('SetDiscoveryFilter', 'a{sv}', '', SetDiscoveryFilter),
-                   ])
+    self.AddObject(
+        path,
+        ADAPTER_IFACE,
+        # Properties
+        adapter_properties,
+        # Methods
+        [
+            ("RemoveDevice", "o", "", RemoveDevice),
+            ("StartDiscovery", "", "", StartDiscovery),
+            ("StopDiscovery", "", "", StopDiscovery),
+            ("SetDiscoveryFilter", "a{sv}", "", SetDiscoveryFilter),
+        ],
+    )
 
     adapter = mockobject.objects[path]
-    adapter.AddMethods(MEDIA_IFACE, [
-        ('RegisterEndpoint', 'oa{sv}', '', ''),
-        ('UnregisterEndpoint', 'o', '', ''),
-    ])
-    adapter.AddMethods(NETWORK_SERVER_IFACE, [
-        ('Register', 'ss', '', ''),
-        ('Unregister', 's', '', ''),
-    ])
+    adapter.AddMethods(
+        MEDIA_IFACE,
+        [
+            ("RegisterEndpoint", "oa{sv}", "", ""),
+            ("UnregisterEndpoint", "o", "", ""),
+        ],
+    )
+    adapter.AddMethods(
+        NETWORK_SERVER_IFACE,
+        [
+            ("Register", "ss", "", ""),
+            ("Unregister", "s", "", ""),
+        ],
+    )
 
-    manager = mockobject.objects['/']
-    manager.EmitSignal(OBJECT_MANAGER_IFACE, 'InterfacesAdded',
-                       'oa{sa{sv}}', [
-                           dbus.ObjectPath(path),
-                           {ADAPTER_IFACE: adapter_properties},
-                       ])
+    manager = mockobject.objects["/"]
+    manager.EmitSignal(
+        OBJECT_MANAGER_IFACE,
+        "InterfacesAdded",
+        "oa{sa{sv}}",
+        [
+            dbus.ObjectPath(path),
+            {ADAPTER_IFACE: adapter_properties},
+        ],
+    )
 
     return path
 
 
-@dbus.service.method(BLUEZ_MOCK_IFACE,
-                     in_signature='s')
+@dbus.service.method(BLUEZ_MOCK_IFACE, in_signature="s")
 def RemoveAdapter(self, device_name):
-    '''Convenience method to remove a Bluetooth adapter
-    '''
-    path = '/org/bluez/' + device_name
+    """Convenience method to remove a Bluetooth adapter"""
+    path = "/org/bluez/" + device_name
     # We could remove the devices related to the adapters here, but
     # when bluez crashes, the InterfacesRemoved aren't necessarily sent
     # devices first, so in effect, our laziness is testing an edge case
     # in the clients
     self.RemoveObject(path)
 
-    manager = mockobject.objects['/']
-    manager.EmitSignal(OBJECT_MANAGER_IFACE, 'InterfacesRemoved',
-                       'oas', [
-                           dbus.ObjectPath(path),
-                           [ADAPTER_IFACE],
-                       ])
+    manager = mockobject.objects["/"]
+    manager.EmitSignal(
+        OBJECT_MANAGER_IFACE,
+        "InterfacesRemoved",
+        "oas",
+        [
+            dbus.ObjectPath(path),
+            [ADAPTER_IFACE],
+        ],
+    )
 
 
-@dbus.service.method(BLUEZ_MOCK_IFACE,
-                     in_signature='s')
+@dbus.service.method(BLUEZ_MOCK_IFACE, in_signature="s")
 def RemoveAdapterWithDevices(self, device_name):
-    '''Convenience method to remove a Bluetooth adapter and all
-       the devices associated to it
-    '''
-    adapter_path = '/org/bluez/' + device_name
+    """Convenience method to remove a Bluetooth adapter and all
+    the devices associated to it
+    """
+    adapter_path = "/org/bluez/" + device_name
     adapter = mockobject.objects[adapter_path]
-    manager = mockobject.objects['/']
+    manager = mockobject.objects["/"]
 
     to_remove = []
     for path in mockobject.objects:
-        if path.startswith(adapter_path + '/'):
+        if path.startswith(adapter_path + "/"):
             to_remove.append(path)
 
     for path in to_remove:
         adapter.RemoveObject(path)
-        manager.EmitSignal(OBJECT_MANAGER_IFACE, 'InterfacesRemoved',
-                           'oas', [
-                               dbus.ObjectPath(path),
-                               [DEVICE_IFACE],
-                           ])
+        manager.EmitSignal(
+            OBJECT_MANAGER_IFACE,
+            "InterfacesRemoved",
+            "oas",
+            [
+                dbus.ObjectPath(path),
+                [DEVICE_IFACE],
+            ],
+        )
 
     self.RemoveObject(adapter_path)
-    manager.EmitSignal(OBJECT_MANAGER_IFACE, 'InterfacesRemoved',
-                       'oas', [
-                           dbus.ObjectPath(adapter_path),
-                           [ADAPTER_IFACE],
-                       ])
+    manager.EmitSignal(
+        OBJECT_MANAGER_IFACE,
+        "InterfacesRemoved",
+        "oas",
+        [
+            dbus.ObjectPath(adapter_path),
+            [ADAPTER_IFACE],
+        ],
+    )
 
 
-@dbus.service.method(DEVICE_IFACE,
-                     in_signature='', out_signature='')
+@dbus.service.method(DEVICE_IFACE, in_signature="", out_signature="")
 def Pair(device):
     if device.paired:
-        raise dbus.exceptions.DBusException(
-            'Device already paired',
-            name='org.bluez.Error.AlreadyExists')
-    device_address = device.props[DEVICE_IFACE]['Address']
-    adapter_device_name = Path(device.props[DEVICE_IFACE]['Adapter']).name
+        raise dbus.exceptions.DBusException("Device already paired", name="org.bluez.Error.AlreadyExists")
+    device_address = device.props[DEVICE_IFACE]["Address"]
+    adapter_device_name = Path(device.props[DEVICE_IFACE]["Adapter"]).name
     device.PairDevice(adapter_device_name, device_address, MOCK_PHONE_CLASS)
 
 
-@dbus.service.method(DEVICE_IFACE,
-                     in_signature='', out_signature='')
+@dbus.service.method(DEVICE_IFACE, in_signature="", out_signature="")
 def Connect(device):
     if device.connected:
-        raise dbus.exceptions.DBusException(
-            'Already Connected',
-            name='org.bluez.Error.AlreadyConnected')
+        raise dbus.exceptions.DBusException("Already Connected", name="org.bluez.Error.AlreadyConnected")
     device.connected = True
-    device.EmitSignal(dbus.PROPERTIES_IFACE, 'PropertiesChanged', 'sa{sv}as', [
-        DEVICE_IFACE,
-        {
-            'Connected': dbus.Boolean(device.connected, variant_level=1),
-        },
-        [],
-    ])
+    device.EmitSignal(
+        dbus.PROPERTIES_IFACE,
+        "PropertiesChanged",
+        "sa{sv}as",
+        [
+            DEVICE_IFACE,
+            {
+                "Connected": dbus.Boolean(device.connected, variant_level=1),
+            },
+            [],
+        ],
+    )
 
 
-@dbus.service.method(DEVICE_IFACE,
-                     in_signature='', out_signature='')
+@dbus.service.method(DEVICE_IFACE, in_signature="", out_signature="")
 def Disconnect(device):
     if not device.connected:
-        raise dbus.exceptions.DBusException(
-            'Not Connected',
-            name='org.bluez.Error.NotConnected')
+        raise dbus.exceptions.DBusException("Not Connected", name="org.bluez.Error.NotConnected")
     device.connected = False
-    device.EmitSignal(dbus.PROPERTIES_IFACE, 'PropertiesChanged', 'sa{sv}as', [
-        DEVICE_IFACE,
-        {
-            'Connected': dbus.Boolean(device.connected, variant_level=1),
-        },
-        [],
-    ])
+    device.EmitSignal(
+        dbus.PROPERTIES_IFACE,
+        "PropertiesChanged",
+        "sa{sv}as",
+        [
+            DEVICE_IFACE,
+            {
+                "Connected": dbus.Boolean(device.connected, variant_level=1),
+            },
+            [],
+        ],
+    )
 
 
-@dbus.service.method(BLUEZ_MOCK_IFACE,
-                     in_signature='sss', out_signature='s')
+@dbus.service.method(BLUEZ_MOCK_IFACE, in_signature="sss", out_signature="s")
 def AddDevice(self, adapter_device_name, device_address, alias):
-    '''Convenience method to add a Bluetooth device
+    """Convenience method to add a Bluetooth device
 
     You have to specify a device address which must be a valid Bluetooth
     address (e.g. 'AA:BB:CC:DD:EE:FF'). The alias is the human-readable name
@@ -351,73 +386,78 @@ def AddDevice(self, adapter_device_name, device_address, alias):
     This will create a new, unpaired and unconnected device.
 
     Returns the new object path.
-    '''
-    device_name = 'dev_' + device_address.replace(':', '_').upper()
-    adapter_path = '/org/bluez/' + adapter_device_name
-    path = adapter_path + '/' + device_name
+    """
+    device_name = "dev_" + device_address.replace(":", "_").upper()
+    adapter_path = "/org/bluez/" + adapter_device_name
+    path = adapter_path + "/" + device_name
 
     if adapter_path not in mockobject.objects:
         raise dbus.exceptions.DBusException(
-            f'Adapter {adapter_device_name} does not exist.',
-            name=BLUEZ_MOCK_IFACE + '.NoSuchAdapter')
+            f"Adapter {adapter_device_name} does not exist.", name=BLUEZ_MOCK_IFACE + ".NoSuchAdapter"
+        )
 
     properties = {
-        'Address': dbus.String(device_address, variant_level=1),
-        'AddressType': dbus.String('public', variant_level=1),
-        'Name': dbus.String(alias, variant_level=1),
-        'Icon': dbus.String('', variant_level=1),
-        'Class': dbus.UInt32(0, variant_level=1),
-        'Appearance': dbus.UInt16(0, variant_level=1),
-        'UUIDs': dbus.Array([], signature='s', variant_level=1),
-        'Paired': dbus.Boolean(False, variant_level=1),
-        'Connected': dbus.Boolean(False, variant_level=1),
-        'Trusted': dbus.Boolean(False, variant_level=1),
-        'Blocked': dbus.Boolean(False, variant_level=1),
-        'WakeAllowed': dbus.Boolean(False, variant_level=1),
-        'Alias': dbus.String(alias, variant_level=1),
-        'Adapter': dbus.ObjectPath(adapter_path, variant_level=1),
-        'LegacyPairing': dbus.Boolean(False, variant_level=1),
-        'Modalias': dbus.String('', variant_level=1),
-        'RSSI': dbus.Int16(-79, variant_level=1),  # arbitrary
-        'TxPower': dbus.Int16(0, variant_level=1),
-        'ManufacturerData': dbus.Array([], signature='a{qv}', variant_level=1),
-        'ServiceData': dbus.Array([], signature='a{sv}', variant_level=1),
-        'ServicesResolved': dbus.Boolean(False, variant_level=1),
-        'AdvertisingFlags': dbus.Array([], signature='ay', variant_level=1),
-        'AdvertisingData': dbus.Array([], signature='a{yv}', variant_level=1),
+        "Address": dbus.String(device_address, variant_level=1),
+        "AddressType": dbus.String("public", variant_level=1),
+        "Name": dbus.String(alias, variant_level=1),
+        "Icon": dbus.String("", variant_level=1),
+        "Class": dbus.UInt32(0, variant_level=1),
+        "Appearance": dbus.UInt16(0, variant_level=1),
+        "UUIDs": dbus.Array([], signature="s", variant_level=1),
+        "Paired": dbus.Boolean(False, variant_level=1),
+        "Connected": dbus.Boolean(False, variant_level=1),
+        "Trusted": dbus.Boolean(False, variant_level=1),
+        "Blocked": dbus.Boolean(False, variant_level=1),
+        "WakeAllowed": dbus.Boolean(False, variant_level=1),
+        "Alias": dbus.String(alias, variant_level=1),
+        "Adapter": dbus.ObjectPath(adapter_path, variant_level=1),
+        "LegacyPairing": dbus.Boolean(False, variant_level=1),
+        "Modalias": dbus.String("", variant_level=1),
+        "RSSI": dbus.Int16(-79, variant_level=1),  # arbitrary
+        "TxPower": dbus.Int16(0, variant_level=1),
+        "ManufacturerData": dbus.Array([], signature="a{qv}", variant_level=1),
+        "ServiceData": dbus.Array([], signature="a{sv}", variant_level=1),
+        "ServicesResolved": dbus.Boolean(False, variant_level=1),
+        "AdvertisingFlags": dbus.Array([], signature="ay", variant_level=1),
+        "AdvertisingData": dbus.Array([], signature="a{yv}", variant_level=1),
     }
 
-    self.AddObject(path,
-                   DEVICE_IFACE,
-                   # Properties
-                   properties,
-                   # Methods
-                   [
-                       ('CancelPairing', '', '', ''),
-                       ('Connect', '', '', Connect),
-                       ('ConnectProfile', 's', '', ''),
-                       ('Disconnect', '', '', Disconnect),
-                       ('DisconnectProfile', 's', '', ''),
-                       ('Pair', '', '', Pair),
-                   ])
+    self.AddObject(
+        path,
+        DEVICE_IFACE,
+        # Properties
+        properties,
+        # Methods
+        [
+            ("CancelPairing", "", "", ""),
+            ("Connect", "", "", Connect),
+            ("ConnectProfile", "s", "", ""),
+            ("Disconnect", "", "", Disconnect),
+            ("DisconnectProfile", "s", "", ""),
+            ("Pair", "", "", Pair),
+        ],
+    )
     device = mockobject.objects[path]
     device.paired = False
     device.connected = False
 
-    manager = mockobject.objects['/']
-    manager.EmitSignal(OBJECT_MANAGER_IFACE, 'InterfacesAdded',
-                       'oa{sa{sv}}', [
-                           dbus.ObjectPath(path),
-                           {DEVICE_IFACE: properties},
-                       ])
+    manager = mockobject.objects["/"]
+    manager.EmitSignal(
+        OBJECT_MANAGER_IFACE,
+        "InterfacesAdded",
+        "oa{sa{sv}}",
+        [
+            dbus.ObjectPath(path),
+            {DEVICE_IFACE: properties},
+        ],
+    )
 
     return path
 
 
-@dbus.service.method(BLUEZ_MOCK_IFACE,
-                     in_signature='ssi', out_signature='')
+@dbus.service.method(BLUEZ_MOCK_IFACE, in_signature="ssi", out_signature="")
 def PairDevice(_self, adapter_device_name, device_address, class_):
-    '''Convenience method to mark an existing device as paired.
+    """Convenience method to mark an existing device as paired.
 
     You have to specify a device address which must be a valid Bluetooth
     address (e.g. 'AA:BB:CC:DD:EE:FF'). The adapter device name is the
@@ -429,71 +469,76 @@ def PairDevice(_self, adapter_device_name, device_address, class_):
     NoSuchDevice error will be returned on the bus.
 
     Returns nothing.
-    '''
-    device_name = 'dev_' + device_address.replace(':', '_').upper()
-    adapter_path = '/org/bluez/' + adapter_device_name
-    device_path = adapter_path + '/' + device_name
+    """
+    device_name = "dev_" + device_address.replace(":", "_").upper()
+    adapter_path = "/org/bluez/" + adapter_device_name
+    device_path = adapter_path + "/" + device_name
 
     if adapter_path not in mockobject.objects:
         raise dbus.exceptions.DBusException(
-            f'Adapter {adapter_device_name} does not exist.',
-            name=BLUEZ_MOCK_IFACE + '.NoSuchAdapter')
+            f"Adapter {adapter_device_name} does not exist.", name=BLUEZ_MOCK_IFACE + ".NoSuchAdapter"
+        )
     if device_path not in mockobject.objects:
-        raise dbus.exceptions.DBusException(f'Device {device_name} does not exist.', name=BLUEZ_MOCK_IFACE + '.NoSuchDevice')
+        raise dbus.exceptions.DBusException(
+            f"Device {device_name} does not exist.", name=BLUEZ_MOCK_IFACE + ".NoSuchDevice"
+        )
 
     device = mockobject.objects[device_path]
     device.paired = True
 
     # Based off pairing with an Android phone.
     uuids = [
-        '00001105-0000-1000-8000-00805f9b34fb',
-        '0000110a-0000-1000-8000-00805f9b34fb',
-        '0000110c-0000-1000-8000-00805f9b34fb',
-        '00001112-0000-1000-8000-00805f9b34fb',
-        '00001115-0000-1000-8000-00805f9b34fb',
-        '00001116-0000-1000-8000-00805f9b34fb',
-        '0000111f-0000-1000-8000-00805f9b34fb',
-        '0000112f-0000-1000-8000-00805f9b34fb',
-        '00001200-0000-1000-8000-00805f9b34fb',
+        "00001105-0000-1000-8000-00805f9b34fb",
+        "0000110a-0000-1000-8000-00805f9b34fb",
+        "0000110c-0000-1000-8000-00805f9b34fb",
+        "00001112-0000-1000-8000-00805f9b34fb",
+        "00001115-0000-1000-8000-00805f9b34fb",
+        "00001116-0000-1000-8000-00805f9b34fb",
+        "0000111f-0000-1000-8000-00805f9b34fb",
+        "0000112f-0000-1000-8000-00805f9b34fb",
+        "00001200-0000-1000-8000-00805f9b34fb",
     ]
 
-    device.props[DEVICE_IFACE]['UUIDs'] = dbus.Array(uuids, variant_level=1)
-    device.props[DEVICE_IFACE]['Paired'] = dbus.Boolean(True, variant_level=1)
-    device.props[DEVICE_IFACE]['LegacyPairing'] = dbus.Boolean(True,
-                                                               variant_level=1)
-    device.props[DEVICE_IFACE]['Blocked'] = dbus.Boolean(False,
-                                                         variant_level=1)
+    device.props[DEVICE_IFACE]["UUIDs"] = dbus.Array(uuids, variant_level=1)
+    device.props[DEVICE_IFACE]["Paired"] = dbus.Boolean(True, variant_level=1)
+    device.props[DEVICE_IFACE]["LegacyPairing"] = dbus.Boolean(True, variant_level=1)
+    device.props[DEVICE_IFACE]["Blocked"] = dbus.Boolean(False, variant_level=1)
 
     try:
-        device.props[DEVICE_IFACE]['Modalias']
+        device.props[DEVICE_IFACE]["Modalias"]
     except KeyError:
-        device.AddProperties(DEVICE_IFACE, {
-            'Modalias': dbus.String('bluetooth:v000Fp1200d1436',
-                                    variant_level=1),
-            'Class': dbus.UInt32(class_, variant_level=1),
-            'Icon': dbus.String('phone', variant_level=1),
-        })
+        device.AddProperties(
+            DEVICE_IFACE,
+            {
+                "Modalias": dbus.String("bluetooth:v000Fp1200d1436", variant_level=1),
+                "Class": dbus.UInt32(class_, variant_level=1),
+                "Icon": dbus.String("phone", variant_level=1),
+            },
+        )
 
-    device.EmitSignal(dbus.PROPERTIES_IFACE, 'PropertiesChanged', 'sa{sv}as', [
-        DEVICE_IFACE,
-        {
-            'UUIDs': dbus.Array(uuids, variant_level=1),
-            'Paired': dbus.Boolean(True, variant_level=1),
-            'LegacyPairing': dbus.Boolean(True, variant_level=1),
-            'Blocked': dbus.Boolean(False, variant_level=1),
-            'Modalias': dbus.String('bluetooth:v000Fp1200d1436',
-                                    variant_level=1),
-            'Class': dbus.UInt32(class_, variant_level=1),
-            'Icon': dbus.String('phone', variant_level=1),
-        },
-        [],
-    ])
+    device.EmitSignal(
+        dbus.PROPERTIES_IFACE,
+        "PropertiesChanged",
+        "sa{sv}as",
+        [
+            DEVICE_IFACE,
+            {
+                "UUIDs": dbus.Array(uuids, variant_level=1),
+                "Paired": dbus.Boolean(True, variant_level=1),
+                "LegacyPairing": dbus.Boolean(True, variant_level=1),
+                "Blocked": dbus.Boolean(False, variant_level=1),
+                "Modalias": dbus.String("bluetooth:v000Fp1200d1436", variant_level=1),
+                "Class": dbus.UInt32(class_, variant_level=1),
+                "Icon": dbus.String("phone", variant_level=1),
+            },
+            [],
+        ],
+    )
 
 
-@dbus.service.method(BLUEZ_MOCK_IFACE,
-                     in_signature='ss', out_signature='')
+@dbus.service.method(BLUEZ_MOCK_IFACE, in_signature="ss", out_signature="")
 def BlockDevice(_self, adapter_device_name, device_address):
-    '''Convenience method to mark an existing device as blocked.
+    """Convenience method to mark an existing device as blocked.
 
     You have to specify a device address which must be a valid Bluetooth
     address (e.g. 'AA:BB:CC:DD:EE:FF'). The adapter device name is the
@@ -505,38 +550,43 @@ def BlockDevice(_self, adapter_device_name, device_address):
     NoSuchDevice error will be returned on the bus.
 
     Returns nothing.
-    '''
-    device_name = 'dev_' + device_address.replace(':', '_').upper()
-    adapter_path = '/org/bluez/' + adapter_device_name
-    device_path = adapter_path + '/' + device_name
+    """
+    device_name = "dev_" + device_address.replace(":", "_").upper()
+    adapter_path = "/org/bluez/" + adapter_device_name
+    device_path = adapter_path + "/" + device_name
 
     if adapter_path not in mockobject.objects:
         raise dbus.exceptions.DBusException(
-            f'Adapter {adapter_device_name} does not exist.',
-            name=BLUEZ_MOCK_IFACE + '.NoSuchAdapter')
+            f"Adapter {adapter_device_name} does not exist.", name=BLUEZ_MOCK_IFACE + ".NoSuchAdapter"
+        )
     if device_path not in mockobject.objects:
-        raise dbus.exceptions.DBusException(f'Device {device_name} does not exist.', name=BLUEZ_MOCK_IFACE + '.NoSuchDevice')
+        raise dbus.exceptions.DBusException(
+            f"Device {device_name} does not exist.", name=BLUEZ_MOCK_IFACE + ".NoSuchDevice"
+        )
 
     device = mockobject.objects[device_path]
 
-    device.props[DEVICE_IFACE]['Blocked'] = dbus.Boolean(True, variant_level=1)
-    device.props[DEVICE_IFACE]['Connected'] = dbus.Boolean(False,
-                                                           variant_level=1)
+    device.props[DEVICE_IFACE]["Blocked"] = dbus.Boolean(True, variant_level=1)
+    device.props[DEVICE_IFACE]["Connected"] = dbus.Boolean(False, variant_level=1)
 
-    device.EmitSignal(dbus.PROPERTIES_IFACE, 'PropertiesChanged', 'sa{sv}as', [
-        DEVICE_IFACE,
-        {
-            'Blocked': dbus.Boolean(True, variant_level=1),
-            'Connected': dbus.Boolean(False, variant_level=1),
-        },
-        [],
-    ])
+    device.EmitSignal(
+        dbus.PROPERTIES_IFACE,
+        "PropertiesChanged",
+        "sa{sv}as",
+        [
+            DEVICE_IFACE,
+            {
+                "Blocked": dbus.Boolean(True, variant_level=1),
+                "Connected": dbus.Boolean(False, variant_level=1),
+            },
+            [],
+        ],
+    )
 
 
-@dbus.service.method(BLUEZ_MOCK_IFACE,
-                     in_signature='ss', out_signature='')
+@dbus.service.method(BLUEZ_MOCK_IFACE, in_signature="ss", out_signature="")
 def ConnectDevice(_self, adapter_device_name, device_address):
-    '''Convenience method to mark an existing device as connected.
+    """Convenience method to mark an existing device as connected.
 
     You have to specify a device address which must be a valid Bluetooth
     address (e.g. 'AA:BB:CC:DD:EE:FF'). The adapter device name is the
@@ -548,41 +598,43 @@ def ConnectDevice(_self, adapter_device_name, device_address):
     NoSuchDevice error will be returned on the bus.
 
     Returns nothing.
-    '''
-    device_name = 'dev_' + device_address.replace(':', '_').upper()
-    adapter_path = '/org/bluez/' + adapter_device_name
-    device_path = adapter_path + '/' + device_name
+    """
+    device_name = "dev_" + device_address.replace(":", "_").upper()
+    adapter_path = "/org/bluez/" + adapter_device_name
+    device_path = adapter_path + "/" + device_name
 
     if adapter_path not in mockobject.objects:
         raise dbus.exceptions.DBusException(
-            f'Adapter {adapter_device_name} does not exist.',
-            name=BLUEZ_MOCK_IFACE + '.NoSuchAdapter')
+            f"Adapter {adapter_device_name} does not exist.", name=BLUEZ_MOCK_IFACE + ".NoSuchAdapter"
+        )
     if device_path not in mockobject.objects:
         raise dbus.exceptions.DBusException(
-            f'Device {device_name} does not exist.',
-            name=BLUEZ_MOCK_IFACE + '.NoSuchDevice')
+            f"Device {device_name} does not exist.", name=BLUEZ_MOCK_IFACE + ".NoSuchDevice"
+        )
 
     device = mockobject.objects[device_path]
 
-    device.props[DEVICE_IFACE]['Blocked'] = dbus.Boolean(False,
-                                                         variant_level=1)
-    device.props[DEVICE_IFACE]['Connected'] = dbus.Boolean(True,
-                                                           variant_level=1)
+    device.props[DEVICE_IFACE]["Blocked"] = dbus.Boolean(False, variant_level=1)
+    device.props[DEVICE_IFACE]["Connected"] = dbus.Boolean(True, variant_level=1)
 
-    device.EmitSignal(dbus.PROPERTIES_IFACE, 'PropertiesChanged', 'sa{sv}as', [
-        DEVICE_IFACE,
-        {
-            'Blocked': dbus.Boolean(False, variant_level=1),
-            'Connected': dbus.Boolean(True, variant_level=1),
-        },
-        [],
-    ])
+    device.EmitSignal(
+        dbus.PROPERTIES_IFACE,
+        "PropertiesChanged",
+        "sa{sv}as",
+        [
+            DEVICE_IFACE,
+            {
+                "Blocked": dbus.Boolean(False, variant_level=1),
+                "Connected": dbus.Boolean(True, variant_level=1),
+            },
+            [],
+        ],
+    )
 
 
-@dbus.service.method(BLUEZ_MOCK_IFACE,
-                     in_signature='ss', out_signature='')
+@dbus.service.method(BLUEZ_MOCK_IFACE, in_signature="ss", out_signature="")
 def DisconnectDevice(_self, adapter_device_name, device_address):
-    '''Convenience method to mark an existing device as disconnected.
+    """Convenience method to mark an existing device as disconnected.
 
     You have to specify a device address which must be a valid Bluetooth
     address (e.g. 'AA:BB:CC:DD:EE:FF'). The adapter device name is the
@@ -594,29 +646,33 @@ def DisconnectDevice(_self, adapter_device_name, device_address):
     NoSuchDevice error will be returned on the bus.
 
     Returns nothing.
-    '''
-    device_name = 'dev_' + device_address.replace(':', '_').upper()
-    adapter_path = '/org/bluez/' + adapter_device_name
-    device_path = adapter_path + '/' + device_name
+    """
+    device_name = "dev_" + device_address.replace(":", "_").upper()
+    adapter_path = "/org/bluez/" + adapter_device_name
+    device_path = adapter_path + "/" + device_name
 
     if adapter_path not in mockobject.objects:
         raise dbus.exceptions.DBusException(
-            f'Adapter {adapter_device_name} does not exist.',
-            name=BLUEZ_MOCK_IFACE + '.NoSuchAdapter')
+            f"Adapter {adapter_device_name} does not exist.", name=BLUEZ_MOCK_IFACE + ".NoSuchAdapter"
+        )
     if device_path not in mockobject.objects:
         raise dbus.exceptions.DBusException(
-            f'Device {device_name} does not exist.',
-            name=BLUEZ_MOCK_IFACE + '.NoSuchDevice')
+            f"Device {device_name} does not exist.", name=BLUEZ_MOCK_IFACE + ".NoSuchDevice"
+        )
 
     device = mockobject.objects[device_path]
 
-    device.props[DEVICE_IFACE]['Connected'] = dbus.Boolean(False,
-                                                           variant_level=1)
+    device.props[DEVICE_IFACE]["Connected"] = dbus.Boolean(False, variant_level=1)
 
-    device.EmitSignal(dbus.PROPERTIES_IFACE, 'PropertiesChanged', 'sa{sv}as', [
-        DEVICE_IFACE,
-        {
-            'Connected': dbus.Boolean(False, variant_level=1),
-        },
-        [],
-    ])
+    device.EmitSignal(
+        dbus.PROPERTIES_IFACE,
+        "PropertiesChanged",
+        "sa{sv}as",
+        [
+            DEVICE_IFACE,
+            {
+                "Connected": dbus.Boolean(False, variant_level=1),
+            },
+            [],
+        ],
+    )

--- a/dbusmock/templates/gnome_screensaver.py
+++ b/dbusmock/templates/gnome_screensaver.py
@@ -1,8 +1,8 @@
-'''gnome-shell screensaver mock template
+"""gnome-shell screensaver mock template
 
 This creates the expected methods and properties of the
 org.gnome.ScreenSaver object.
-'''
+"""
 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -10,28 +10,31 @@ org.gnome.ScreenSaver object.
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Bastien Nocera'
-__copyright__ = '''
+__author__ = "Bastien Nocera"
+__copyright__ = """
 (c) 2013 Red Hat Inc.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
-BUS_NAME = 'org.gnome.ScreenSaver'
-MAIN_OBJ = '/org/gnome/ScreenSaver'
-MAIN_IFACE = 'org.gnome.ScreenSaver'
+BUS_NAME = "org.gnome.ScreenSaver"
+MAIN_OBJ = "/org/gnome/ScreenSaver"
+MAIN_IFACE = "org.gnome.ScreenSaver"
 SYSTEM_BUS = False
 
 
 def load(mock, _parameters):
-    mock.AddMethods(MAIN_IFACE, [
-        ('GetActive', '', 'b', 'ret = self.is_active'),
-        ('GetActiveTime', '', 'u', 'ret = 1'),
-        ('SetActive', 'b', '', 'self.is_active = args[0]; self.EmitSignal('
-                               '"", "ActiveChanged", "b", [self.is_active])'),
-        ('Lock', '', '', 'time.sleep(1); self.SetActive(True)'),
-        ('ShowMessage', 'sss', '', ''),
-        ('SimulateUserActivity', '', '', ''),
-    ])
+    mock.AddMethods(
+        MAIN_IFACE,
+        [
+            ("GetActive", "", "b", "ret = self.is_active"),
+            ("GetActiveTime", "", "u", "ret = 1"),
+            # fmt: off
+            ("SetActive", "b", "", 'self.is_active = args[0]; self.EmitSignal("", "ActiveChanged", "b", [self.is_active])'),
+            ("Lock", "", "", "time.sleep(1); self.SetActive(True)"),
+            ("ShowMessage", "sss", "", ""),
+            ("SimulateUserActivity", "", "", ""),
+        ],
+    )
 
     # default state
     mock.is_active = False

--- a/dbusmock/templates/iio-sensors-proxy.py
+++ b/dbusmock/templates/iio-sensors-proxy.py
@@ -1,5 +1,5 @@
-'''sensors proxy mock template
-'''
+"""sensors proxy mock template
+"""
 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -7,11 +7,11 @@
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Marco Trevisan'
-__copyright__ = '''
+__author__ = "Marco Trevisan"
+__copyright__ = """
 (c) 2021 Canonical Ltd.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 import re
 
@@ -19,22 +19,22 @@ import dbus
 
 from dbusmock import MOCK_IFACE
 
-BUS_NAME = 'net.hadess.SensorProxy'
-MAIN_OBJ = '/net/hadess/SensorProxy'
-MAIN_IFACE = 'net.hadess.SensorProxy'
-COMPASS_IFACE = 'net.hadess.SensorProxy.Compass'
+BUS_NAME = "net.hadess.SensorProxy"
+MAIN_OBJ = "/net/hadess/SensorProxy"
+MAIN_IFACE = "net.hadess.SensorProxy"
+COMPASS_IFACE = "net.hadess.SensorProxy.Compass"
 SYSTEM_BUS = True
 
-CAMEL_TO_SNAKE_CASE_RE = re.compile(r'(?<!^)(?=[A-Z])')
+CAMEL_TO_SNAKE_CASE_RE = re.compile(r"(?<!^)(?=[A-Z])")
 
 
 def load(mock, parameters=None):
     mock.has_accelerometer = False
     mock.accelerometer_owners = {}
-    mock.accelerometer_orientation = 'undefined'
+    mock.accelerometer_orientation = "undefined"
     mock.has_ambient_light = False
     mock.ambient_light_owners = {}
-    mock.light_level_unit = 'lux'
+    mock.light_level_unit = "lux"
     mock.light_level = 0.0
     mock.has_proximity = False
     mock.proximity_near = False
@@ -62,8 +62,7 @@ def emit_signal_to_destination(mock, interface, name, signature, destination, *a
         location[0].send_message(message)
 
 
-def emit_properties_changed(mock, interface=MAIN_IFACE, properties=None,
-                            destination=None):
+def emit_properties_changed(mock, interface=MAIN_IFACE, properties=None, destination=None):
     if properties is None:
         properties = mock.GetAll(interface)
     elif isinstance(properties, str):
@@ -72,31 +71,31 @@ def emit_properties_changed(mock, interface=MAIN_IFACE, properties=None,
     if isinstance(properties, (list, set)):
         properties = {p: mock.Get(interface, p) for p in properties}
     elif not isinstance(properties, dict):
-        raise TypeError('Unsupported properties type')
+        raise TypeError("Unsupported properties type")
 
-    emit_signal_to_destination(mock, dbus.PROPERTIES_IFACE, 'PropertiesChanged',
-                               'sa{sv}as', destination, interface, properties, [])
+    emit_signal_to_destination(
+        mock, dbus.PROPERTIES_IFACE, "PropertiesChanged", "sa{sv}as", destination, interface, properties, []
+    )
 
 
-@dbus.service.method(dbus.PROPERTIES_IFACE, in_signature='s',
-                     out_signature='a{sv}')
+@dbus.service.method(dbus.PROPERTIES_IFACE, in_signature="s", out_signature="a{sv}")
 def GetAll(self, interface):
     if interface == MAIN_IFACE:
         return {
-            'HasAccelerometer': dbus.Boolean(self.has_accelerometer),
-            'AccelerometerOrientation': dbus.String(self.accelerometer_orientation),
-            'HasAmbientLight': dbus.Boolean(self.has_ambient_light),
-            'LightLevelUnit': dbus.String(self.light_level_unit),
-            'LightLevel': dbus.Double(self.light_level),
-            'HasProximity': dbus.Boolean(self.has_proximity),
-            'ProximityNear': dbus.Boolean(self.proximity_near),
+            "HasAccelerometer": dbus.Boolean(self.has_accelerometer),
+            "AccelerometerOrientation": dbus.String(self.accelerometer_orientation),
+            "HasAmbientLight": dbus.Boolean(self.has_ambient_light),
+            "LightLevelUnit": dbus.String(self.light_level_unit),
+            "LightLevel": dbus.Double(self.light_level),
+            "HasProximity": dbus.Boolean(self.has_proximity),
+            "ProximityNear": dbus.Boolean(self.proximity_near),
         }
     if interface == COMPASS_IFACE:
         return {
-            'HasCompass': dbus.Boolean(self.has_compass),
-            'CompassHeading': dbus.Double(self.compass_heading),
+            "HasCompass": dbus.Boolean(self.has_compass),
+            "CompassHeading": dbus.Double(self.compass_heading),
         }
-    return dbus.Dictionary({}, signature='sv')
+    return dbus.Dictionary({}, signature="sv")
 
 
 def register_owner(self, owners_dict, name):
@@ -117,75 +116,75 @@ def unregister_owner(owners_dict, name):
         watcher.cancel()
 
 
-@dbus.service.method(MAIN_IFACE, sender_keyword='sender')
+@dbus.service.method(MAIN_IFACE, sender_keyword="sender")
 def ClaimAccelerometer(self, sender):
     register_owner(self, self.accelerometer_owners, sender)
 
 
-@dbus.service.method(MAIN_IFACE, sender_keyword='sender')
+@dbus.service.method(MAIN_IFACE, sender_keyword="sender")
 def ReleaseAccelerometer(self, sender):
     unregister_owner(self.accelerometer_owners, sender)
 
 
-@dbus.service.method(MAIN_IFACE, sender_keyword='sender')
+@dbus.service.method(MAIN_IFACE, sender_keyword="sender")
 def ClaimLight(self, sender):
     register_owner(self, self.ambient_light_owners, sender)
 
 
-@dbus.service.method(MAIN_IFACE, sender_keyword='sender')
+@dbus.service.method(MAIN_IFACE, sender_keyword="sender")
 def ReleaseLight(self, sender):
     unregister_owner(self.ambient_light_owners, sender)
 
 
-@dbus.service.method(MAIN_IFACE, sender_keyword='sender')
+@dbus.service.method(MAIN_IFACE, sender_keyword="sender")
 def ClaimProximity(self, sender):
     register_owner(self, self.proximity_owners, sender)
 
 
-@dbus.service.method(MAIN_IFACE, sender_keyword='sender')
+@dbus.service.method(MAIN_IFACE, sender_keyword="sender")
 def ReleaseProximity(self, sender):
     unregister_owner(self.proximity_owners, sender)
 
 
-@dbus.service.method(MAIN_IFACE, sender_keyword='sender')
+@dbus.service.method(MAIN_IFACE, sender_keyword="sender")
 def ClaimCompass(self, sender):
     register_owner(self, self.compass_owners, sender)
 
 
-@dbus.service.method(MAIN_IFACE, sender_keyword='sender')
+@dbus.service.method(MAIN_IFACE, sender_keyword="sender")
 def ReleaseCompass(self, sender):
     unregister_owner(self.compass_owners, sender)
 
 
 def sensor_to_attribute(sensor):
-    if sensor == 'light':
-        return 'ambient_light'
+    if sensor == "light":
+        return "ambient_light"
     return sensor
 
 
 def is_valid_sensor_for_interface(sensor, interface):
-    if interface == 'net.hadess.SensorProxy':
-        return sensor in ['accelerometer', 'ambient_light', 'proximity']
+    if interface == "net.hadess.SensorProxy":
+        return sensor in ["accelerometer", "ambient_light", "proximity"]
 
-    if interface == 'net.hadess.SensorProxy.Compass':
-        return sensor == 'compass'
+    if interface == "net.hadess.SensorProxy.Compass":
+        return sensor == "compass"
 
     return False
 
 
-@dbus.service.method(MOCK_IFACE, in_signature='ssv')
+@dbus.service.method(MOCK_IFACE, in_signature="ssv")
 def SetInternalProperty(self, interface, property_name, value):
-    property_attribute = CAMEL_TO_SNAKE_CASE_RE.sub('_', property_name).lower()
-    sensor = sensor_to_attribute(property_attribute.split('_')[0])
+    property_attribute = CAMEL_TO_SNAKE_CASE_RE.sub("_", property_name).lower()
+    sensor = sensor_to_attribute(property_attribute.split("_")[0])
 
     owners = None
     if is_valid_sensor_for_interface(sensor, interface):
+        if not getattr(self, f"has_{sensor}"):
+            raise dbus.exceptions.DBusException(
+                f"No {sensor} sensor available", name="org.freedesktop.DBus.Mock.Error"
+            )
 
-        if not getattr(self, f'has_{sensor}'):
-            raise dbus.exceptions.DBusException(f'No {sensor} sensor available',
-                                                name='org.freedesktop.DBus.Mock.Error')
-
-        owners = getattr(self, f'{sensor}_owners')
+        owners = getattr(self, f"{sensor}_owners")
         # We allow setting a property from any client here, even if not claiming
         # but only owners, if any, will be notified about sensors changes
 
@@ -199,11 +198,11 @@ def SetInternalProperty(self, interface, property_name, value):
             emit_properties_changed(self, interface, property_name, None)
 
 
-@dbus.service.method(MOCK_IFACE, in_signature='s')
+@dbus.service.method(MOCK_IFACE, in_signature="s")
 def GetInternalProperty(self, property_name):
-    property_attribute = CAMEL_TO_SNAKE_CASE_RE.sub('_', property_name).lower()
+    property_attribute = CAMEL_TO_SNAKE_CASE_RE.sub("_", property_name).lower()
     value = getattr(self, property_attribute)
 
-    if property_name.endswith('Owners'):
-        return dbus.Array(value.keys(), signature='s')
+    if property_name.endswith("Owners"):
+        return dbus.Array(value.keys(), signature="s")
     return value

--- a/dbusmock/templates/logind.py
+++ b/dbusmock/templates/logind.py
@@ -1,9 +1,9 @@
-'''systemd logind mock template
+"""systemd logind mock template
 
 This creates the expected methods and properties of the main
 org.freedesktop.login1.Manager object. You can specify D-Bus property values
 like "CanSuspend" or the return value of Inhibit() in "parameters".
-'''
+"""
 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -11,11 +11,11 @@ like "CanSuspend" or the return value of Inhibit() in "parameters".
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Martin Pitt'
-__copyright__ = '''
+__author__ = "Martin Pitt"
+__copyright__ = """
 (c) 2013 Canonical Ltd.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 import os
 
@@ -24,93 +24,93 @@ from gi.repository import GLib
 
 from dbusmock import MOCK_IFACE, mockobject
 
-BUS_NAME = 'org.freedesktop.login1'
-MAIN_OBJ = '/org/freedesktop/login1'
-MAIN_IFACE = 'org.freedesktop.login1.Manager'
+BUS_NAME = "org.freedesktop.login1"
+MAIN_OBJ = "/org/freedesktop/login1"
+MAIN_IFACE = "org.freedesktop.login1.Manager"
 SYSTEM_BUS = True
 
 
 def load(mock, parameters):
-    mock.AddMethods(MAIN_IFACE, [
-        ('PowerOff', 'b', '', ''),
-        ('Reboot', 'b', '', ''),
-        ('Suspend', 'b', '', ''),
-        ('Hibernate', 'b', '', ''),
-        ('HybridSleep', 'b', '', ''),
-        ('SuspendThenHibernate', 'b', '', ''),
-        ('CanPowerOff', '', 's', f'ret = "{parameters.get("CanPowerOff", "yes")}"'),
-        ('CanReboot', '', 's', f'ret = "{parameters.get("CanReboot", "yes")}"'),
-        ('CanSuspend', '', 's', f'ret = "{parameters.get("CanSuspend", "yes")}"'),
-        ('CanHibernate', '', 's', f'ret = "{parameters.get("CanHibernate", "yes")}"'),
-        ('CanHybridSleep', '', 's', f'ret = "{parameters.get("CanHybridSleep", "yes")}"'),
-        ('CanSuspendThenHibernate', '', 's', f'ret = "{parameters.get("CanSuspendThenHibernate", "yes")}"'),
+    mock.AddMethods(
+        MAIN_IFACE,
+        [
+            ("PowerOff", "b", "", ""),
+            ("Reboot", "b", "", ""),
+            ("Suspend", "b", "", ""),
+            ("Hibernate", "b", "", ""),
+            ("HybridSleep", "b", "", ""),
+            ("SuspendThenHibernate", "b", "", ""),
+            ("CanPowerOff", "", "s", f'ret = "{parameters.get("CanPowerOff", "yes")}"'),
+            ("CanReboot", "", "s", f'ret = "{parameters.get("CanReboot", "yes")}"'),
+            ("CanSuspend", "", "s", f'ret = "{parameters.get("CanSuspend", "yes")}"'),
+            ("CanHibernate", "", "s", f'ret = "{parameters.get("CanHibernate", "yes")}"'),
+            ("CanHybridSleep", "", "s", f'ret = "{parameters.get("CanHybridSleep", "yes")}"'),
+            ("CanSuspendThenHibernate", "", "s", f'ret = "{parameters.get("CanSuspendThenHibernate", "yes")}"'),
+            ("GetSession", "s", "o", 'ret = "/org/freedesktop/login1/session/" + args[0]'),
+            ("ActivateSession", "s", "", ""),
+            ("ActivateSessionOnSeat", "ss", "", ""),
+            ("KillSession", "sss", "", ""),
+            ("LockSession", "s", "", ""),
+            ("LockSessions", "", "", ""),
+            ("ReleaseSession", "s", "", ""),
+            ("TerminateSession", "s", "", ""),
+            ("UnlockSession", "s", "", ""),
+            ("UnlockSessions", "", "", ""),
+            ("GetSeat", "s", "o", 'ret = "/org/freedesktop/login1/seat/" + args[0]'),
+            ("ListSeats", "", "a(so)", 'ret = [(k.split("/")[-1], k) for k in objects.keys() if "/seat/" in k]'),
+            ("TerminateSeat", "s", "", ""),
+            ("GetUser", "u", "o", 'ret = "/org/freedesktop/login1/user/" + args[0]'),
+            ("KillUser", "us", "", ""),
+            ("TerminateUser", "u", "", ""),
+        ],
+    )
 
-        ('GetSession', 's', 'o', 'ret = "/org/freedesktop/login1/session/" + args[0]'),
-        ('ActivateSession', 's', '', ''),
-        ('ActivateSessionOnSeat', 'ss', '', ''),
-        ('KillSession', 'sss', '', ''),
-        ('LockSession', 's', '', ''),
-        ('LockSessions', '', '', ''),
-        ('ReleaseSession', 's', '', ''),
-        ('TerminateSession', 's', '', ''),
-        ('UnlockSession', 's', '', ''),
-        ('UnlockSessions', '', '', ''),
-
-        ('GetSeat', 's', 'o', 'ret = "/org/freedesktop/login1/seat/" + args[0]'),
-        ('ListSeats', '', 'a(so)', 'ret = [(k.split("/")[-1], k) for k in objects.keys() if "/seat/" in k]'),
-        ('TerminateSeat', 's', '', ''),
-
-        ('GetUser', 'u', 'o', 'ret = "/org/freedesktop/login1/user/" + args[0]'),
-        ('KillUser', 'us', '', ''),
-        ('TerminateUser', 'u', '', ''),
-    ])
-
-    mock.AddProperties(MAIN_IFACE,
-                       dbus.Dictionary({
-                           'IdleHint': parameters.get('IdleHint', False),
-                           'IdleAction': parameters.get('IdleAction', 'ignore'),
-                           'IdleSinceHint': dbus.UInt64(parameters.get('IdleSinceHint', 0)),
-                           'IdleSinceHintMonotonic': dbus.UInt64(parameters.get('IdleSinceHintMonotonic', 0)),
-                           'IdleActionUSec': dbus.UInt64(parameters.get('IdleActionUSec', 1)),
-                           'PreparingForShutdown': parameters.get('PreparingForShutdown', False),
-                           'PreparingForSleep': parameters.get('PreparingForSleep', False),
-                       }, signature='sv'))
+    mock.AddProperties(
+        MAIN_IFACE,
+        dbus.Dictionary(
+            {
+                "IdleHint": parameters.get("IdleHint", False),
+                "IdleAction": parameters.get("IdleAction", "ignore"),
+                "IdleSinceHint": dbus.UInt64(parameters.get("IdleSinceHint", 0)),
+                "IdleSinceHintMonotonic": dbus.UInt64(parameters.get("IdleSinceHintMonotonic", 0)),
+                "IdleActionUSec": dbus.UInt64(parameters.get("IdleActionUSec", 1)),
+                "PreparingForShutdown": parameters.get("PreparingForShutdown", False),
+                "PreparingForSleep": parameters.get("PreparingForSleep", False),
+            },
+            signature="sv",
+        ),
+    )
 
 
 #
 # logind methods which are too big for squeezing into AddMethod()
 #
 
-@dbus.service.method(MAIN_IFACE,
-                     in_signature='',
-                     out_signature='a(uso)')
+
+@dbus.service.method(MAIN_IFACE, in_signature="", out_signature="a(uso)")
 def ListUsers(_):
     users = []
     for k, obj in mockobject.objects.items():
-        if '/user/' in k:
+        if "/user/" in k:
             uid = dbus.UInt32(int(k.split("/")[-1]))
-            users.append((uid, obj.Get('org.freedesktop.login1.User', 'Name'), k))
+            users.append((uid, obj.Get("org.freedesktop.login1.User", "Name"), k))
     return users
 
 
-@dbus.service.method(MAIN_IFACE,
-                     in_signature='',
-                     out_signature='a(susso)')
+@dbus.service.method(MAIN_IFACE, in_signature="", out_signature="a(susso)")
 def ListSessions(_):
     sessions = []
     for k, obj in mockobject.objects.items():
-        if '/session/' in k:
+        if "/session/" in k:
             session_id = k.split("/")[-1]
-            uid = obj.Get('org.freedesktop.login1.Session', 'User')[0]
-            username = obj.Get('org.freedesktop.login1.Session', 'Name')
-            seat = obj.Get('org.freedesktop.login1.Session', 'Seat')[0]
+            uid = obj.Get("org.freedesktop.login1.Session", "User")[0]
+            username = obj.Get("org.freedesktop.login1.Session", "Name")
+            seat = obj.Get("org.freedesktop.login1.Session", "Seat")[0]
             sessions.append((session_id, uid, username, seat, k))
     return sessions
 
 
-@dbus.service.method(MAIN_IFACE,
-                     in_signature='ssss',
-                     out_signature='h')
+@dbus.service.method(MAIN_IFACE, in_signature="ssss", out_signature="h")
 def Inhibit(_, what, who, why, mode):
     if not hasattr(mockobject, "inhibitors"):
         mockobject.inhibitors = []
@@ -132,9 +132,7 @@ def Inhibit(_, what, who, why, mode):
     return fd_w
 
 
-@dbus.service.method(MAIN_IFACE,
-                     in_signature='',
-                     out_signature='a(ssssuu)')
+@dbus.service.method(MAIN_IFACE, in_signature="", out_signature="a(ssssuu)")
 def ListInhibitors(_):
     if not hasattr(mockobject, "inhibitors"):
         mockobject.inhibitors = []
@@ -147,151 +145,152 @@ def ListInhibitors(_):
 #
 
 
-@dbus.service.method(MOCK_IFACE,
-                     in_signature='s', out_signature='s')
+@dbus.service.method(MOCK_IFACE, in_signature="s", out_signature="s")
 def AddSeat(self, seat):
-    '''Convenience method to add a seat.
+    """Convenience method to add a seat.
 
     Return the object path of the new seat.
-    '''
-    seat_path = '/org/freedesktop/login1/seat/' + seat
+    """
+    seat_path = "/org/freedesktop/login1/seat/" + seat
     if seat_path in mockobject.objects:
-        raise dbus.exceptions.DBusException(f'Seat {seat} already exists', name=MOCK_IFACE + '.SeatExists')
+        raise dbus.exceptions.DBusException(f"Seat {seat} already exists", name=MOCK_IFACE + ".SeatExists")
 
-    self.AddObject(seat_path,
-                   'org.freedesktop.login1.Seat',
-                   {
-                       'Sessions': dbus.Array([], signature='(so)'),
-                       'CanGraphical': False,
-                       'CanMultiSession': True,
-                       'CanTTY': False,
-                       'IdleHint': False,
-                       'ActiveSession': ('', dbus.ObjectPath('/')),
-                       'Id': seat,
-                       'IdleSinceHint': dbus.UInt64(0),
-                       'IdleSinceHintMonotonic': dbus.UInt64(0),
-                   },
-                   [
-                       ('ActivateSession', 's', '', ''),
-                       ('Terminate', '', '', '')
-                   ])
+    self.AddObject(
+        seat_path,
+        "org.freedesktop.login1.Seat",
+        {
+            "Sessions": dbus.Array([], signature="(so)"),
+            "CanGraphical": False,
+            "CanMultiSession": True,
+            "CanTTY": False,
+            "IdleHint": False,
+            "ActiveSession": ("", dbus.ObjectPath("/")),
+            "Id": seat,
+            "IdleSinceHint": dbus.UInt64(0),
+            "IdleSinceHintMonotonic": dbus.UInt64(0),
+        },
+        [("ActivateSession", "s", "", ""), ("Terminate", "", "", "")],
+    )
 
     return seat_path
 
 
-@dbus.service.method(MOCK_IFACE,
-                     in_signature='usb', out_signature='s')
+@dbus.service.method(MOCK_IFACE, in_signature="usb", out_signature="s")
 def AddUser(self, uid, username, active):
-    '''Convenience method to add a user.
+    """Convenience method to add a user.
 
     Return the object path of the new user.
-    '''
-    user_path = f'/org/freedesktop/login1/user/{uid}'
+    """
+    user_path = f"/org/freedesktop/login1/user/{uid}"
     if user_path in mockobject.objects:
-        raise dbus.exceptions.DBusException(f'User {uid} already exists', name=MOCK_IFACE + '.UserExists')
+        raise dbus.exceptions.DBusException(f"User {uid} already exists", name=MOCK_IFACE + ".UserExists")
 
-    self.AddObject(user_path,
-                   'org.freedesktop.login1.User',
-                   {
-                       'DefaultControlGroup': 'systemd:/user/' + username,
-                       'Display': ('', dbus.ObjectPath('/')),
-                       'GID': dbus.UInt32(uid),
-                       'IdleHint': False,
-                       'IdleSinceHint': dbus.UInt64(0),
-                       'IdleSinceHintMonotonic': dbus.UInt64(0),
-                       'Linger': False,
-                       'Name': username,
-                       'RuntimePath': f'/run/user/{uid}',
-                       'Service': '',
-                       'Sessions': dbus.Array([], signature='(so)'),
-                       'Slice': f'user-{uid}.slice',
-                       'State': (active and 'active' or 'online'),
-                       'Timestamp': dbus.UInt64(42),
-                       'TimestampMonotonic': dbus.UInt64(42),
-                       'UID': dbus.UInt32(uid),
-                   },
-                   [
-                       ('Kill', 's', '', ''),
-                       ('Terminate', '', '', ''),
-                   ])
+    self.AddObject(
+        user_path,
+        "org.freedesktop.login1.User",
+        {
+            "DefaultControlGroup": "systemd:/user/" + username,
+            "Display": ("", dbus.ObjectPath("/")),
+            "GID": dbus.UInt32(uid),
+            "IdleHint": False,
+            "IdleSinceHint": dbus.UInt64(0),
+            "IdleSinceHintMonotonic": dbus.UInt64(0),
+            "Linger": False,
+            "Name": username,
+            "RuntimePath": f"/run/user/{uid}",
+            "Service": "",
+            "Sessions": dbus.Array([], signature="(so)"),
+            "Slice": f"user-{uid}.slice",
+            "State": (active and "active" or "online"),
+            "Timestamp": dbus.UInt64(42),
+            "TimestampMonotonic": dbus.UInt64(42),
+            "UID": dbus.UInt32(uid),
+        },
+        [
+            ("Kill", "s", "", ""),
+            ("Terminate", "", "", ""),
+        ],
+    )
 
     return user_path
 
 
-@dbus.service.method(MOCK_IFACE,
-                     in_signature='ssusb', out_signature='s')
+@dbus.service.method(MOCK_IFACE, in_signature="ssusb", out_signature="s")
 def AddSession(self, session_id, seat, uid, username, active):
-    '''Convenience method to add a session.
+    """Convenience method to add a session.
 
     If the given seat and/or user do not exit, they will be created.
 
     Return the object path of the new session.
-    '''
-    seat_path = dbus.ObjectPath(f'/org/freedesktop/login1/seat/{seat}')
+    """
+    seat_path = dbus.ObjectPath(f"/org/freedesktop/login1/seat/{seat}")
     if seat_path not in mockobject.objects:
         self.AddSeat(seat)
 
-    user_path = dbus.ObjectPath(f'/org/freedesktop/login1/user/{uid}')
+    user_path = dbus.ObjectPath(f"/org/freedesktop/login1/user/{uid}")
     if user_path not in mockobject.objects:
         self.AddUser(uid, username, active)
 
-    session_path = dbus.ObjectPath(f'/org/freedesktop/login1/session/{session_id}')
+    session_path = dbus.ObjectPath(f"/org/freedesktop/login1/session/{session_id}")
     if session_path in mockobject.objects:
-        raise dbus.exceptions.DBusException(f'Session {session_id} already exists',
-                                            name=MOCK_IFACE + '.SessionExists')
+        raise dbus.exceptions.DBusException(
+            f"Session {session_id} already exists", name=MOCK_IFACE + ".SessionExists"
+        )
 
-    self.AddObject(session_path,
-                   'org.freedesktop.login1.Session',
-                   {
-                       'Controllers': dbus.Array([], signature='s'),
-                       'ResetControllers': dbus.Array([], signature='s'),
-                       'Active': active,
-                       'IdleHint': False,
-                       'LockedHint': False,
-                       'KillProcesses': False,
-                       'Remote': False,
-                       'Class': 'user',
-                       'DefaultControlGroup': f'systemd:/user/{username}/{session_id}',
-                       'Display': os.getenv('DISPLAY', ''),
-                       'Id': session_id,
-                       'Name': username,
-                       'RemoteHost': '',
-                       'RemoteUser': '',
-                       'Service': 'dbusmock',
-                       'State': (active and 'active' or 'online'),
-                       'TTY': '',
-                       'Type': 'test',
-                       'Seat': (seat, seat_path),
-                       'User': (dbus.UInt32(uid), user_path),
-                       'Audit': dbus.UInt32(0),
-                       'Leader': dbus.UInt32(1),
-                       'VTNr': dbus.UInt32(1),
-                       'IdleSinceHint': dbus.UInt64(0),
-                       'IdleSinceHintMonotonic': dbus.UInt64(0),
-                       'Timestamp': dbus.UInt64(42),
-                       'TimestampMonotonic': dbus.UInt64(42),
-                   },
-                   [
-                       ('Activate', '', '', ''),
-                       ('Kill', 'ss', '', ''),
-                       ('Lock', '', '', 'self.EmitSignal("", "Lock", "", [])'),
-                       ('SetIdleHint', 'b', '', ''),
-                       ('SetLockedHint', 'b', '', 'self.UpdateProperties("", {"LockedHint": args[0]})'),
-                       ('Terminate', '', '', ''),
-                       ('Unlock', '', '', 'self.EmitSignal("", "Unlock", "", [])'),
-                   ])
+    self.AddObject(
+        session_path,
+        "org.freedesktop.login1.Session",
+        {
+            "Controllers": dbus.Array([], signature="s"),
+            "ResetControllers": dbus.Array([], signature="s"),
+            "Active": active,
+            "IdleHint": False,
+            "LockedHint": False,
+            "KillProcesses": False,
+            "Remote": False,
+            "Class": "user",
+            "DefaultControlGroup": f"systemd:/user/{username}/{session_id}",
+            "Display": os.getenv("DISPLAY", ""),
+            "Id": session_id,
+            "Name": username,
+            "RemoteHost": "",
+            "RemoteUser": "",
+            "Service": "dbusmock",
+            "State": (active and "active" or "online"),
+            "TTY": "",
+            "Type": "test",
+            "Seat": (seat, seat_path),
+            "User": (dbus.UInt32(uid), user_path),
+            "Audit": dbus.UInt32(0),
+            "Leader": dbus.UInt32(1),
+            "VTNr": dbus.UInt32(1),
+            "IdleSinceHint": dbus.UInt64(0),
+            "IdleSinceHintMonotonic": dbus.UInt64(0),
+            "Timestamp": dbus.UInt64(42),
+            "TimestampMonotonic": dbus.UInt64(42),
+        },
+        [
+            ("Activate", "", "", ""),
+            ("Kill", "ss", "", ""),
+            ("Lock", "", "", 'self.EmitSignal("", "Lock", "", [])'),
+            ("SetIdleHint", "b", "", ""),
+            ("SetLockedHint", "b", "", 'self.UpdateProperties("", {"LockedHint": args[0]})'),
+            ("Terminate", "", "", ""),
+            ("Unlock", "", "", 'self.EmitSignal("", "Unlock", "", [])'),
+        ],
+    )
 
     # add session to seat
     obj_seat = mockobject.objects[seat_path]
-    cur_sessions = obj_seat.Get('org.freedesktop.login1.Seat', 'Sessions')
+    cur_sessions = obj_seat.Get("org.freedesktop.login1.Seat", "Sessions")
     cur_sessions.append((session_id, session_path))
-    obj_seat.Set('org.freedesktop.login1.Seat', 'Sessions', cur_sessions)
-    obj_seat.Set('org.freedesktop.login1.Seat', 'ActiveSession', (session_id, session_path))
+    obj_seat.Set("org.freedesktop.login1.Seat", "Sessions", cur_sessions)
+    obj_seat.Set("org.freedesktop.login1.Seat", "ActiveSession", (session_id, session_path))
 
     # add session to user
     obj_user = mockobject.objects[user_path]
-    cur_sessions = obj_user.Get('org.freedesktop.login1.User', 'Sessions')
+    cur_sessions = obj_user.Get("org.freedesktop.login1.User", "Sessions")
     cur_sessions.append((session_id, session_path))
-    obj_user.Set('org.freedesktop.login1.User', 'Sessions', cur_sessions)
+    obj_user.Set("org.freedesktop.login1.User", "Sessions", cur_sessions)
 
     return session_path

--- a/dbusmock/templates/low_memory_monitor.py
+++ b/dbusmock/templates/low_memory_monitor.py
@@ -1,10 +1,10 @@
-'''low-memory-monitor mock template
+"""low-memory-monitor mock template
 
 This creates the expected methods and properties of the main
 org.freedesktop.LowMemoryMonitor object.
 
 This provides only the 2.0 D-Bus API of low-memory-monitor.
-'''
+"""
 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -12,19 +12,19 @@ This provides only the 2.0 D-Bus API of low-memory-monitor.
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Bastien Nocera'
-__copyright__ = '''
+__author__ = "Bastien Nocera"
+__copyright__ = """
 (c) 2019, Red Hat Inc.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 import dbus
 
 from dbusmock import MOCK_IFACE
 
-BUS_NAME = 'org.freedesktop.LowMemoryMonitor'
-MAIN_OBJ = '/org/freedesktop/LowMemoryMonitor'
-MAIN_IFACE = 'org.freedesktop.LowMemoryMonitor'
+BUS_NAME = "org.freedesktop.LowMemoryMonitor"
+MAIN_OBJ = "/org/freedesktop/LowMemoryMonitor"
+MAIN_IFACE = "org.freedesktop.LowMemoryMonitor"
 SYSTEM_BUS = True
 
 
@@ -33,7 +33,6 @@ def load(mock, _parameters):
     mock.loaded = True
 
 
-@dbus.service.method(MOCK_IFACE,
-                     in_signature='y', out_signature='')
+@dbus.service.method(MOCK_IFACE, in_signature="y", out_signature="")
 def EmitWarning(self, state):
-    self.EmitSignal(MAIN_IFACE, 'LowMemoryWarning', 'y', [dbus.Byte(state)])
+    self.EmitSignal(MAIN_IFACE, "LowMemoryWarning", "y", [dbus.Byte(state)])

--- a/dbusmock/templates/networkmanager.py
+++ b/dbusmock/templates/networkmanager.py
@@ -1,10 +1,10 @@
-'''NetworkManager mock template
+"""NetworkManager mock template
 
 This creates the expected methods and properties of the main
 org.freedesktop.NetworkManager object, but no devices. You can specify any
 property such as 'NetworkingEnabled', or 'WirelessEnabled' etc. in
 "parameters".
-'''
+"""
 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -12,11 +12,11 @@ property such as 'NetworkingEnabled', or 'WirelessEnabled' etc. in
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Iftikhar Ahmad'
-__copyright__ = '''
+__author__ = "Iftikhar Ahmad"
+__copyright__ = """
 (c) 2012 Canonical Ltd.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 import binascii
 import uuid
@@ -26,27 +26,28 @@ import dbus
 import dbusmock
 from dbusmock import MOCK_IFACE
 
-BUS_NAME = 'org.freedesktop.NetworkManager'
-MAIN_OBJ = '/org/freedesktop'
-MANAGER_IFACE = 'org.freedesktop.NetworkManager'
-MANAGER_OBJ = '/org/freedesktop/NetworkManager'
-SETTINGS_OBJ = '/org/freedesktop/NetworkManager/Settings'
-SETTINGS_IFACE = 'org.freedesktop.NetworkManager.Settings'
-DEVICE_IFACE = 'org.freedesktop.NetworkManager.Device'
-WIRELESS_DEVICE_IFACE = 'org.freedesktop.NetworkManager.Device.Wireless'
-ACCESS_POINT_IFACE = 'org.freedesktop.NetworkManager.AccessPoint'
-CSETTINGS_IFACE = 'org.freedesktop.NetworkManager.Settings.Connection'
-ACTIVE_CONNECTION_IFACE = 'org.freedesktop.NetworkManager.Connection.Active'
+BUS_NAME = "org.freedesktop.NetworkManager"
+MAIN_OBJ = "/org/freedesktop"
+MANAGER_IFACE = "org.freedesktop.NetworkManager"
+MANAGER_OBJ = "/org/freedesktop/NetworkManager"
+SETTINGS_OBJ = "/org/freedesktop/NetworkManager/Settings"
+SETTINGS_IFACE = "org.freedesktop.NetworkManager.Settings"
+DEVICE_IFACE = "org.freedesktop.NetworkManager.Device"
+WIRELESS_DEVICE_IFACE = "org.freedesktop.NetworkManager.Device.Wireless"
+ACCESS_POINT_IFACE = "org.freedesktop.NetworkManager.AccessPoint"
+CSETTINGS_IFACE = "org.freedesktop.NetworkManager.Settings.Connection"
+ACTIVE_CONNECTION_IFACE = "org.freedesktop.NetworkManager.Connection.Active"
 SYSTEM_BUS = True
 IS_OBJECT_MANAGER = True
 
 
 # these really want to be dataclasses, but need to drop support for Python 3.6 for that
 class NMState:  # pylint: disable=too-few-public-methods
-    '''Global state
+    """Global state
 
     As per https://developer.gnome.org/NetworkManager/unstable/nm-dbus-types.html#NMState
-    '''
+    """
+
     NM_STATE_UNKNOWN = 0
     NM_STATE_ASLEEP = 10
     NM_STATE_DISCONNECTED = 20
@@ -58,10 +59,11 @@ class NMState:  # pylint: disable=too-few-public-methods
 
 
 class NMConnectivityState:  # pylint: disable=too-few-public-methods
-    '''Connectvity state
+    """Connectvity state
 
     As per https://developer.gnome.org/NetworkManager/unstable/nm-dbus-types.html#NMConnectivityState
-    '''
+    """
+
     NM_CONNECTIVITY_UNKNOWN = 0
     NM_CONNECTIVITY_NONE = 1
     NM_CONNECTIVITY_PORTAL = 2
@@ -70,10 +72,11 @@ class NMConnectivityState:  # pylint: disable=too-few-public-methods
 
 
 class NMActiveConnectionState:  # pylint: disable=too-few-public-methods
-    '''Active connection state
+    """Active connection state
 
     As per https://developer.gnome.org/NetworkManager/unstable/nm-dbus-types.html#NMActiveConnectionState
-    '''
+    """
+
     NM_ACTIVE_CONNECTION_STATE_UNKNOWN = 0
     NM_ACTIVE_CONNECTION_STATE_ACTIVATING = 1
     NM_ACTIVE_CONNECTION_STATE_ACTIVATED = 2
@@ -82,28 +85,30 @@ class NMActiveConnectionState:  # pylint: disable=too-few-public-methods
 
 
 class InfrastructureMode:  # pylint: disable=too-few-public-methods
-    '''Infrastructure mode
+    """Infrastructure mode
 
     As per https://developer.gnome.org/NetworkManager/unstable/nm-dbus-types.html#NM80211Mode
-    '''
+    """
+
     NM_802_11_MODE_UNKNOWN = 0
     NM_802_11_MODE_ADHOC = 1
     NM_802_11_MODE_INFRA = 2
     NM_802_11_MODE_AP = 3
 
     NAME_MAP = {
-        NM_802_11_MODE_UNKNOWN: 'unknown',
-        NM_802_11_MODE_ADHOC: 'adhoc',
-        NM_802_11_MODE_INFRA: 'infrastructure',
-        NM_802_11_MODE_AP: 'access-point',
+        NM_802_11_MODE_UNKNOWN: "unknown",
+        NM_802_11_MODE_ADHOC: "adhoc",
+        NM_802_11_MODE_INFRA: "infrastructure",
+        NM_802_11_MODE_AP: "access-point",
     }
 
 
 class DeviceState:  # pylint: disable=too-few-public-methods
-    '''Device states
+    """Device states
 
     As per https://developer.gnome.org/NetworkManager/unstable/nm-dbus-types.html#NMDeviceState
-    '''
+    """
+
     UNKNOWN = 0
     UNMANAGED = 10
     UNAVAILABLE = 20
@@ -120,10 +125,11 @@ class DeviceState:  # pylint: disable=too-few-public-methods
 
 
 class NM80211ApSecurityFlags:  # pylint: disable=too-few-public-methods
-    '''Security flags
+    """Security flags
 
     As per https://developer.gnome.org/NetworkManager/unstable/nm-dbus-types.html#NM80211ApSecurityFlags
-    '''
+    """
+
     NM_802_11_AP_SEC_NONE = 0x00000000
     NM_802_11_AP_SEC_PAIR_WEP40 = 0x00000001
     NM_802_11_AP_SEC_PAIR_WEP104 = 0x00000002
@@ -137,18 +143,16 @@ class NM80211ApSecurityFlags:  # pylint: disable=too-few-public-methods
     NM_802_11_AP_SEC_KEY_MGMT_802_1X = 0x00000200
 
     NAME_MAP = {
-        NM_802_11_AP_SEC_KEY_MGMT_PSK: {
-            'key-mgmt': 'wpa-psk',
-            'auth-alg': 'open'
-        },
+        NM_802_11_AP_SEC_KEY_MGMT_PSK: {"key-mgmt": "wpa-psk", "auth-alg": "open"},
     }
 
 
 class NM80211ApFlags:  # pylint: disable=too-few-public-methods
-    '''Device flags
+    """Device flags
 
     As per https://developer.gnome.org/NetworkManager/unstable/nm-dbus-types.html#NM80211ApFlags
-    '''
+    """
+
     NM_802_11_AP_FLAGS_NONE = 0x00000000
     NM_802_11_AP_FLAGS_PRIVACY = 0x00000001
 
@@ -156,16 +160,16 @@ class NM80211ApFlags:  # pylint: disable=too-few-public-methods
 def activate_connection(self, conn, dev, ap):
     # find a new name
     count = 0
-    active_connections = dbusmock.get_object(MANAGER_OBJ).Get(MANAGER_IFACE, 'ActiveConnections')
+    active_connections = dbusmock.get_object(MANAGER_OBJ).Get(MANAGER_IFACE, "ActiveConnections")
     while True:
-        path = dbus.ObjectPath('/org/freedesktop/NetworkManager/ActiveConnection/' + str(count))
+        path = dbus.ObjectPath("/org/freedesktop/NetworkManager/ActiveConnection/" + str(count))
         if path not in active_connections:
             break
         count += 1
 
     state = dbus.UInt32(NMActiveConnectionState.NM_ACTIVE_CONNECTION_STATE_ACTIVATED)
     devices = []
-    if str(dev) != '/':
+    if str(dev) != "/":
         devices.append(dev)
     return dbus.ObjectPath(AddActiveConnection(self, devices, conn, ap, str(count), state))
 
@@ -178,13 +182,13 @@ def deactivate_connection(self, active_conn_path):
 
 
 def add_and_activate_connection(self, conn_conf, dev, ap):
-    name = ap.rsplit('/', 1)[1]
-    RemoveWifiConnection(self, dev, '/org/freedesktop/NetworkManager/Settings/' + name)
+    name = ap.rsplit("/", 1)[1]
+    RemoveWifiConnection(self, dev, "/org/freedesktop/NetworkManager/Settings/" + name)
 
     try:
-        raw_ssid = ''.join([chr(byte) for byte in conn_conf["802-11-wireless"]["ssid"]])
+        raw_ssid = "".join([chr(byte) for byte in conn_conf["802-11-wireless"]["ssid"]])
     except KeyError:
-        raw_ssid = dbusmock.get_object(ap).props['org.freedesktop.NetworkManager.AccessPoint']['Ssid'].decode()
+        raw_ssid = dbusmock.get_object(ap).props["org.freedesktop.NetworkManager.AccessPoint"]["Ssid"].decode()
     wifi_conn = dbus.ObjectPath(AddWiFiConnection(self, dev, name, raw_ssid, ""))
 
     active_conn = activate_connection(self, wifi_conn, dev, ap)
@@ -196,7 +200,7 @@ def get_device_by_ip_iface(_self, iface):
     NM = dbusmock.get_object(MANAGER_OBJ)
     for dev_path in NM.GetDevices():
         dev_obj = dbusmock.get_object(dev_path)
-        interface = dev_obj.Get(DEVICE_IFACE, 'Interface')
+        interface = dev_obj.Get(DEVICE_IFACE, "Interface")
         if interface == iface:
             return dev_path
 
@@ -217,35 +221,40 @@ def set_networking_enabled(self, networking_enabled):
 
 
 def load(mock, parameters):
-    manager_props = {'ActiveConnections': dbus.Array([], signature='o'),
-                     'Devices': dbus.Array([], signature='o'),
-                     'NetworkingEnabled': parameters.get('NetworkingEnabled', True),
-                     'Connectivity': parameters.get('Connectivity', dbus.UInt32(NMConnectivityState.NM_CONNECTIVITY_FULL)),
-                     'State': parameters.get('State', dbus.UInt32(NMState.NM_STATE_CONNECTED_GLOBAL)),
-                     'Startup': False,
-                     'Version': parameters.get('Version', '0.9.6.0'),
-                     'WimaxEnabled': parameters.get('WimaxEnabled', True),
-                     'WimaxHardwareEnabled': parameters.get('WimaxHardwareEnabled', True),
-                     'WirelessEnabled': parameters.get('WirelessEnabled', True),
-                     'WirelessHardwareEnabled': parameters.get('WirelessHardwareEnabled', True),
-                     'WwanEnabled': parameters.get('WwanEnabled', False),
-                     'WwanHardwareEnabled': parameters.get('WwanHardwareEnabled', True)}
-    manager_methods = [('GetDevices', '', 'ao', 'ret = [k for k in objects.keys() if "/Devices" in k]'),
-                       ('GetPermissions', '', 'a{ss}', 'ret = {}'),
-                       ('state', '', 'u', f"ret = self.Get('{MANAGER_IFACE}', 'State')"),
-                       ('CheckConnectivity', '', 'u', f"ret = self.Get('{MANAGER_IFACE}', 'Connectivity')"),
-                       ('ActivateConnection', 'ooo', 'o', "ret = self.activate_connection(self, args[0], args[1], args[2])"),
-                       ('DeactivateConnection', 'o', '', "self.deactivate_connection(self, args[0])"),
-                       ('AddAndActivateConnection', 'a{sa{sv}}oo', 'oo',
-                        'ret = self.add_and_activate_connection(self, args[0], args[1], args[2])'),
-                       ('GetDeviceByIpIface', 's', 'o', 'ret = self.get_device_by_ip_iface(self, args[0])'),
-                       ('Reload', 'u', '', ''),
-                       ('Enable', 'b', '', 'self.set_networking_enabled(self, args[0])')]
+    manager_props = {
+        "ActiveConnections": dbus.Array([], signature="o"),
+        "Devices": dbus.Array([], signature="o"),
+        "NetworkingEnabled": parameters.get("NetworkingEnabled", True),
+        "Connectivity": parameters.get("Connectivity", dbus.UInt32(NMConnectivityState.NM_CONNECTIVITY_FULL)),
+        "State": parameters.get("State", dbus.UInt32(NMState.NM_STATE_CONNECTED_GLOBAL)),
+        "Startup": False,
+        "Version": parameters.get("Version", "0.9.6.0"),
+        "WimaxEnabled": parameters.get("WimaxEnabled", True),
+        "WimaxHardwareEnabled": parameters.get("WimaxHardwareEnabled", True),
+        "WirelessEnabled": parameters.get("WirelessEnabled", True),
+        "WirelessHardwareEnabled": parameters.get("WirelessHardwareEnabled", True),
+        "WwanEnabled": parameters.get("WwanEnabled", False),
+        "WwanHardwareEnabled": parameters.get("WwanHardwareEnabled", True),
+    }
+    manager_methods = [
+        ("GetDevices", "", "ao", 'ret = [k for k in objects.keys() if "/Devices" in k]'),
+        ("GetPermissions", "", "a{ss}", "ret = {}"),
+        ("state", "", "u", f"ret = self.Get('{MANAGER_IFACE}', 'State')"),
+        ("CheckConnectivity", "", "u", f"ret = self.Get('{MANAGER_IFACE}', 'Connectivity')"),
+        ("ActivateConnection", "ooo", "o", "ret = self.activate_connection(self, args[0], args[1], args[2])"),
+        ("DeactivateConnection", "o", "", "self.deactivate_connection(self, args[0])"),
+        (
+            "AddAndActivateConnection",
+            "a{sa{sv}}oo",
+            "oo",
+            "ret = self.add_and_activate_connection(self, args[0], args[1], args[2])",
+        ),
+        ("GetDeviceByIpIface", "s", "o", "ret = self.get_device_by_ip_iface(self, args[0])"),
+        ("Reload", "u", "", ""),
+        ("Enable", "b", "", "self.set_networking_enabled(self, args[0])"),
+    ]
 
-    mock.AddObject(MANAGER_OBJ,
-                   MANAGER_IFACE,
-                   manager_props,
-                   manager_methods)
+    mock.AddObject(MANAGER_OBJ, MANAGER_IFACE, manager_props, manager_methods)
     mock.object_manager_emit_added(MANAGER_OBJ)
 
     obj = dbusmock.get_object(MANAGER_OBJ)
@@ -255,76 +264,72 @@ def load(mock, parameters):
     obj.get_device_by_ip_iface = get_device_by_ip_iface
     obj.set_networking_enabled = set_networking_enabled
 
-    settings_props = {'Hostname': 'hostname',
-                      'CanModify': True,
-                      'Connections': dbus.Array([], signature='o')}
-    settings_methods = [('ListConnections', '', 'ao', f"ret = self.Get('{SETTINGS_IFACE}', 'Connections')"),
-                        ('GetConnectionByUuid', 's', 'o', 'ret = self.SettingsGetConnectionByUuid(args[0])'),
-                        ('AddConnection', 'a{sa{sv}}', 'o', 'ret = self.SettingsAddConnection(args[0])'),
-                        ('AddConnectionUnsaved', 'a{sa{sv}}', 'o', 'ret = self.SettingsAddConnection(args[0])'),
-                        ('SaveHostname', 's', '', '')]
-    mock.AddObject(SETTINGS_OBJ,
-                   SETTINGS_IFACE,
-                   settings_props,
-                   settings_methods)
+    settings_props = {"Hostname": "hostname", "CanModify": True, "Connections": dbus.Array([], signature="o")}
+    settings_methods = [
+        ("ListConnections", "", "ao", f"ret = self.Get('{SETTINGS_IFACE}', 'Connections')"),
+        ("GetConnectionByUuid", "s", "o", "ret = self.SettingsGetConnectionByUuid(args[0])"),
+        ("AddConnection", "a{sa{sv}}", "o", "ret = self.SettingsAddConnection(args[0])"),
+        ("AddConnectionUnsaved", "a{sa{sv}}", "o", "ret = self.SettingsAddConnection(args[0])"),
+        ("SaveHostname", "s", "", ""),
+    ]
+    mock.AddObject(SETTINGS_OBJ, SETTINGS_IFACE, settings_props, settings_methods)
     mock.object_manager_emit_added(SETTINGS_OBJ)
 
 
-@dbus.service.method(MOCK_IFACE,
-                     in_signature='sssv', out_signature='')
+@dbus.service.method(MOCK_IFACE, in_signature="sssv", out_signature="")
 def SetProperty(_self, path, iface, name, value):
     obj = dbusmock.get_object(path)
     obj.Set(iface, name, value)
-    obj.EmitSignal(iface, 'PropertiesChanged', 'a{sv}', [{name: value}])
+    obj.EmitSignal(iface, "PropertiesChanged", "a{sv}", [{name: value}])
 
 
-@dbus.service.method(MOCK_IFACE,
-                     in_signature='u', out_signature='')
+@dbus.service.method(MOCK_IFACE, in_signature="u", out_signature="")
 def SetGlobalConnectionState(self, state):
-    self.SetProperty(MANAGER_OBJ, MANAGER_IFACE, 'State', dbus.UInt32(state, variant_level=1))
-    self.EmitSignal(MANAGER_IFACE, 'StateChanged', 'u', [state])
+    self.SetProperty(MANAGER_OBJ, MANAGER_IFACE, "State", dbus.UInt32(state, variant_level=1))
+    self.EmitSignal(MANAGER_IFACE, "StateChanged", "u", [state])
 
 
-@dbus.service.method(MOCK_IFACE,
-                     in_signature='u', out_signature='')
+@dbus.service.method(MOCK_IFACE, in_signature="u", out_signature="")
 def SetConnectivity(self, connectivity):
-    self.SetProperty(MANAGER_OBJ, MANAGER_IFACE, 'Connectivity', dbus.UInt32(connectivity, variant_level=1))
+    self.SetProperty(MANAGER_OBJ, MANAGER_IFACE, "Connectivity", dbus.UInt32(connectivity, variant_level=1))
 
 
-@dbus.service.method(MOCK_IFACE,
-                     in_signature='b', out_signature='')
+@dbus.service.method(MOCK_IFACE, in_signature="b", out_signature="")
 def SetNetworkingEnabled(self, networking_enabled):
-    self.SetProperty(MANAGER_OBJ, MANAGER_IFACE, 'NetworkingEnabled', dbus.Boolean(networking_enabled, variant_level=1))
+    self.SetProperty(
+        MANAGER_OBJ, MANAGER_IFACE, "NetworkingEnabled", dbus.Boolean(networking_enabled, variant_level=1)
+    )
 
 
-@dbus.service.method(MOCK_IFACE,
-                     in_signature='ss', out_signature='')
+@dbus.service.method(MOCK_IFACE, in_signature="ss", out_signature="")
 def SetDeviceActive(_self, device_path, active_connection_path):
     dev_obj = dbusmock.get_object(device_path)
-    dev_obj.Set(DEVICE_IFACE, 'ActiveConnection', dbus.ObjectPath(active_connection_path))
-    old_state = dev_obj.Get(DEVICE_IFACE, 'State')
-    dev_obj.Set(DEVICE_IFACE, 'State', dbus.UInt32(DeviceState.ACTIVATED))
-    dev_obj.Set(DEVICE_IFACE, 'StateReason', (dbus.UInt32(DeviceState.ACTIVATED), dbus.UInt32(0)))
+    dev_obj.Set(DEVICE_IFACE, "ActiveConnection", dbus.ObjectPath(active_connection_path))
+    old_state = dev_obj.Get(DEVICE_IFACE, "State")
+    dev_obj.Set(DEVICE_IFACE, "State", dbus.UInt32(DeviceState.ACTIVATED))
+    dev_obj.Set(DEVICE_IFACE, "StateReason", (dbus.UInt32(DeviceState.ACTIVATED), dbus.UInt32(0)))
 
-    dev_obj.EmitSignal(DEVICE_IFACE, 'StateChanged', 'uuu', [dbus.UInt32(DeviceState.ACTIVATED), old_state, dbus.UInt32(1)])
+    dev_obj.EmitSignal(
+        DEVICE_IFACE, "StateChanged", "uuu", [dbus.UInt32(DeviceState.ACTIVATED), old_state, dbus.UInt32(1)]
+    )
 
 
-@dbus.service.method(MOCK_IFACE,
-                     in_signature='s', out_signature='')
+@dbus.service.method(MOCK_IFACE, in_signature="s", out_signature="")
 def SetDeviceDisconnected(_self, device_path):
     dev_obj = dbusmock.get_object(device_path)
-    dev_obj.Set(DEVICE_IFACE, 'ActiveConnection', dbus.ObjectPath('/'))
-    old_state = dev_obj.Get(DEVICE_IFACE, 'State')
-    dev_obj.Set(DEVICE_IFACE, 'State', dbus.UInt32(DeviceState.DISCONNECTED))
-    dev_obj.Set(DEVICE_IFACE, 'StateReason', (dbus.UInt32(DeviceState.DISCONNECTED), dbus.UInt32(0)))
+    dev_obj.Set(DEVICE_IFACE, "ActiveConnection", dbus.ObjectPath("/"))
+    old_state = dev_obj.Get(DEVICE_IFACE, "State")
+    dev_obj.Set(DEVICE_IFACE, "State", dbus.UInt32(DeviceState.DISCONNECTED))
+    dev_obj.Set(DEVICE_IFACE, "StateReason", (dbus.UInt32(DeviceState.DISCONNECTED), dbus.UInt32(0)))
 
-    dev_obj.EmitSignal(DEVICE_IFACE, 'StateChanged', 'uuu', [dbus.UInt32(DeviceState.DISCONNECTED), old_state, dbus.UInt32(1)])
+    dev_obj.EmitSignal(
+        DEVICE_IFACE, "StateChanged", "uuu", [dbus.UInt32(DeviceState.DISCONNECTED), old_state, dbus.UInt32(1)]
+    )
 
 
-@dbus.service.method(MOCK_IFACE,
-                     in_signature='ssi', out_signature='s')
+@dbus.service.method(MOCK_IFACE, in_signature="ssi", out_signature="s")
 def AddEthernetDevice(self, device_name, iface_name, state):
-    '''Add an ethernet device.
+    """Add an ethernet device.
 
     You have to specify device_name, device interface name (e. g. eth0), and
     state. You can use the predefined DeviceState values (e. g.
@@ -335,27 +340,28 @@ def AddEthernetDevice(self, device_name, iface_name, state):
     Please note that this does not set any global properties.
 
     Returns the new object path.
-    '''
-    path = '/org/freedesktop/NetworkManager/Devices/' + device_name
-    wired_props = {'Carrier': False,
-                   'HwAddress': dbus.String('78:DD:08:D2:3D:43'),
-                   'PermHwAddress': dbus.String('78:DD:08:D2:3D:43'),
-                   'Speed': dbus.UInt32(0)}
-    self.AddObject(path,
-                   'org.freedesktop.NetworkManager.Device.Wired',
-                   wired_props,
-                   [])
+    """
+    path = "/org/freedesktop/NetworkManager/Devices/" + device_name
+    wired_props = {
+        "Carrier": False,
+        "HwAddress": dbus.String("78:DD:08:D2:3D:43"),
+        "PermHwAddress": dbus.String("78:DD:08:D2:3D:43"),
+        "Speed": dbus.UInt32(0),
+    }
+    self.AddObject(path, "org.freedesktop.NetworkManager.Device.Wired", wired_props, [])
 
-    props = {'DeviceType': dbus.UInt32(1),
-             'State': dbus.UInt32(state),
-             'StateReason': (dbus.UInt32(state), dbus.UInt32(0)),
-             'Interface': iface_name,
-             'ActiveConnection': dbus.ObjectPath('/'),
-             'AvailableConnections': dbus.Array([], signature='o'),
-             'AutoConnect': False,
-             'Managed': True,
-             'Driver': 'dbusmock',
-             'IpInterface': ''}
+    props = {
+        "DeviceType": dbus.UInt32(1),
+        "State": dbus.UInt32(state),
+        "StateReason": (dbus.UInt32(state), dbus.UInt32(0)),
+        "Interface": iface_name,
+        "ActiveConnection": dbus.ObjectPath("/"),
+        "AvailableConnections": dbus.Array([], signature="o"),
+        "AutoConnect": False,
+        "Managed": True,
+        "Driver": "dbusmock",
+        "IpInterface": "",
+    }
 
     obj = dbusmock.get_object(path)
     obj.AddProperties(DEVICE_IFACE, props)
@@ -363,18 +369,17 @@ def AddEthernetDevice(self, device_name, iface_name, state):
     self.object_manager_emit_added(path)
 
     NM = dbusmock.get_object(MANAGER_OBJ)
-    devices = NM.Get(MANAGER_IFACE, 'Devices')
+    devices = NM.Get(MANAGER_IFACE, "Devices")
     devices.append(path)
-    NM.Set(MANAGER_IFACE, 'Devices', devices)
-    NM.EmitSignal('org.freedesktop.NetworkManager', 'DeviceAdded', 'o', [path])
+    NM.Set(MANAGER_IFACE, "Devices", devices)
+    NM.EmitSignal("org.freedesktop.NetworkManager", "DeviceAdded", "o", [path])
 
     return path
 
 
-@dbus.service.method(MOCK_IFACE,
-                     in_signature='ssi', out_signature='s')
+@dbus.service.method(MOCK_IFACE, in_signature="ssi", out_signature="s")
 def AddWiFiDevice(self, device_name, iface_name, state):
-    '''Add a WiFi Device.
+    """Add a WiFi Device.
 
     You have to specify device_name, device interface name (e. g.  wlan0) and
     state. You can use the predefined DeviceState values (e. g.
@@ -385,59 +390,59 @@ def AddWiFiDevice(self, device_name, iface_name, state):
     Please note that this does not set any global properties.
 
     Returns the new object path.
-    '''
+    """
 
-    path = '/org/freedesktop/NetworkManager/Devices/' + device_name
-    self.AddObject(path,
-                   WIRELESS_DEVICE_IFACE,
-                   {
-                       'HwAddress': dbus.String('11:22:33:44:55:66'),
-                       'PermHwAddress': dbus.String('11:22:33:44:55:66'),
-                       'Bitrate': dbus.UInt32(5400),
-                       'Mode': dbus.UInt32(2),
-                       'WirelessCapabilities': dbus.UInt32(255),
-                       'AccessPoints': dbus.Array([], signature='o'),
-                   },
-                   [
-                       ('GetAccessPoints', '', 'ao',
-                        'ret = self.access_points'),
-                       ('GetAllAccessPoints', '', 'ao',
-                        'ret = self.access_points'),
-                       ('RequestScan', 'a{sv}', '', ''),
-                   ])
+    path = "/org/freedesktop/NetworkManager/Devices/" + device_name
+    self.AddObject(
+        path,
+        WIRELESS_DEVICE_IFACE,
+        {
+            "HwAddress": dbus.String("11:22:33:44:55:66"),
+            "PermHwAddress": dbus.String("11:22:33:44:55:66"),
+            "Bitrate": dbus.UInt32(5400),
+            "Mode": dbus.UInt32(2),
+            "WirelessCapabilities": dbus.UInt32(255),
+            "AccessPoints": dbus.Array([], signature="o"),
+        },
+        [
+            ("GetAccessPoints", "", "ao", "ret = self.access_points"),
+            ("GetAllAccessPoints", "", "ao", "ret = self.access_points"),
+            ("RequestScan", "a{sv}", "", ""),
+        ],
+    )
 
     dev_obj = dbusmock.get_object(path)
     dev_obj.access_points = []
-    dev_obj.AddProperties(DEVICE_IFACE,
-                          {
-                              'ActiveConnection': dbus.ObjectPath('/'),
-                              'AvailableConnections': dbus.Array([], signature='o'),
-                              'AutoConnect': False,
-                              'Managed': True,
-                              'Driver': 'dbusmock',
-                              'DeviceType': dbus.UInt32(2),
-                              'State': dbus.UInt32(state),
-                              'StateReason': (dbus.UInt32(state), dbus.UInt32(0)),
-                              'Interface': iface_name,
-                              'IpInterface': iface_name,
-                          })
+    dev_obj.AddProperties(
+        DEVICE_IFACE,
+        {
+            "ActiveConnection": dbus.ObjectPath("/"),
+            "AvailableConnections": dbus.Array([], signature="o"),
+            "AutoConnect": False,
+            "Managed": True,
+            "Driver": "dbusmock",
+            "DeviceType": dbus.UInt32(2),
+            "State": dbus.UInt32(state),
+            "StateReason": (dbus.UInt32(state), dbus.UInt32(0)),
+            "Interface": iface_name,
+            "IpInterface": iface_name,
+        },
+    )
 
     self.object_manager_emit_added(path)
 
     NM = dbusmock.get_object(MANAGER_OBJ)
-    devices = NM.Get(MANAGER_IFACE, 'Devices')
+    devices = NM.Get(MANAGER_IFACE, "Devices")
     devices.append(path)
-    NM.Set(MANAGER_IFACE, 'Devices', devices)
-    NM.EmitSignal('org.freedesktop.NetworkManager', 'DeviceAdded', 'o', [path])
+    NM.Set(MANAGER_IFACE, "Devices", devices)
+    NM.EmitSignal("org.freedesktop.NetworkManager", "DeviceAdded", "o", [path])
 
     return path
 
 
-@dbus.service.method(MOCK_IFACE,
-                     in_signature='ssssuuuyu', out_signature='s')
-def AddAccessPoint(self, dev_path, ap_name, ssid, hw_address,
-                   mode, frequency, rate, strength, security):
-    '''Add an access point to an existing WiFi device.
+@dbus.service.method(MOCK_IFACE, in_signature="ssssuuuyu", out_signature="s")
+def AddAccessPoint(self, dev_path, ap_name, ssid, hw_address, mode, frequency, rate, strength, security):
+    """Add an access point to an existing WiFi device.
 
     You have to specify WiFi Device path, Access Point object name,
     ssid, hw_address, mode, frequency, rate, strength and security.
@@ -447,48 +452,51 @@ def AddAccessPoint(self, dev_path, ap_name, ssid, hw_address,
     Please note that this does not set any global properties.
 
     Returns the new object path.
-    '''
+    """
     dev_obj = dbusmock.get_object(dev_path)
-    ap_path = '/org/freedesktop/NetworkManager/AccessPoint/' + ap_name
+    ap_path = "/org/freedesktop/NetworkManager/AccessPoint/" + ap_name
     if ap_path in dev_obj.access_points:
         raise dbus.exceptions.DBusException(
-            f'Access point {ap_name} on device {dev_path} already exists',
-            name=MANAGER_IFACE + '.AlreadyExists')
+            f"Access point {ap_name} on device {dev_path} already exists", name=MANAGER_IFACE + ".AlreadyExists"
+        )
 
     flags = NM80211ApFlags.NM_802_11_AP_FLAGS_PRIVACY
     if security == NM80211ApSecurityFlags.NM_802_11_AP_SEC_NONE:
         flags = NM80211ApFlags.NM_802_11_AP_FLAGS_NONE
 
-    self.AddObject(ap_path,
-                   ACCESS_POINT_IFACE,
-                   {'Ssid': dbus.ByteArray(ssid.encode('UTF-8')),
-                    'HwAddress': dbus.String(hw_address),
-                    'Flags': dbus.UInt32(flags),
-                    'LastSeen': dbus.Int32(1),
-                    'Frequency': dbus.UInt32(frequency),
-                    'MaxBitrate': dbus.UInt32(rate),
-                    'Mode': dbus.UInt32(mode),
-                    'RsnFlags': dbus.UInt32(security),
-                    'WpaFlags': dbus.UInt32(security),
-                    'Strength': dbus.Byte(strength)},
-                   [])
+    self.AddObject(
+        ap_path,
+        ACCESS_POINT_IFACE,
+        {
+            "Ssid": dbus.ByteArray(ssid.encode("UTF-8")),
+            "HwAddress": dbus.String(hw_address),
+            "Flags": dbus.UInt32(flags),
+            "LastSeen": dbus.Int32(1),
+            "Frequency": dbus.UInt32(frequency),
+            "MaxBitrate": dbus.UInt32(rate),
+            "Mode": dbus.UInt32(mode),
+            "RsnFlags": dbus.UInt32(security),
+            "WpaFlags": dbus.UInt32(security),
+            "Strength": dbus.Byte(strength),
+        },
+        [],
+    )
     self.object_manager_emit_added(ap_path)
 
     dev_obj.access_points.append(ap_path)
 
-    aps = dev_obj.Get(WIRELESS_DEVICE_IFACE, 'AccessPoints')
+    aps = dev_obj.Get(WIRELESS_DEVICE_IFACE, "AccessPoints")
     aps.append(ap_path)
-    dev_obj.Set(WIRELESS_DEVICE_IFACE, 'AccessPoints', aps)
+    dev_obj.Set(WIRELESS_DEVICE_IFACE, "AccessPoints", aps)
 
-    dev_obj.EmitSignal(WIRELESS_DEVICE_IFACE, 'AccessPointAdded', 'o', [ap_path])
+    dev_obj.EmitSignal(WIRELESS_DEVICE_IFACE, "AccessPointAdded", "o", [ap_path])
 
     return ap_path
 
 
-@dbus.service.method(MOCK_IFACE,
-                     in_signature='ssss', out_signature='s')
+@dbus.service.method(MOCK_IFACE, in_signature="ssss", out_signature="s")
 def AddWiFiConnection(self, dev_path, connection_name, ssid_name, _key_mgmt):
-    '''Add an available connection to an existing WiFi device and access point.
+    """Add an available connection to an existing WiFi device and access point.
 
     You have to specify WiFi Device path, Connection object name,
     SSID and key management.
@@ -498,73 +506,73 @@ def AddWiFiConnection(self, dev_path, connection_name, ssid_name, _key_mgmt):
     Please note that this does not set any global properties.
 
     Returns the new object path.
-    '''
+    """
 
     dev_obj = dbusmock.get_object(dev_path)
-    connection_path = '/org/freedesktop/NetworkManager/Settings/' + connection_name
-    connections = dev_obj.Get(DEVICE_IFACE, 'AvailableConnections')
+    connection_path = "/org/freedesktop/NetworkManager/Settings/" + connection_name
+    connections = dev_obj.Get(DEVICE_IFACE, "AvailableConnections")
 
     settings_obj = dbusmock.get_object(SETTINGS_OBJ)
     main_connections = settings_obj.ListConnections()
 
-    ssid = ssid_name.encode('UTF-8')
+    ssid = ssid_name.encode("UTF-8")
 
     # Find the access point by ssid
     access_point = None
     access_points = dev_obj.access_points
     for ap_path in access_points:
         ap = dbusmock.get_object(ap_path)
-        if ap.Get(ACCESS_POINT_IFACE, 'Ssid') == ssid:
+        if ap.Get(ACCESS_POINT_IFACE, "Ssid") == ssid:
             access_point = ap
             break
 
     if not access_point:
         raise dbus.exceptions.DBusException(
-            f'Access point with SSID [{ssid_name}] could not be found',
-            name=MANAGER_IFACE + '.DoesNotExist')
+            f"Access point with SSID [{ssid_name}] could not be found", name=MANAGER_IFACE + ".DoesNotExist"
+        )
 
-    hw_address = access_point.Get(ACCESS_POINT_IFACE, 'HwAddress')
-    mode = access_point.Get(ACCESS_POINT_IFACE, 'Mode')
-    security = access_point.Get(ACCESS_POINT_IFACE, 'WpaFlags')
+    hw_address = access_point.Get(ACCESS_POINT_IFACE, "HwAddress")
+    mode = access_point.Get(ACCESS_POINT_IFACE, "Mode")
+    security = access_point.Get(ACCESS_POINT_IFACE, "WpaFlags")
 
     if connection_path in connections or connection_path in main_connections:
         raise dbus.exceptions.DBusException(
-            f'Connection {connection_name} on device {dev_path} already exists',
-            name=MANAGER_IFACE + '.AlreadyExists')
+            f"Connection {connection_name} on device {dev_path} already exists", name=MANAGER_IFACE + ".AlreadyExists"
+        )
 
     # Parse mac address string into byte array
-    mac_bytes = binascii.unhexlify(hw_address.replace(':', ''))
+    mac_bytes = binascii.unhexlify(hw_address.replace(":", ""))
 
     settings = {
-        '802-11-wireless': {
-            'seen-bssids': [hw_address],
-            'ssid': dbus.ByteArray(ssid),
-            'mac-address': dbus.ByteArray(mac_bytes),
-            'mode': InfrastructureMode.NAME_MAP[mode]
+        "802-11-wireless": {
+            "seen-bssids": [hw_address],
+            "ssid": dbus.ByteArray(ssid),
+            "mac-address": dbus.ByteArray(mac_bytes),
+            "mode": InfrastructureMode.NAME_MAP[mode],
         },
-        'connection': {
-            'timestamp': dbus.UInt64(1374828522),
-            'type': '802-11-wireless',
-            'id': ssid_name,
-            'uuid': str(uuid.uuid4())
+        "connection": {
+            "timestamp": dbus.UInt64(1374828522),
+            "type": "802-11-wireless",
+            "id": ssid_name,
+            "uuid": str(uuid.uuid4()),
         },
     }
 
     if security != NM80211ApSecurityFlags.NM_802_11_AP_SEC_NONE:
-        settings['802-11-wireless']['security'] = '802-11-wireless-security'
-        settings['802-11-wireless-security'] = NM80211ApSecurityFlags.NAME_MAP[security]
+        settings["802-11-wireless"]["security"] = "802-11-wireless-security"
+        settings["802-11-wireless-security"] = NM80211ApSecurityFlags.NAME_MAP[security]
 
-    self.AddObject(connection_path,
-                   CSETTINGS_IFACE,
-                   {
-                       'Unsaved': False
-                   },
-                   [
-                       ('Delete', '', '', 'self.ConnectionDelete(self)'),
-                       ('GetSettings', '', 'a{sa{sv}}', 'ret = self.ConnectionGetSettings(self)'),
-                       ('GetSecrets', 's', 'a{sa{sv}}', 'ret = self.ConnectionGetSecrets(self, args[0])'),
-                       ('Update', 'a{sa{sv}}', '', 'self.ConnectionUpdate(self, args[0])'),
-                   ])
+    self.AddObject(
+        connection_path,
+        CSETTINGS_IFACE,
+        {"Unsaved": False},
+        [
+            ("Delete", "", "", "self.ConnectionDelete(self)"),
+            ("GetSettings", "", "a{sa{sv}}", "ret = self.ConnectionGetSettings(self)"),
+            ("GetSecrets", "s", "a{sa{sv}}", "ret = self.ConnectionGetSecrets(self, args[0])"),
+            ("Update", "a{sa{sv}}", "", "self.ConnectionUpdate(self, args[0])"),
+        ],
+    )
     self.object_manager_emit_added(connection_path)
 
     connection_obj = dbusmock.get_object(connection_path)
@@ -576,20 +584,21 @@ def AddWiFiConnection(self, dev_path, connection_name, ssid_name, _key_mgmt):
     connection_obj.ConnectionUpdate = ConnectionUpdate
 
     connections.append(dbus.ObjectPath(connection_path))
-    dev_obj.Set(DEVICE_IFACE, 'AvailableConnections', connections)
+    dev_obj.Set(DEVICE_IFACE, "AvailableConnections", connections)
 
     main_connections.append(connection_path)
-    settings_obj.Set(SETTINGS_IFACE, 'Connections', main_connections)
+    settings_obj.Set(SETTINGS_IFACE, "Connections", main_connections)
 
-    settings_obj.EmitSignal(SETTINGS_IFACE, 'NewConnection', 'o', [ap_path])  # pylint: disable=undefined-loop-variable
+    settings_obj.EmitSignal(
+        SETTINGS_IFACE, "NewConnection", "o", [ap_path]  # pylint: disable=undefined-loop-variable
+    )
 
     return connection_path
 
 
-@dbus.service.method(MOCK_IFACE,
-                     in_signature='assssu', out_signature='s')
+@dbus.service.method(MOCK_IFACE, in_signature="assssu", out_signature="s")
 def AddActiveConnection(self, devices, connection_device, specific_object, name, state):
-    '''Add an active connection to an existing WiFi device.
+    """Add an active connection to an existing WiFi device.
 
     You have to a list of the involved WiFi devices, the connection path,
     the access point path, ActiveConnection object name and connection
@@ -598,33 +607,35 @@ def AddActiveConnection(self, devices, connection_device, specific_object, name,
     Please note that this does not set any global properties.
 
     Returns the new object path.
-    '''
+    """
 
     conn_obj = dbusmock.get_object(connection_device)
     settings = conn_obj.settings
-    conn_uuid = settings['connection']['uuid']
-    conn_type = settings['connection']['type']
-    conn_id = settings['connection']['id']
+    conn_uuid = settings["connection"]["uuid"]
+    conn_type = settings["connection"]["type"]
+    conn_id = settings["connection"]["id"]
 
     device_objects = [dbus.ObjectPath(dev) for dev in devices]
 
-    active_connection_path = '/org/freedesktop/NetworkManager/ActiveConnection/' + name
-    self.AddObject(active_connection_path,
-                   ACTIVE_CONNECTION_IFACE,
-                   {
-                       'Devices': dbus.Array(device_objects, signature='o'),
-                       'Default6': False,
-                       'Default': True,
-                       'Type': conn_type,
-                       'Vpn': (conn_type == 'vpn'),
-                       'Connection': dbus.ObjectPath(connection_device),
-                       'Master': dbus.ObjectPath('/'),
-                       'SpecificObject': dbus.ObjectPath(specific_object),
-                       'Uuid': conn_uuid,
-                       'State': dbus.UInt32(state),
-                       'Id': conn_id,
-                   },
-                   [])
+    active_connection_path = "/org/freedesktop/NetworkManager/ActiveConnection/" + name
+    self.AddObject(
+        active_connection_path,
+        ACTIVE_CONNECTION_IFACE,
+        {
+            "Devices": dbus.Array(device_objects, signature="o"),
+            "Default6": False,
+            "Default": True,
+            "Type": conn_type,
+            "Vpn": (conn_type == "vpn"),
+            "Connection": dbus.ObjectPath(connection_device),
+            "Master": dbus.ObjectPath("/"),
+            "SpecificObject": dbus.ObjectPath(specific_object),
+            "Uuid": conn_uuid,
+            "State": dbus.UInt32(state),
+            "Id": conn_id,
+        },
+        [],
+    )
 
     for dev_path in devices:
         self.SetDeviceActive(dev_path, active_connection_path)
@@ -632,111 +643,107 @@ def AddActiveConnection(self, devices, connection_device, specific_object, name,
     self.object_manager_emit_added(active_connection_path)
 
     NM = dbusmock.get_object(MANAGER_OBJ)
-    active_connections = NM.Get(MANAGER_IFACE, 'ActiveConnections')
+    active_connections = NM.Get(MANAGER_IFACE, "ActiveConnections")
     active_connections.append(dbus.ObjectPath(active_connection_path))
-    NM.SetProperty(MANAGER_OBJ, MANAGER_IFACE, 'ActiveConnections', active_connections)
+    NM.SetProperty(MANAGER_OBJ, MANAGER_IFACE, "ActiveConnections", active_connections)
 
     return active_connection_path
 
 
-@dbus.service.method(MOCK_IFACE,
-                     in_signature='ss', out_signature='')
+@dbus.service.method(MOCK_IFACE, in_signature="ss", out_signature="")
 def RemoveAccessPoint(self, dev_path, ap_path):
-    '''Remove the specified access point.
+    """Remove the specified access point.
 
     You have to specify the device to remove the access point from, and the
     path of the access point.
 
     Please note that this does not set any global properties.
-    '''
+    """
 
     dev_obj = dbusmock.get_object(dev_path)
 
-    aps = dev_obj.Get(WIRELESS_DEVICE_IFACE, 'AccessPoints')
+    aps = dev_obj.Get(WIRELESS_DEVICE_IFACE, "AccessPoints")
     aps.remove(ap_path)
-    dev_obj.Set(WIRELESS_DEVICE_IFACE, 'AccessPoints', aps)
+    dev_obj.Set(WIRELESS_DEVICE_IFACE, "AccessPoints", aps)
 
     dev_obj.access_points.remove(ap_path)
 
-    dev_obj.EmitSignal(WIRELESS_DEVICE_IFACE, 'AccessPointRemoved', 'o', [ap_path])
+    dev_obj.EmitSignal(WIRELESS_DEVICE_IFACE, "AccessPointRemoved", "o", [ap_path])
 
     self.object_manager_emit_removed(ap_path)
     self.RemoveObject(ap_path)
 
 
-@dbus.service.method(MOCK_IFACE,
-                     in_signature='ss', out_signature='')
+@dbus.service.method(MOCK_IFACE, in_signature="ss", out_signature="")
 def RemoveWifiConnection(self, dev_path, connection_path):
-    '''Remove the specified WiFi connection.
+    """Remove the specified WiFi connection.
 
     You have to specify the device to remove the connection from, and the
     path of the Connection.
 
     Please note that this does not set any global properties.
-    '''
+    """
 
     dev_obj = dbusmock.get_object(dev_path)
     settings_obj = dbusmock.get_object(SETTINGS_OBJ)
 
-    connections = dev_obj.Get(DEVICE_IFACE, 'AvailableConnections')
+    connections = dev_obj.Get(DEVICE_IFACE, "AvailableConnections")
     main_connections = settings_obj.ListConnections()
 
     if connection_path not in connections and connection_path not in main_connections:
         return
 
     connections.remove(dbus.ObjectPath(connection_path))
-    dev_obj.Set(DEVICE_IFACE, 'AvailableConnections', connections)
+    dev_obj.Set(DEVICE_IFACE, "AvailableConnections", connections)
 
     main_connections.remove(connection_path)
-    settings_obj.Set(SETTINGS_IFACE, 'Connections', main_connections)
+    settings_obj.Set(SETTINGS_IFACE, "Connections", main_connections)
 
-    settings_obj.EmitSignal(SETTINGS_IFACE, 'ConnectionRemoved', 'o', [connection_path])
+    settings_obj.EmitSignal(SETTINGS_IFACE, "ConnectionRemoved", "o", [connection_path])
 
     connection_obj = dbusmock.get_object(connection_path)
-    connection_obj.EmitSignal(CSETTINGS_IFACE, 'Removed', '', [])
+    connection_obj.EmitSignal(CSETTINGS_IFACE, "Removed", "", [])
 
     self.object_manager_emit_removed(connection_path)
     self.RemoveObject(connection_path)
 
 
-@dbus.service.method(MOCK_IFACE,
-                     in_signature='ss', out_signature='')
+@dbus.service.method(MOCK_IFACE, in_signature="ss", out_signature="")
 def RemoveActiveConnection(self, dev_path, active_connection_path):
-    '''Remove the specified ActiveConnection.
+    """Remove the specified ActiveConnection.
 
     You have to specify the device to remove the connection from, and the
     path of the ActiveConnection.
 
     Please note that this does not set any global properties.
-    '''
+    """
     self.SetDeviceDisconnected(dev_path)
 
     NM = dbusmock.get_object(MANAGER_OBJ)
-    active_connections = NM.Get(MANAGER_IFACE, 'ActiveConnections')
+    active_connections = NM.Get(MANAGER_IFACE, "ActiveConnections")
 
     if active_connection_path not in active_connections:
         return
 
     active_connections.remove(dbus.ObjectPath(active_connection_path))
-    NM.SetProperty(MANAGER_OBJ, MANAGER_IFACE, 'ActiveConnections', active_connections)
+    NM.SetProperty(MANAGER_OBJ, MANAGER_IFACE, "ActiveConnections", active_connections)
 
     self.object_manager_emit_removed(active_connection_path)
     self.RemoveObject(active_connection_path)
 
 
-@dbus.service.method(SETTINGS_IFACE,
-                     in_signature='a{sa{sv}}', out_signature='o')
+@dbus.service.method(SETTINGS_IFACE, in_signature="a{sa{sv}}", out_signature="o")
 def SettingsAddConnection(self, connection_settings):
-    '''Add a connection.
+    """Add a connection.
 
     connection_settings is a String String Variant Map Map. See
     https://developer.gnome.org/NetworkManager/0.9/spec.html #type-String_String_Variant_Map_Map
 
     If you omit uuid, this method adds one for you.
-    '''
+    """
 
-    if 'uuid' not in connection_settings['connection']:
-        connection_settings['connection']['uuid'] = str(uuid.uuid4())
+    if "uuid" not in connection_settings["connection"]:
+        connection_settings["connection"]["uuid"] = str(uuid.uuid4())
 
     NM = dbusmock.get_object(MANAGER_OBJ)
     settings_obj = dbusmock.get_object(SETTINGS_OBJ)
@@ -745,23 +752,23 @@ def SettingsAddConnection(self, connection_settings):
     # Mimic how NM names connections
     count = 0
     while True:
-        connection_obj_path = dbus.ObjectPath(SETTINGS_OBJ + '/' + str(count))
+        connection_obj_path = dbus.ObjectPath(SETTINGS_OBJ + "/" + str(count))
         if connection_obj_path not in main_connections:
             break
         count += 1
     connection_path = str(connection_obj_path)
 
-    self.AddObject(connection_path,
-                   CSETTINGS_IFACE,
-                   {
-                       'Unsaved': False
-                   },
-                   [
-                       ('Delete', '', '', 'self.ConnectionDelete(self)'),
-                       ('GetSettings', '', 'a{sa{sv}}', 'ret = self.ConnectionGetSettings(self)'),
-                       ('GetSecrets', 's', 'a{sa{sv}}', 'ret = self.ConnectionGetSecrets(self, args[0])'),
-                       ('Update', 'a{sa{sv}}', '', 'self.ConnectionUpdate(self, args[0])'),
-                   ])
+    self.AddObject(
+        connection_path,
+        CSETTINGS_IFACE,
+        {"Unsaved": False},
+        [
+            ("Delete", "", "", "self.ConnectionDelete(self)"),
+            ("GetSettings", "", "a{sa{sv}}", "ret = self.ConnectionGetSettings(self)"),
+            ("GetSecrets", "s", "a{sa{sv}}", "ret = self.ConnectionGetSecrets(self, args[0])"),
+            ("Update", "a{sa{sv}}", "", "self.ConnectionUpdate(self, args[0])"),
+        ],
+    )
     self.object_manager_emit_added(connection_path)
 
     connection_obj = dbusmock.get_object(connection_path)
@@ -773,13 +780,13 @@ def SettingsAddConnection(self, connection_settings):
     connection_obj.ConnectionUpdate = ConnectionUpdate
 
     main_connections.append(connection_path)
-    settings_obj.Set(SETTINGS_IFACE, 'Connections', main_connections)
+    settings_obj.Set(SETTINGS_IFACE, "Connections", main_connections)
 
-    settings_obj.EmitSignal(SETTINGS_IFACE, 'NewConnection', 'o', [connection_path])
+    settings_obj.EmitSignal(SETTINGS_IFACE, "NewConnection", "o", [connection_path])
 
     auto_connect = False
-    if 'autoconnect' in connection_settings['connection']:
-        auto_connect = connection_settings['connection']['autoconnect']
+    if "autoconnect" in connection_settings["connection"]:
+        auto_connect = connection_settings["connection"]["autoconnect"]
 
     if auto_connect:
         dev = None
@@ -795,23 +802,23 @@ def SettingsAddConnection(self, connection_settings):
     return connection_path
 
 
-@dbus.service.method(SETTINGS_IFACE, in_signature='s', out_signature='o')
+@dbus.service.method(SETTINGS_IFACE, in_signature="s", out_signature="o")
 def SettingsGetConnectionByUuid(self, conn_uuid):
     conns = self.ListConnections()
     for o in conns:
         self.conn = dbusmock.get_object(o)
         settings = self.conn.GetSettings()
-        if settings['connection']['uuid'] == conn_uuid:
+        if settings["connection"]["uuid"] == conn_uuid:
             return o
     raise dbus.exceptions.DBusException(f"There was no connection with uuid {conn_uuid}")
 
 
 def ConnectionUpdate(self, settings):
-    '''Update settings on a connection.
+    """Update settings on a connection.
 
     settings is a String String Variant Map Map. See
     https://developer.gnome.org/NetworkManager/0.9/spec.html#type-String_String_Variant_Map_Map
-    '''
+    """
     connection_path = self.connection_path
 
     NM = dbusmock.get_object(MANAGER_OBJ)
@@ -821,8 +828,9 @@ def ConnectionUpdate(self, settings):
 
     if connection_path not in main_connections:
         raise dbus.exceptions.DBusException(
-            f'Connection {connection_path} does not exist',
-            name=MANAGER_IFACE + '.DoesNotExist',)
+            f"Connection {connection_path} does not exist",
+            name=MANAGER_IFACE + ".DoesNotExist",
+        )
 
     # Take care not to overwrite the secrets
     for setting_name in settings:
@@ -832,11 +840,11 @@ def ConnectionUpdate(self, settings):
                 self.settings[setting_name] = {}
             self.settings[setting_name][k] = setting[k]
 
-    self.EmitSignal(CSETTINGS_IFACE, 'Updated', '', [])
+    self.EmitSignal(CSETTINGS_IFACE, "Updated", "", [])
 
     auto_connect = False
-    if 'autoconnect' in settings['connection']:
-        auto_connect = settings['connection']['autoconnect']
+    if "autoconnect" in settings["connection"]:
+        auto_connect = settings["connection"]["autoconnect"]
 
     if auto_connect:
         dev = None
@@ -860,7 +868,7 @@ def ConnectionGetSettings(self):
     for setting_name in self.settings:
         setting = self.settings[setting_name]
         for k in setting:
-            if k != 'secrets':
+            if k != "secrets":
                 if setting_name not in settings:
                     settings[setting_name] = {}
                 settings[setting_name][k] = setting[k]
@@ -871,16 +879,16 @@ def ConnectionGetSettings(self):
 def ConnectionGetSecrets(self, setting):
     settings = self.settings[setting]
 
-    if 'secrets' in settings:
-        secrets = {setting: {'secrets': settings['secrets']}}
+    if "secrets" in settings:
+        secrets = {setting: {"secrets": settings["secrets"]}}
     else:
-        secrets = {setting: {'secrets': {'no-secrets': True}}}
+        secrets = {setting: {"secrets": {"no-secrets": True}}}
 
     return secrets
 
 
 def ConnectionDelete(self):
-    '''Deletes a connection.
+    """Deletes a connection.
 
     This also
         * removes the deleted connection from any device,
@@ -890,18 +898,18 @@ def ConnectionDelete(self):
 
     Note: If this was the only active connection, we change the global
     connection state.
-    '''
+    """
     connection_path = self.connection_path
 
     NM = dbusmock.get_object(MANAGER_OBJ)
     settings_obj = dbusmock.get_object(SETTINGS_OBJ)
 
     # Find the associated active connection(s).
-    active_connections = NM.Get(MANAGER_IFACE, 'ActiveConnections')
+    active_connections = NM.Get(MANAGER_IFACE, "ActiveConnections")
     associated_active_connections = []
     for ac in active_connections:
         ac_obj = dbusmock.get_object(ac)
-        ac_con = ac_obj.Get(ACTIVE_CONNECTION_IFACE, 'Connection')
+        ac_con = ac_obj.Get(ACTIVE_CONNECTION_IFACE, "Connection")
         if ac_con == connection_path:
             associated_active_connections.append(ac)
 
@@ -915,7 +923,7 @@ def ConnectionDelete(self):
     # We also remove all associated active connections.
     for dev_path in NM.GetDevices():
         dev_obj = dbusmock.get_object(dev_path)
-        connections = dev_obj.Get(DEVICE_IFACE, 'AvailableConnections')
+        connections = dev_obj.Get(DEVICE_IFACE, "AvailableConnections")
 
         for ac in associated_active_connections:
             NM.RemoveActiveConnection(dev_path, ac)
@@ -924,19 +932,19 @@ def ConnectionDelete(self):
             continue
 
         connections.remove(dbus.ObjectPath(connection_path))
-        dev_obj.Set(DEVICE_IFACE, 'AvailableConnections', connections)
+        dev_obj.Set(DEVICE_IFACE, "AvailableConnections", connections)
 
     # Remove the connection from the settings interface
     main_connections = settings_obj.ListConnections()
     if connection_path not in main_connections:
         return
     main_connections.remove(connection_path)
-    settings_obj.Set(SETTINGS_IFACE, 'Connections', main_connections)
-    settings_obj.EmitSignal(SETTINGS_IFACE, 'ConnectionRemoved', 'o', [connection_path])
+    settings_obj.Set(SETTINGS_IFACE, "Connections", main_connections)
+    settings_obj.EmitSignal(SETTINGS_IFACE, "ConnectionRemoved", "o", [connection_path])
 
     # Remove the connection from the mock
     connection_obj = dbusmock.get_object(connection_path)
-    connection_obj.EmitSignal(CSETTINGS_IFACE, 'Removed', '', [])
+    connection_obj.EmitSignal(CSETTINGS_IFACE, "Removed", "", [])
 
     self.object_manager_emit_removed(connection_path)
     self.RemoveObject(connection_path)

--- a/dbusmock/templates/networkmanager.py
+++ b/dbusmock/templates/networkmanager.py
@@ -520,10 +520,12 @@ def AddWiFiConnection(self, dev_path, connection_name, ssid_name, _key_mgmt):
     # Find the access point by ssid
     access_point = None
     access_points = dev_obj.access_points
+    access_point_path = None
     for ap_path in access_points:
         ap = dbusmock.get_object(ap_path)
         if ap.Get(ACCESS_POINT_IFACE, "Ssid") == ssid:
             access_point = ap
+            access_point_path = ap_path
             break
 
     if not access_point:
@@ -589,9 +591,7 @@ def AddWiFiConnection(self, dev_path, connection_name, ssid_name, _key_mgmt):
     main_connections.append(connection_path)
     settings_obj.Set(SETTINGS_IFACE, "Connections", main_connections)
 
-    settings_obj.EmitSignal(
-        SETTINGS_IFACE, "NewConnection", "o", [ap_path]  # pylint: disable=undefined-loop-variable
-    )
+    settings_obj.EmitSignal(SETTINGS_IFACE, "NewConnection", "o", [access_point_path])
 
     return connection_path
 

--- a/dbusmock/templates/notification_daemon.py
+++ b/dbusmock/templates/notification_daemon.py
@@ -1,9 +1,9 @@
-'''notification-daemon mock template
+"""notification-daemon mock template
 
 This creates the expected methods and properties of the notification-daemon
 services, but no devices. You can specify non-default capabilities in
 "parameters".
-'''
+"""
 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -11,38 +11,57 @@ services, but no devices. You can specify non-default capabilities in
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Martin Pitt'
-__copyright__ = '''
+__author__ = "Martin Pitt"
+__copyright__ = """
 (c) 2012 Canonical Ltd.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
-BUS_NAME = 'org.freedesktop.Notifications'
-MAIN_OBJ = '/org/freedesktop/Notifications'
-MAIN_IFACE = 'org.freedesktop.Notifications'
+BUS_NAME = "org.freedesktop.Notifications"
+MAIN_OBJ = "/org/freedesktop/Notifications"
+MAIN_IFACE = "org.freedesktop.Notifications"
 SYSTEM_BUS = False
 
 # default capabilities, can be modified with "capabilities" parameter
-default_caps = ['body', 'body-markup', 'icon-static', 'image/svg+xml',
-                'private-synchronous', 'append', 'private-icon-only',
-                'truncation']
+default_caps = [
+    "body",
+    "body-markup",
+    "icon-static",
+    "image/svg+xml",
+    "private-synchronous",
+    "append",
+    "private-icon-only",
+    "truncation",
+]
 
 
 def load(mock, parameters):
-    caps = parameters['capabilities'].split() if 'capabilities' in parameters else default_caps
+    caps = parameters["capabilities"].split() if "capabilities" in parameters else default_caps
 
     # next notification ID
     mock.next_id = 1
 
-    mock.AddMethods(MAIN_IFACE, [
-        ('GetCapabilities', '', 'as', f'ret = {caps!r}'),
-        ('CloseNotification', 'i', '', 'if args[0] < self.next_id: self.EmitSignal('
-                                       '"", "NotificationClosed", "uu", [args[0], 1])'),
-        ('GetServerInformation', '', 'ssss', 'ret = ("mock-notify", "test vendor", "1.0", "1.1")'),
-        ('Notify', 'susssasa{sv}i', 'u', '''if args[1]:
+    mock.AddMethods(
+        MAIN_IFACE,
+        [
+            ("GetCapabilities", "", "as", f"ret = {caps!r}"),
+            (
+                "CloseNotification",
+                "i",
+                "",
+                "if args[0] < self.next_id: self.EmitSignal('', 'NotificationClosed', 'uu', [args[0], 1])",
+            ),
+            ("GetServerInformation", "", "ssss", 'ret = ("mock-notify", "test vendor", "1.0", "1.1")'),
+            (
+                "Notify",
+                "susssasa{sv}i",
+                "u",
+                """if args[1]:
     ret = args[1]
 else:
     ret = self.next_id
     self.next_id += 1
-'''),
-    ])
+""",
+            ),
+        ],
+    )

--- a/dbusmock/templates/ofono.py
+++ b/dbusmock/templates/ofono.py
@@ -1,4 +1,4 @@
-'''ofonod D-Bus mock template'''
+"""ofonod D-Bus mock template"""
 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -6,20 +6,20 @@
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Martin Pitt'
-__copyright__ = '''
+__author__ = "Martin Pitt"
+__copyright__ = """
 (c) 2013 Canonical Ltd.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 
 import dbus
 
 import dbusmock
 
-BUS_NAME = 'org.ofono'
-MAIN_OBJ = '/'
-MAIN_IFACE = 'org.ofono.Manager'
+BUS_NAME = "org.ofono"
+MAIN_OBJ = "/"
+MAIN_IFACE = "org.ofono.Manager"
 SYSTEM_BUS = True
 
 NOT_IMPLEMENTED = 'raise dbus.exceptions.DBusException("not implemented", name="org.ofono.Error.NotImplemented")'
@@ -44,11 +44,16 @@ def load(mock, parameters):
     mock.imsi_counter = 0
     mock.iccid_counter = 0
     _parameters = parameters
-    mock.AddMethod(MAIN_IFACE, 'GetModems', '', 'a(oa{sv})',
-                   'ret = [(m, objects[m].GetAll("org.ofono.Modem")) for m in self.modems]')
+    mock.AddMethod(
+        MAIN_IFACE,
+        "GetModems",
+        "",
+        "a(oa{sv})",
+        'ret = [(m, objects[m].GetAll("org.ofono.Modem")) for m in self.modems]',
+    )
 
-    if not parameters.get('no_modem', False):
-        mock.AddModem(parameters.get('ModemName', 'ril_0'), {})
+    if not parameters.get("no_modem", False):
+        mock.AddModem(parameters.get("ModemName", "ril_0"), {})
 
 
 #  interface org.ofono.Modem {
@@ -61,48 +66,55 @@ def load(mock, parameters):
 #                      v value);
 #  };
 
-@dbus.service.method(dbusmock.MOCK_IFACE,
-                     in_signature='sa{sv}', out_signature='s')
+
+@dbus.service.method(dbusmock.MOCK_IFACE, in_signature="sa{sv}", out_signature="s")
 def AddModem(self, name, _properties):
-    '''Convenience method to add a modem
+    """Convenience method to add a modem
 
     You have to specify a device name which must be a valid part of an object
     path, e. g. "mock_ac". For future extensions you can specify a "properties"
     array, but no extra properties are supported for now.
 
     Returns the new object path.
-    '''
-    path = '/' + name
-    self.AddObject(path,
-                   'org.ofono.Modem',
-                   {
-                       'Online': dbus.Boolean(True, variant_level=1),
-                       'Powered': dbus.Boolean(True, variant_level=1),
-                       'Lockdown': dbus.Boolean(False, variant_level=1),
-                       'Emergency': dbus.Boolean(False, variant_level=1),
-                       'Manufacturer': dbus.String('Fakesys', variant_level=1),
-                       'Model': dbus.String('Mock Modem', variant_level=1),
-                       'Revision': dbus.String('0815.42', variant_level=1),
-                       'Serial': dbus.String(new_modem_serial(self), variant_level=1),
-                       'Type': dbus.String('hardware', variant_level=1),
-                       'Interfaces': ['org.ofono.CallVolume',
-                                      'org.ofono.VoiceCallManager',
-                                      'org.ofono.NetworkRegistration',
-                                      'org.ofono.SimManager',
-                                      # 'org.ofono.MessageManager',
-                                      'org.ofono.ConnectionManager',
-                                      # 'org.ofono.NetworkTime'
-                                     ],
-                       # 'Features': ['sms', 'net', 'gprs', 'sim']
-                       'Features': ['gprs', 'net'],
-                   },
-                   [
-                       ('GetProperties', '', 'a{sv}', 'ret = self.GetAll("org.ofono.Modem")'),
-                       ('SetProperty', 'sv', '', 'self.Set("org.ofono.Modem", args[0], args[1]); '
-                                                 'self.EmitSignal("org.ofono.Modem", "PropertyChanged",'
-                                                 ' "sv", [args[0], args[1]])'),
-                   ]
-                  )
+    """
+    path = "/" + name
+    self.AddObject(
+        path,
+        "org.ofono.Modem",
+        {
+            "Online": dbus.Boolean(True, variant_level=1),
+            "Powered": dbus.Boolean(True, variant_level=1),
+            "Lockdown": dbus.Boolean(False, variant_level=1),
+            "Emergency": dbus.Boolean(False, variant_level=1),
+            "Manufacturer": dbus.String("Fakesys", variant_level=1),
+            "Model": dbus.String("Mock Modem", variant_level=1),
+            "Revision": dbus.String("0815.42", variant_level=1),
+            "Serial": dbus.String(new_modem_serial(self), variant_level=1),
+            "Type": dbus.String("hardware", variant_level=1),
+            "Interfaces": [
+                "org.ofono.CallVolume",
+                "org.ofono.VoiceCallManager",
+                "org.ofono.NetworkRegistration",
+                "org.ofono.SimManager",
+                # 'org.ofono.MessageManager',
+                "org.ofono.ConnectionManager",
+                # 'org.ofono.NetworkTime'
+            ],
+            # 'Features': ['sms', 'net', 'gprs', 'sim']
+            "Features": ["gprs", "net"],
+        },
+        [
+            ("GetProperties", "", "a{sv}", 'ret = self.GetAll("org.ofono.Modem")'),
+            (
+                "SetProperty",
+                "sv",
+                "",
+                'self.Set("org.ofono.Modem", args[0], args[1]); '
+                'self.EmitSignal("org.ofono.Modem", "PropertyChanged",'
+                ' "sv", [args[0], args[1]])',
+            ),
+        ],
+    )
     obj = dbusmock.mockobject.objects[path]
     obj.name = name
     add_voice_call_api(obj)
@@ -110,15 +122,15 @@ def AddModem(self, name, _properties):
     add_simmanager_api(self, obj)
     add_connectionmanager_api(obj)
     self.modems.append(path)
-    props = obj.GetAll('org.ofono.Modem', dbus_interface=dbus.PROPERTIES_IFACE)
-    self.EmitSignal(MAIN_IFACE, 'ModemAdded', 'oa{sv}', [path, props])
+    props = obj.GetAll("org.ofono.Modem", dbus_interface=dbus.PROPERTIES_IFACE)
+    self.EmitSignal(MAIN_IFACE, "ModemAdded", "oa{sv}", [path, props])
     return path
 
 
 # Generate a new modem serial number so each modem we add gets a unique one.
 # Use a counter so that the result is predictable for tests.
 def new_modem_serial(mock):
-    serial = f'12345678-1234-1234-1234-{mock.modem_serial_counter:012d}'
+    serial = f"12345678-1234-1234-1234-{mock.modem_serial_counter:012d}"
     mock.modem_serial_counter += 1
     return serial
 
@@ -126,7 +138,7 @@ def new_modem_serial(mock):
 # Generate a new unique IMSI (start with USA/AT&T 310/150 to match the MCC/MNC SIM properties)
 # Use a counter so that the result is predictable for tests.
 def new_imsi(mock):
-    imsi = f'310150{mock.imsi_counter:09d}'
+    imsi = f"310150{mock.imsi_counter:09d}"
     mock.imsi_counter += 1
     return imsi
 
@@ -134,9 +146,10 @@ def new_imsi(mock):
 # Generate a new unique ICCID
 # Use a counter so that the result is predictable for tests.
 def new_iccid(mock):
-    iccid = f'893581234{mock.iccid_counter:012d}'
+    iccid = f"893581234{mock.iccid_counter:012d}"
     mock.iccid_counter += 1
     return iccid
+
 
 #  interface org.ofono.VoiceCallManager {
 #    methods:
@@ -168,65 +181,77 @@ def new_iccid(mock):
 
 
 def add_voice_call_api(mock):
-    '''Add org.ofono.VoiceCallManager API to a mock'''
+    """Add org.ofono.VoiceCallManager API to a mock"""
 
     # also add an emergency number which is not a real one, in case one runs a
     # test case against a production ofono :-)
-    mock.AddProperty('org.ofono.VoiceCallManager', 'EmergencyNumbers', ['911', '13373'])
+    mock.AddProperty("org.ofono.VoiceCallManager", "EmergencyNumbers", ["911", "13373"])
 
     mock.calls = []  # object paths
 
-    mock.AddMethods('org.ofono.VoiceCallManager', [
-        ('GetProperties', '', 'a{sv}', 'ret = self.GetAll("org.ofono.VoiceCallManager")'),
-        ('Transfer', '', '', ''),
-        ('SwapCalls', '', '', ''),
-        ('ReleaseAndAnswer', '', '', ''),
-        ('ReleaseAndSwap', '', '', ''),
-        ('HoldAndAnswer', '', '', ''),
-        ('SendTones', 's', '', ''),
-        ('PrivateChat', 'o', 'ao', NOT_IMPLEMENTED),
-        ('CreateMultiparty', '', 'o', NOT_IMPLEMENTED),
-        ('HangupMultiparty', '', '', NOT_IMPLEMENTED),
-        ('GetCalls', '', 'a(oa{sv})', 'ret = [(c, objects[c].GetAll("org.ofono.VoiceCall")) for c in self.calls]')
-    ])
+    mock.AddMethods(
+        "org.ofono.VoiceCallManager",
+        [
+            ("GetProperties", "", "a{sv}", 'ret = self.GetAll("org.ofono.VoiceCallManager")'),
+            ("Transfer", "", "", ""),
+            ("SwapCalls", "", "", ""),
+            ("ReleaseAndAnswer", "", "", ""),
+            ("ReleaseAndSwap", "", "", ""),
+            ("HoldAndAnswer", "", "", ""),
+            ("SendTones", "s", "", ""),
+            ("PrivateChat", "o", "ao", NOT_IMPLEMENTED),
+            ("CreateMultiparty", "", "o", NOT_IMPLEMENTED),
+            ("HangupMultiparty", "", "", NOT_IMPLEMENTED),
+            (
+                "GetCalls",
+                "",
+                "a(oa{sv})",
+                'ret = [(c, objects[c].GetAll("org.ofono.VoiceCall")) for c in self.calls]',
+            ),
+        ],
+    )
 
 
-@dbus.service.method('org.ofono.VoiceCallManager',
-                     in_signature='ss', out_signature='s')
+@dbus.service.method("org.ofono.VoiceCallManager", in_signature="ss", out_signature="s")
 def Dial(self, number, _hide_callerid):
     # pylint: disable=protected-access # _object_path
-    path = f'{self._object_path}/voicecall{(len(self.calls) + 1):02}'
-    self.AddObject(path, 'org.ofono.VoiceCall',
-                   {
-                       'State': dbus.String('dialing', variant_level=1),
-                       'LineIdentification': dbus.String(number, variant_level=1),
-                       'Name': dbus.String('', variant_level=1),
-                       'Multiparty': dbus.Boolean(False, variant_level=1),
-                       'RemoteHeld': dbus.Boolean(False, variant_level=1),
-                       'RemoteMultiparty': dbus.Boolean(False, variant_level=1),
-                       'Emergency': dbus.Boolean(False, variant_level=1),
-                   },
-                   [
-                       ('GetProperties', '', 'a{sv}', 'ret = self.GetAll("org.ofono.VoiceCall")'),
-                       ('Deflect', 's', '', NOT_IMPLEMENTED),
-                       ('Hangup', '', '', 'self.parent.calls.remove(self._object_path);'
-                        'self.parent.RemoveObject(self._object_path);'
-                        'self.EmitSignal("org.ofono.VoiceCallManager", "CallRemoved", "o", [self._object_path])'),
-                       ('Answer', '', '', NOT_IMPLEMENTED),
-                   ]
-                  )
+    path = f"{self._object_path}/voicecall{(len(self.calls) + 1):02}"
+    self.AddObject(
+        path,
+        "org.ofono.VoiceCall",
+        {
+            "State": dbus.String("dialing", variant_level=1),
+            "LineIdentification": dbus.String(number, variant_level=1),
+            "Name": dbus.String("", variant_level=1),
+            "Multiparty": dbus.Boolean(False, variant_level=1),
+            "RemoteHeld": dbus.Boolean(False, variant_level=1),
+            "RemoteMultiparty": dbus.Boolean(False, variant_level=1),
+            "Emergency": dbus.Boolean(False, variant_level=1),
+        },
+        [
+            ("GetProperties", "", "a{sv}", 'ret = self.GetAll("org.ofono.VoiceCall")'),
+            ("Deflect", "s", "", NOT_IMPLEMENTED),
+            (
+                "Hangup",
+                "",
+                "",
+                "self.parent.calls.remove(self._object_path);"
+                "self.parent.RemoveObject(self._object_path);"
+                'self.EmitSignal("org.ofono.VoiceCallManager", "CallRemoved", "o", [self._object_path])',
+            ),
+            ("Answer", "", "", NOT_IMPLEMENTED),
+        ],
+    )
     obj = dbusmock.mockobject.objects[path]
     obj.parent = self
     self.calls.append(path)
-    self.EmitSignal('org.ofono.VoiceCallManager', 'CallAdded', 'oa{sv}',
-                    [path, obj.GetProperties()])
+    self.EmitSignal("org.ofono.VoiceCallManager", "CallAdded", "oa{sv}", [path, obj.GetProperties()])
     return path
 
 
-@dbus.service.method('org.ofono.VoiceCallManager',
-                     in_signature='', out_signature='')
+@dbus.service.method("org.ofono.VoiceCallManager", in_signature="", out_signature="")
 def HangupAll(self):
-    print('XXX HangupAll', self.calls)
+    print("XXX HangupAll", self.calls)
     for c in list(self.calls):  # needs a copy
         dbusmock.mockobject.objects[c].Hangup()
     assert self.calls == []
@@ -256,52 +281,64 @@ def HangupAll(self):
 #          properties:
 #        };
 
+
 def get_all_operators(mock):
-    return ('ret = [(m, objects[m].GetAll("org.ofono.NetworkOperator")) '
-            f'for m in objects if "{mock.name}/operator/" in m]')
+    return f'ret = [(m, objects[m].GetAll("org.ofono.NetworkOperator")) for m in objects if "{mock.name}/operator/" in m]'
 
 
 def add_netreg_api(mock):
-    '''Add org.ofono.NetworkRegistration API to a mock'''
+    """Add org.ofono.NetworkRegistration API to a mock"""
 
     # also add an emergency number which is not a real one, in case one runs a
     # test case against a production ofono :-)
-    mock.AddProperties('org.ofono.NetworkRegistration', {
-        'Mode': 'auto',
-        'Status': 'registered',
-        'LocationAreaCode': _parameters.get('LocationAreaCode', 987),
-        'CellId': _parameters.get('CellId', 10203),
-        'MobileCountryCode': _parameters.get('MobileCountryCode', '777'),
-        'MobileNetworkCode': _parameters.get('MobileNetworkCode', '11'),
-        'Technology': _parameters.get('Technology', 'gsm'),
-        'Name': _parameters.get('Name', 'fake.tel'),
-        'Strength': _parameters.get('Strength', dbus.Byte(80)),
-        'BaseStation': _parameters.get('BaseStation', ''),
-    })
+    mock.AddProperties(
+        "org.ofono.NetworkRegistration",
+        {
+            "Mode": "auto",
+            "Status": "registered",
+            "LocationAreaCode": _parameters.get("LocationAreaCode", 987),
+            "CellId": _parameters.get("CellId", 10203),
+            "MobileCountryCode": _parameters.get("MobileCountryCode", "777"),
+            "MobileNetworkCode": _parameters.get("MobileNetworkCode", "11"),
+            "Technology": _parameters.get("Technology", "gsm"),
+            "Name": _parameters.get("Name", "fake.tel"),
+            "Strength": _parameters.get("Strength", dbus.Byte(80)),
+            "BaseStation": _parameters.get("BaseStation", ""),
+        },
+    )
 
-    mock.AddObject(f'/{mock.name}/operator/op1',
-                   'org.ofono.NetworkOperator',
-                   {
-                       'Name': _parameters.get('Name', 'fake.tel'),
-                       'Status': 'current',
-                       'MobileCountryCode': _parameters.get('MobileCountryCode', '777'),
-                       'MobileNetworkCode': _parameters.get('MobileNetworkCode', '11'),
-                       'Technologies': [_parameters.get('Technology', 'gsm')],
-                   },
-                   [
-                       ('GetProperties', '', 'a{sv}', 'ret = self.GetAll("org.ofono.NetworkOperator")'),
-                       ('Register', '', '', ''),
-                   ]
-                  )
+    mock.AddObject(
+        f"/{mock.name}/operator/op1",
+        "org.ofono.NetworkOperator",
+        {
+            "Name": _parameters.get("Name", "fake.tel"),
+            "Status": "current",
+            "MobileCountryCode": _parameters.get("MobileCountryCode", "777"),
+            "MobileNetworkCode": _parameters.get("MobileNetworkCode", "11"),
+            "Technologies": [_parameters.get("Technology", "gsm")],
+        },
+        [
+            ("GetProperties", "", "a{sv}", 'ret = self.GetAll("org.ofono.NetworkOperator")'),
+            ("Register", "", "", ""),
+        ],
+    )
 
-    mock.AddMethods('org.ofono.NetworkRegistration', [
-        ('GetProperties', '', 'a{sv}', 'ret = self.GetAll("org.ofono.NetworkRegistration")'),
-        ('SetProperty', 'sv', '', 'self.Set("org.ofono.NetworkRegistration", args[0], args[1]); '
-         'self.EmitSignal("org.ofono.NetworkRegistration", "PropertyChanged", "sv", [args[0], args[1]])'),
-        ('Register', '', '', ''),
-        ('GetOperators', '', 'a(oa{sv})', get_all_operators(mock)),
-        ('Scan', '', 'a(oa{sv})', get_all_operators(mock)),
-    ])
+    mock.AddMethods(
+        "org.ofono.NetworkRegistration",
+        [
+            ("GetProperties", "", "a{sv}", 'ret = self.GetAll("org.ofono.NetworkRegistration")'),
+            (
+                "SetProperty",
+                "sv",
+                "",
+                'self.Set("org.ofono.NetworkRegistration", args[0], args[1]); '
+                'self.EmitSignal("org.ofono.NetworkRegistration", "PropertyChanged", "sv", [args[0], args[1]])',
+            ),
+            ("Register", "", "", ""),
+            ("GetOperators", "", "a(oa{sv})", get_all_operators(mock)),
+            ("Scan", "", "a(oa{sv})", get_all_operators(mock)),
+        ],
+    )
 
 
 #  interface org.ofono.SimManager {
@@ -328,68 +365,81 @@ def add_netreg_api(mock):
 #                      v value);
 #  };
 
+
 def add_simmanager_api(self, mock):
-    '''Add org.ofono.SimManager API to a mock'''
+    """Add org.ofono.SimManager API to a mock"""
 
-    iface = 'org.ofono.SimManager'
-    mock.AddProperties(iface, {
-        'BarredDialing': _parameters.get('BarredDialing', False),
-        'CardIdentifier': _parameters.get('CardIdentifier', new_iccid(self)),
-        'FixedDialing': _parameters.get('FixedDialing', False),
-        'LockedPins': _parameters.get('LockedPins', dbus.Array([], signature='s')),
-        'MobileCountryCode': _parameters.get('MobileCountryCode', '310'),
-        'MobileNetworkCode': _parameters.get('MobileNetworkCode', '150'),
-        'PreferredLanguages': _parameters.get('PreferredLanguages', ['en']),
-        'Present': _parameters.get('Present', dbus.Boolean(True)),
-        'Retries': _parameters.get('Retries', dbus.Dictionary([["pin", dbus.Byte(3)], ["puk", dbus.Byte(10)]])),
-        'PinRequired': _parameters.get('PinRequired', "none"),
-        'SubscriberNumbers': _parameters.get('SubscriberNumbers', ['123456789', '234567890']),
-        'SubscriberIdentity': _parameters.get('SubscriberIdentity', new_imsi(self)),
-    })
-    mock.AddMethods(iface, [
-        ('GetProperties', '', 'a{sv}', f'ret = self.GetAll("{iface}")'),
-        ('SetProperty', 'sv', '', f'self.Set("{iface}", args[0], args[1]); '
-         f'self.EmitSignal("{iface}", "PropertyChanged", "sv", [args[0], args[1]])'),
-        ('ChangePin', 'sss', '', ''),
-
-        ('EnterPin', 'ss', '',
-         'correctPin = "1234"\n'
-         f'iface = "{iface}"\n'
-         'newRetries = self.Get(iface, "Retries")\n'
-         'if args[0] == "pin" and args[1] != correctPin:\n'
-         '    newRetries["pin"] = dbus.Byte(newRetries["pin"] - 1)\n'
-         'elif args[0] == "pin":\n'
-         '    newRetries["pin"] = dbus.Byte(3)\n'
-
-         'self.Set(iface, "Retries", newRetries)\n'
-         'self.EmitSignal(iface, "PropertyChanged", "sv", ["Retries", newRetries])\n'
-
-         'if args[0] == "pin" and args[1] != correctPin:\n'
-         '    class Failed(dbus.exceptions.DBusException):\n'
-         '        _dbus_error_name = "org.ofono.Error.Failed"\n'
-         '    raise Failed("Operation failed")'),
-
-        ('ResetPin', 'sss', '',
-         'correctPuk = "12345678"\n'
-         f'iface = "{iface}"\n'
-         'newRetries = self.Get(iface, "Retries")\n'
-         'if args[0] == "puk" and args[1] != correctPuk:\n'
-         '    newRetries["puk"] = dbus.Byte(newRetries["puk"] - 1)\n'
-         'elif args[0] == "puk":\n'
-         '    newRetries["pin"] = dbus.Byte(3)\n'
-         '    newRetries["puk"] = dbus.Byte(10)\n'
-
-         'self.Set(iface, "Retries", newRetries)\n'
-         'self.EmitSignal(iface, "PropertyChanged", "sv", ["Retries", newRetries])\n'
-
-         'if args[0] == "puk" and args[1] != correctPuk:\n'
-         '    class Failed(dbus.exceptions.DBusException):\n'
-         '        _dbus_error_name = "org.ofono.Error.Failed"\n'
-         '    raise Failed("Operation failed")'),
-
-        ('LockPin', 'ss', '', ''),
-        ('UnlockPin', 'ss', '', ''),
-    ])
+    iface = "org.ofono.SimManager"
+    mock.AddProperties(
+        iface,
+        {
+            "BarredDialing": _parameters.get("BarredDialing", False),
+            "CardIdentifier": _parameters.get("CardIdentifier", new_iccid(self)),
+            "FixedDialing": _parameters.get("FixedDialing", False),
+            "LockedPins": _parameters.get("LockedPins", dbus.Array([], signature="s")),
+            "MobileCountryCode": _parameters.get("MobileCountryCode", "310"),
+            "MobileNetworkCode": _parameters.get("MobileNetworkCode", "150"),
+            "PreferredLanguages": _parameters.get("PreferredLanguages", ["en"]),
+            "Present": _parameters.get("Present", dbus.Boolean(True)),
+            "Retries": _parameters.get("Retries", dbus.Dictionary([["pin", dbus.Byte(3)], ["puk", dbus.Byte(10)]])),
+            "PinRequired": _parameters.get("PinRequired", "none"),
+            "SubscriberNumbers": _parameters.get("SubscriberNumbers", ["123456789", "234567890"]),
+            "SubscriberIdentity": _parameters.get("SubscriberIdentity", new_imsi(self)),
+        },
+    )
+    mock.AddMethods(
+        iface,
+        [
+            ("GetProperties", "", "a{sv}", f'ret = self.GetAll("{iface}")'),
+            (
+                "SetProperty",
+                "sv",
+                "",
+                f'self.Set("{iface}", args[0], args[1]); '
+                f'self.EmitSignal("{iface}", "PropertyChanged", "sv", [args[0], args[1]])',
+            ),
+            ("ChangePin", "sss", "", ""),
+            (
+                "EnterPin",
+                "ss",
+                "",
+                'correctPin = "1234"\n'
+                f'iface = "{iface}"\n'
+                'newRetries = self.Get(iface, "Retries")\n'
+                'if args[0] == "pin" and args[1] != correctPin:\n'
+                '    newRetries["pin"] = dbus.Byte(newRetries["pin"] - 1)\n'
+                'elif args[0] == "pin":\n'
+                '    newRetries["pin"] = dbus.Byte(3)\n'
+                'self.Set(iface, "Retries", newRetries)\n'
+                'self.EmitSignal(iface, "PropertyChanged", "sv", ["Retries", newRetries])\n'
+                'if args[0] == "pin" and args[1] != correctPin:\n'
+                "    class Failed(dbus.exceptions.DBusException):\n"
+                '        _dbus_error_name = "org.ofono.Error.Failed"\n'
+                '    raise Failed("Operation failed")',
+            ),
+            (
+                "ResetPin",
+                "sss",
+                "",
+                'correctPuk = "12345678"\n'
+                f'iface = "{iface}"\n'
+                'newRetries = self.Get(iface, "Retries")\n'
+                'if args[0] == "puk" and args[1] != correctPuk:\n'
+                '    newRetries["puk"] = dbus.Byte(newRetries["puk"] - 1)\n'
+                'elif args[0] == "puk":\n'
+                '    newRetries["pin"] = dbus.Byte(3)\n'
+                '    newRetries["puk"] = dbus.Byte(10)\n'
+                'self.Set(iface, "Retries", newRetries)\n'
+                'self.EmitSignal(iface, "PropertyChanged", "sv", ["Retries", newRetries])\n'
+                'if args[0] == "puk" and args[1] != correctPuk:\n'
+                "    class Failed(dbus.exceptions.DBusException):\n"
+                '        _dbus_error_name = "org.ofono.Error.Failed"\n'
+                '    raise Failed("Operation failed")',
+            ),
+            ("LockPin", "ss", "", ""),
+            ("UnlockPin", "ss", "", ""),
+        ],
+    )
 
 
 #  interface org.ofono.ConnectionManager {
@@ -410,24 +460,36 @@ def add_simmanager_api(self, mock):
 #      ContextRemoved(o path);
 #  };
 def add_connectionmanager_api(mock):
-    '''Add org.ofono.ConnectionManager API to a mock'''
+    """Add org.ofono.ConnectionManager API to a mock"""
 
-    iface = 'org.ofono.ConnectionManager'
-    mock.AddProperties(iface, {
-        'Attached': _parameters.get('Attached', True),
-        'Bearer': _parameters.get('Bearer', 'gprs'),
-        'RoamingAllowed': _parameters.get('RoamingAllowed', False),
-        'Powered': _parameters.get('ConnectionPowered', True),
-    })
-    mock.AddMethods(iface, [
-        ('GetProperties', '', 'a{sv}', f'ret = self.GetAll("{iface}")'),
-        ('SetProperty', 'sv', '', f'self.Set("{iface}", args[0], args[1]); '
-         f'self.EmitSignal("{iface}", "PropertyChanged", "sv", [args[0], args[1]])'),
-        ('AddContext', 's', 'o', 'ret = "/"'),
-        ('RemoveContext', 'o', '', ''),
-        ('DeactivateAll', '', '', ''),
-        ('GetContexts', '', 'a(oa{sv})', 'ret = dbus.Array([])'),
-    ])
+    iface = "org.ofono.ConnectionManager"
+    mock.AddProperties(
+        iface,
+        {
+            "Attached": _parameters.get("Attached", True),
+            "Bearer": _parameters.get("Bearer", "gprs"),
+            "RoamingAllowed": _parameters.get("RoamingAllowed", False),
+            "Powered": _parameters.get("ConnectionPowered", True),
+        },
+    )
+    mock.AddMethods(
+        iface,
+        [
+            ("GetProperties", "", "a{sv}", f'ret = self.GetAll("{iface}")'),
+            (
+                "SetProperty",
+                "sv",
+                "",
+                f'self.Set("{iface}", args[0], args[1]); '
+                f'self.EmitSignal("{iface}", "PropertyChanged", "sv", [args[0], args[1]])',
+            ),
+            ("AddContext", "s", "o", 'ret = "/"'),
+            ("RemoveContext", "o", "", ""),
+            ("DeactivateAll", "", "", ""),
+            ("GetContexts", "", "a(oa{sv})", "ret = dbus.Array([])"),
+        ],
+    )
+
 
 # unimplemented Modem object interfaces:
 #

--- a/dbusmock/templates/polkitd.py
+++ b/dbusmock/templates/polkitd.py
@@ -1,10 +1,10 @@
-'''polkitd mock template
+"""polkitd mock template
 
 This creates the expected methods and properties of the main
 org.freedesktop.PolicyKit1 object. By default, all actions are rejected.  You
 can call AllowUnknown() and SetAllowed() on the mock D-Bus interface to control
 which actions are allowed.
-'''
+"""
 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -12,11 +12,11 @@ which actions are allowed.
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Martin Pitt'
-__copyright__ = '''
+__author__ = "Martin Pitt"
+__copyright__ = """
 (c) 2013-2021 Canonical Ltd.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 import time
 
@@ -24,19 +24,24 @@ import dbus
 
 from dbusmock import MOCK_IFACE
 
-BUS_NAME = 'org.freedesktop.PolicyKit1'
-MAIN_OBJ = '/org/freedesktop/PolicyKit1/Authority'
-MAIN_IFACE = 'org.freedesktop.PolicyKit1.Authority'
+BUS_NAME = "org.freedesktop.PolicyKit1"
+MAIN_OBJ = "/org/freedesktop/PolicyKit1/Authority"
+MAIN_IFACE = "org.freedesktop.PolicyKit1.Authority"
 SYSTEM_BUS = True
 
 
 def load(mock, _parameters):
-    mock.AddProperties(MAIN_IFACE,
-                       dbus.Dictionary({
-                           'BackendName': 'local',
-                           'BackendVersion': '0.8.15',
-                           'BackendFeatures': dbus.UInt32(1, variant_level=1),
-                       }, signature='sv'))
+    mock.AddProperties(
+        MAIN_IFACE,
+        dbus.Dictionary(
+            {
+                "BackendName": "local",
+                "BackendVersion": "0.8.15",
+                "BackendFeatures": dbus.UInt32(1, variant_level=1),
+            },
+            signature="sv",
+        ),
+    )
 
     # default state
     mock.allow_unknown = False
@@ -47,15 +52,13 @@ def load(mock, _parameters):
     mock.hanging_calls = []
 
 
-@dbus.service.method(MAIN_IFACE,
-                     in_signature='(sa{sv})sa{ss}us',
-                     out_signature='(bba{ss})',
-                     async_callbacks=('ok_cb', '_err_cb'))
-def CheckAuthorization(self, _subject, action_id, _details, _flags,
-                       _cancellation_id, ok_cb, _err_cb):
+@dbus.service.method(
+    MAIN_IFACE, in_signature="(sa{sv})sa{ss}us", out_signature="(bba{ss})", async_callbacks=("ok_cb", "_err_cb")
+)
+def CheckAuthorization(self, _subject, action_id, _details, _flags, _cancellation_id, ok_cb, _err_cb):
     time.sleep(self.delay)
     allowed = action_id in self.allowed or self.allow_unknown
-    ret = (allowed, False, {'test': 'test'})
+    ret = (allowed, False, {"test": "test"})
 
     if self.simulate_hang or action_id in self.hanging_actions:
         self.hanging_calls.append((ok_cb, ret))
@@ -63,55 +66,55 @@ def CheckAuthorization(self, _subject, action_id, _details, _flags,
         ok_cb(ret)
 
 
-@dbus.service.method(MAIN_IFACE, in_signature='(sa{sv})ss')
+@dbus.service.method(MAIN_IFACE, in_signature="(sa{sv})ss")
 def RegisterAuthenticationAgent(_self, _subject, _locale, _object_path):
     pass
 
 
-@dbus.service.method(MOCK_IFACE, in_signature='b', out_signature='')
+@dbus.service.method(MOCK_IFACE, in_signature="b", out_signature="")
 def AllowUnknown(self, default):
-    '''Control whether unknown actions are allowed
+    """Control whether unknown actions are allowed
 
     This controls the return value of CheckAuthorization for actions which were
     not explicitly allowed by SetAllowed().
-    '''
+    """
     self.allow_unknown = default
 
 
-@dbus.service.method(MOCK_IFACE, in_signature='as', out_signature='')
+@dbus.service.method(MOCK_IFACE, in_signature="as", out_signature="")
 def SetAllowed(self, actions):
-    '''Set allowed actions'''
+    """Set allowed actions"""
 
     self.allowed = actions
 
 
-@dbus.service.method(MOCK_IFACE, in_signature='d', out_signature='')
+@dbus.service.method(MOCK_IFACE, in_signature="d", out_signature="")
 def SetDelay(self, delay):
-    '''Makes the CheckAuthorization() method to delay'''
+    """Makes the CheckAuthorization() method to delay"""
     self.delay = delay
 
 
-@dbus.service.method(MOCK_IFACE, in_signature='b', out_signature='')
+@dbus.service.method(MOCK_IFACE, in_signature="b", out_signature="")
 def SimulateHang(self, hang):
-    '''Makes the CheckAuthorization() method to hang'''
+    """Makes the CheckAuthorization() method to hang"""
     self.simulate_hang = hang
 
 
-@dbus.service.method(MOCK_IFACE, in_signature='as', out_signature='')
+@dbus.service.method(MOCK_IFACE, in_signature="as", out_signature="")
 def SimulateHangActions(self, actions):
-    '''Makes the CheckAuthorization() method to hang on such actions'''
+    """Makes the CheckAuthorization() method to hang on such actions"""
     self.hanging_actions = actions
 
 
-@dbus.service.method(MOCK_IFACE, in_signature='', out_signature='')
+@dbus.service.method(MOCK_IFACE, in_signature="", out_signature="")
 def ReleaseHangingCalls(self):
-    '''Calls all the hanging callbacks'''
-    for (cb, ret) in self.hanging_calls:
+    """Calls all the hanging callbacks"""
+    for cb, ret in self.hanging_calls:
         cb(ret)
     self.hanging_calls = []
 
 
-@dbus.service.method(MOCK_IFACE, in_signature='', out_signature='b')
+@dbus.service.method(MOCK_IFACE, in_signature="", out_signature="b")
 def HaveHangingCalls(self):
-    '''Check if we've hangling calls'''
+    """Check if we've hangling calls"""
     return len(self.hanging_calls)

--- a/dbusmock/templates/power_profiles_daemon.py
+++ b/dbusmock/templates/power_profiles_daemon.py
@@ -1,10 +1,10 @@
-'''power-profiles-daemon mock template
+"""power-profiles-daemon mock template
 
 This creates the expected methods and properties of the main
 net.hadess.PowerProfiles object.
 
 This provides only the non-deprecated D-Bus API as of version 0.9.
-'''
+"""
 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -12,40 +12,37 @@ This provides only the non-deprecated D-Bus API as of version 0.9.
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Bastien Nocera'
-__copyright__ = '''
+__author__ = "Bastien Nocera"
+__copyright__ = """
 (c) 2021, Red Hat Inc.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 import dbus
 
-BUS_NAME = 'net.hadess.PowerProfiles'
-MAIN_OBJ = '/net/hadess/PowerProfiles'
-MAIN_IFACE = 'net.hadess.PowerProfiles'
+BUS_NAME = "net.hadess.PowerProfiles"
+MAIN_OBJ = "/net/hadess/PowerProfiles"
+MAIN_IFACE = "net.hadess.PowerProfiles"
 SYSTEM_BUS = True
 
 
 def hold_profile(self, profile, reason, application_id):
     self.cookie += 1
-    element = {'Profile': profile,
-               'Reason': reason,
-               'ApplicationId': application_id}
+    element = {"Profile": profile, "Reason": reason, "ApplicationId": application_id}
     self.holds[self.cookie] = element
-    self.props[MAIN_IFACE]['ActiveProfileHolds'] = []
+    self.props[MAIN_IFACE]["ActiveProfileHolds"] = []
     for value in self.holds.values():
-        self.props[MAIN_IFACE]['ActiveProfileHolds'].append(value)
+        self.props[MAIN_IFACE]["ActiveProfileHolds"].append(value)
     return self.cookie
 
 
 def release_profile(self, cookie):
     self.holds.pop(cookie)
-    self.props[MAIN_IFACE]['ActiveProfileHolds'] = []
+    self.props[MAIN_IFACE]["ActiveProfileHolds"] = []
     for value in self.holds.values():
-        self.props[MAIN_IFACE]['ActiveProfileHolds'].append(value)
-    if len(self.props[MAIN_IFACE]['ActiveProfileHolds']) == 0:
-        self.props[MAIN_IFACE]['ActiveProfileHolds'] = \
-            dbus.Array([], signature='(aa{sv})')
+        self.props[MAIN_IFACE]["ActiveProfileHolds"].append(value)
+    if len(self.props[MAIN_IFACE]["ActiveProfileHolds"]) == 0:
+        self.props[MAIN_IFACE]["ActiveProfileHolds"] = dbus.Array([], signature="(aa{sv})")
 
 
 def load(mock, parameters):
@@ -57,20 +54,22 @@ def load(mock, parameters):
     mock.holds = {}
 
     props = {
-        'ActiveProfile': parameters.get('ActiveProfile', 'balanced'),
-        'PerformanceDegraded': parameters.get('PerformanceDegraded', ''),
-        'Profiles': [
-            dbus.Dictionary({'Profile': 'power-saver', 'Driver': 'dbusmock'}, signature='sv'),
-            dbus.Dictionary({'Profile': 'balanced', 'Driver': 'dbusmock'}, signature='sv'),
-            dbus.Dictionary({'Profile': 'performance', 'Driver': 'dbusmock'}, signature='sv')
+        "ActiveProfile": parameters.get("ActiveProfile", "balanced"),
+        "PerformanceDegraded": parameters.get("PerformanceDegraded", ""),
+        "Profiles": [
+            dbus.Dictionary({"Profile": "power-saver", "Driver": "dbusmock"}, signature="sv"),
+            dbus.Dictionary({"Profile": "balanced", "Driver": "dbusmock"}, signature="sv"),
+            dbus.Dictionary({"Profile": "performance", "Driver": "dbusmock"}, signature="sv"),
         ],
-        'Actions': dbus.Array([], signature='s'),
-        'ActiveProfileHolds': dbus.Array([], signature='(aa{sv})'),
+        "Actions": dbus.Array([], signature="s"),
+        "ActiveProfileHolds": dbus.Array([], signature="(aa{sv})"),
     }
-    mock.AddProperties(MAIN_IFACE, dbus.Dictionary(props, signature='sv'))
+    mock.AddProperties(MAIN_IFACE, dbus.Dictionary(props, signature="sv"))
 
-    mock.AddMethods(MAIN_IFACE, [
-        ('HoldProfile', 'sss', 'u',
-         'ret = self.hold_profile(self, args[0], args[1], args[2])'),
-        ('ReleaseProfile', 'u', '', 'self.release_profile(self, args[0])'),
-    ])
+    mock.AddMethods(
+        MAIN_IFACE,
+        [
+            ("HoldProfile", "sss", "u", "ret = self.hold_profile(self, args[0], args[1], args[2])"),
+            ("ReleaseProfile", "u", "", "self.release_profile(self, args[0])"),
+        ],
+    )

--- a/dbusmock/templates/systemd.py
+++ b/dbusmock/templates/systemd.py
@@ -1,5 +1,5 @@
-'''systemd mock template
-'''
+"""systemd mock template
+"""
 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -7,25 +7,25 @@
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Jonas Ådahl'
-__copyright__ = '''
+__author__ = "Jonas Ådahl"
+__copyright__ = """
 (c) 2021 Red Hat
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 import dbus
 from gi.repository import GLib
 
 from dbusmock import MOCK_IFACE, mockobject
 
-BUS_PREFIX = 'org.freedesktop.systemd1'
-PATH_PREFIX = '/org/freedesktop/systemd1'
+BUS_PREFIX = "org.freedesktop.systemd1"
+PATH_PREFIX = "/org/freedesktop/systemd1"
 
 
 BUS_NAME = BUS_PREFIX
 MAIN_OBJ = PATH_PREFIX
-MAIN_IFACE = BUS_PREFIX + '.Manager'
-UNIT_IFACE = BUS_PREFIX + '.Unit'
+MAIN_IFACE = BUS_PREFIX + ".Manager"
+UNIT_IFACE = BUS_PREFIX + ".Unit"
 SYSTEM_BUS = True
 
 
@@ -33,76 +33,77 @@ def load(mock, _parameters):
     mock.next_job_id = 1
     mock.units = {}
 
-    mock.AddProperties(MAIN_IFACE, {'Version': 'v246'})
+    mock.AddProperties(MAIN_IFACE, {"Version": "v246"})
 
 
 def escape_unit_name(name):
-    for s in ['.', '-']:
-        name = name.replace(s, '_')
+    for s in [".", "-"]:
+        name = name.replace(s, "_")
     return name
 
 
 def emit_job_new_remove(mock, job_id, job_path, name):
-    mock.EmitSignal(MAIN_IFACE, 'JobNew', 'uos', [job_id, job_path, name])
-    mock.EmitSignal(MAIN_IFACE, 'JobRemoved', 'uoss',
-                    [job_id, job_path, name, 'done'])
+    mock.EmitSignal(MAIN_IFACE, "JobNew", "uos", [job_id, job_path, name])
+    mock.EmitSignal(MAIN_IFACE, "JobRemoved", "uoss", [job_id, job_path, name, "done"])
 
 
-@dbus.service.method(MAIN_IFACE, in_signature='ss', out_signature='o')
+@dbus.service.method(MAIN_IFACE, in_signature="ss", out_signature="o")
 def StartUnit(self, name, _mode):
     job_id = self.next_job_id
     self.next_job_id += 1
 
-    job_path = f'{PATH_PREFIX}/Job/{job_id}'
+    job_path = f"{PATH_PREFIX}/Job/{job_id}"
     GLib.idle_add(lambda: emit_job_new_remove(self, job_id, job_path, name))
 
     unit_path = self.units[str(name)]
     unit = mockobject.objects[unit_path]
-    unit.UpdateProperties(UNIT_IFACE, {'ActiveState': 'active'})
+    unit.UpdateProperties(UNIT_IFACE, {"ActiveState": "active"})
 
     return job_path
 
 
-@dbus.service.method(MAIN_IFACE, in_signature='ssa(sv)a(sa(sv))', out_signature='o')
+@dbus.service.method(MAIN_IFACE, in_signature="ssa(sv)a(sa(sv))", out_signature="o")
 def StartTransientUnit(self, name, _mode, _properties, _aux):
     job_id = self.next_job_id
     self.next_job_id += 1
 
-    job_path = f'{PATH_PREFIX}/Job/{job_id}'
+    job_path = f"{PATH_PREFIX}/Job/{job_id}"
     GLib.idle_add(lambda: emit_job_new_remove(self, job_id, job_path, name))
 
     return job_path
 
 
-@dbus.service.method(MAIN_IFACE, in_signature='ss', out_signature='o')
+@dbus.service.method(MAIN_IFACE, in_signature="ss", out_signature="o")
 def StopUnit(self, name, _mode):
     job_id = self.next_job_id
     self.next_job_id += 1
 
-    job_path = f'{PATH_PREFIX}/Job/{job_id}'
+    job_path = f"{PATH_PREFIX}/Job/{job_id}"
     GLib.idle_add(lambda: emit_job_new_remove(self, job_id, job_path, name))
 
     unit_path = self.units[str(name)]
     unit = mockobject.objects[unit_path]
-    unit.UpdateProperties(UNIT_IFACE, {'ActiveState': 'inactive'})
+    unit.UpdateProperties(UNIT_IFACE, {"ActiveState": "inactive"})
     return job_path
 
 
-@dbus.service.method(MAIN_IFACE, in_signature='s', out_signature='o')
+@dbus.service.method(MAIN_IFACE, in_signature="s", out_signature="o")
 def GetUnit(self, name):
     return self.units[str(name)]
 
 
-@dbus.service.method(MOCK_IFACE, in_signature='s')
+@dbus.service.method(MOCK_IFACE, in_signature="s")
 def AddMockUnit(self, name):
-    unit_path = f'{PATH_PREFIX}/unit/{escape_unit_name(name)}'
+    unit_path = f"{PATH_PREFIX}/unit/{escape_unit_name(name)}"
     self.units[str(name)] = unit_path
-    self.AddObject(unit_path,
-                   UNIT_IFACE,
-                   {
-                       'Id': name,
-                       'Names': [name],
-                       'LoadState': 'loaded',
-                       'ActiveState': 'inactive',
-                   },
-                   [])
+    self.AddObject(
+        unit_path,
+        UNIT_IFACE,
+        {
+            "Id": name,
+            "Names": [name],
+            "LoadState": "loaded",
+            "ActiveState": "inactive",
+        },
+        [],
+    )

--- a/dbusmock/templates/timedated.py
+++ b/dbusmock/templates/timedated.py
@@ -1,9 +1,9 @@
-'''systemd timedated mock template
+"""systemd timedated mock template
 
 This creates the expected methods and properties of the main
 org.freedesktop.timedate object. You can specify D-Bus property values like
 "Timezone" or "NTP" in "parameters".
-'''
+"""
 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -11,17 +11,17 @@ org.freedesktop.timedate object. You can specify D-Bus property values like
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Iain Lane'
-__copyright__ = '''
+__author__ = "Iain Lane"
+__copyright__ = """
 (c) 2013 Canonical Ltd.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 import dbus
 
-BUS_NAME = 'org.freedesktop.timedate1'
-MAIN_OBJ = '/org/freedesktop/timedate1'
-MAIN_IFACE = 'org.freedesktop.timedate1'
+BUS_NAME = "org.freedesktop.timedate1"
+MAIN_OBJ = "/org/freedesktop/timedate1"
+MAIN_IFACE = "org.freedesktop.timedate1"
 SYSTEM_BUS = True
 
 
@@ -30,19 +30,27 @@ def setProperty(prop):
 
 
 def load(mock, parameters):
-    mock.AddMethods(MAIN_IFACE, [
-        # There's nothing this can usefully do, but provide it for compatibility
-        ('SetTime', 'xbb', '', ''),
-        ('SetTimezone', 'sb', '', setProperty('Timezone')),
-        ('SetLocalRTC', 'bbb', '', setProperty('LocalRTC')),
-        ('SetNTP', 'bb', '', setProperty('NTP') + '; ' + setProperty('NTPSynchronized'))
-    ])
+    mock.AddMethods(
+        MAIN_IFACE,
+        [
+            # There's nothing this can usefully do, but provide it for compatibility
+            ("SetTime", "xbb", "", ""),
+            ("SetTimezone", "sb", "", setProperty("Timezone")),
+            ("SetLocalRTC", "bbb", "", setProperty("LocalRTC")),
+            ("SetNTP", "bb", "", setProperty("NTP") + "; " + setProperty("NTPSynchronized")),
+        ],
+    )
 
-    mock.AddProperties(MAIN_IFACE,
-                       dbus.Dictionary({
-                           'Timezone': parameters.get('Timezone', 'Etc/Utc'),
-                           'LocalRTC': parameters.get('LocalRTC', False),
-                           'NTP': parameters.get('NTP', True),
-                           'NTPSynchronized': parameters.get('NTP', True),
-                           'CanNTP': parameters.get('CanNTP', True)
-                       }, signature='sv'))
+    mock.AddProperties(
+        MAIN_IFACE,
+        dbus.Dictionary(
+            {
+                "Timezone": parameters.get("Timezone", "Etc/Utc"),
+                "LocalRTC": parameters.get("LocalRTC", False),
+                "NTP": parameters.get("NTP", True),
+                "NTPSynchronized": parameters.get("NTP", True),
+                "CanNTP": parameters.get("CanNTP", True),
+            },
+            signature="sv",
+        ),
+    )

--- a/dbusmock/templates/upower.py
+++ b/dbusmock/templates/upower.py
@@ -1,4 +1,4 @@
-'''upowerd mock template
+"""upowerd mock template
 
 This creates the expected methods and properties of the main
 org.freedesktop.UPower object, but no devices. You can specify any property
@@ -6,7 +6,7 @@ such as 'OnLowBattery' or the return value of 'SuspendAllowed',
 'HibernateAllowed', and 'GetCriticalAction' in "parameters".
 
 This provides the 1.0 D-Bus API of upower.
-'''
+"""
 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -14,75 +14,89 @@ This provides the 1.0 D-Bus API of upower.
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Martin Pitt'
-__copyright__ = '''
+__author__ = "Martin Pitt"
+__copyright__ = """
 (c) 2012, 2013 Canonical Ltd.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 import dbus
 
 import dbusmock
 from dbusmock import MOCK_IFACE, mockobject
 
-BUS_NAME = 'org.freedesktop.UPower'
-MAIN_OBJ = '/org/freedesktop/UPower'
-MAIN_IFACE = 'org.freedesktop.UPower'
+BUS_NAME = "org.freedesktop.UPower"
+MAIN_OBJ = "/org/freedesktop/UPower"
+MAIN_IFACE = "org.freedesktop.UPower"
 SYSTEM_BUS = True
-DEVICE_IFACE = 'org.freedesktop.UPower.Device'
+DEVICE_IFACE = "org.freedesktop.UPower.Device"
 
 
 def load(mock, parameters):
-    mock.AddMethods(MAIN_IFACE, [
-        ('EnumerateDevices', '', 'ao', 'ret = [k for k in objects.keys() '
-         'if "/devices" in k and not k.endswith("/DisplayDevice")]'),
-    ])
+    mock.AddMethods(
+        MAIN_IFACE,
+        [
+            (
+                "EnumerateDevices",
+                "",
+                "ao",
+                'ret = [k for k in objects.keys() if "/devices" in k and not k.endswith("/DisplayDevice")]',
+            ),
+        ],
+    )
 
-    props = dbus.Dictionary({
-        'DaemonVersion': parameters.get('DaemonVersion', '0.99'),
-        'OnBattery': parameters.get('OnBattery', False),
-        'LidIsPresent': parameters.get('LidIsPresent', True),
-        'LidIsClosed': parameters.get('LidIsClosed', False),
-        'LidForceSleep': parameters.get('LidForceSleep', True),
-        'IsDocked': parameters.get('IsDocked', False),
-    }, signature='sv')
+    props = dbus.Dictionary(
+        {
+            "DaemonVersion": parameters.get("DaemonVersion", "0.99"),
+            "OnBattery": parameters.get("OnBattery", False),
+            "LidIsPresent": parameters.get("LidIsPresent", True),
+            "LidIsClosed": parameters.get("LidIsClosed", False),
+            "LidForceSleep": parameters.get("LidForceSleep", True),
+            "IsDocked": parameters.get("IsDocked", False),
+        },
+        signature="sv",
+    )
 
-    mock.AddMethods(MAIN_IFACE, [
-        ('GetCriticalAction', '', 's', f'ret = "{parameters.get("GetCriticalAction", "HybridSleep")}"'),
-        ('GetDisplayDevice', '', 'o', 'ret = "/org/freedesktop/UPower/devices/DisplayDevice"')
-    ])
+    mock.AddMethods(
+        MAIN_IFACE,
+        [
+            ("GetCriticalAction", "", "s", f'ret = "{parameters.get("GetCriticalAction", "HybridSleep")}"'),
+            ("GetDisplayDevice", "", "o", 'ret = "/org/freedesktop/UPower/devices/DisplayDevice"'),
+        ],
+    )
 
-    mock.p_display_dev = '/org/freedesktop/UPower/devices/DisplayDevice'
+    mock.p_display_dev = "/org/freedesktop/UPower/devices/DisplayDevice"
 
     # add Display device; for defined properties, see
     # http://cgit.freedesktop.org/upower/tree/src/org.freedesktop.UPower.xml
-    mock.AddObject(mock.p_display_dev,
-                   DEVICE_IFACE,
-                   {
-                       'Type': dbus.UInt32(0, variant_level=1),
-                       'State': dbus.UInt32(0, variant_level=1),
-                       'Percentage': dbus.Double(0.0, variant_level=1),
-                       'Energy': dbus.Double(0.0, variant_level=1),
-                       'EnergyFull': dbus.Double(0.0, variant_level=1),
-                       'EnergyRate': dbus.Double(0.0, variant_level=1),
-                       'TimeToEmpty': dbus.Int64(0, variant_level=1),
-                       'TimeToFull': dbus.Int64(0, variant_level=1),
-                       'IsPresent': dbus.Boolean(False, variant_level=1),
-                       'IconName': dbus.String('', variant_level=1),
-                       # LEVEL_NONE
-                       'WarningLevel': dbus.UInt32(1, variant_level=1),
-                   },
-                   [
-                       ('Refresh', '', '', ''),
-                   ])
+    mock.AddObject(
+        mock.p_display_dev,
+        DEVICE_IFACE,
+        {
+            "Type": dbus.UInt32(0, variant_level=1),
+            "State": dbus.UInt32(0, variant_level=1),
+            "Percentage": dbus.Double(0.0, variant_level=1),
+            "Energy": dbus.Double(0.0, variant_level=1),
+            "EnergyFull": dbus.Double(0.0, variant_level=1),
+            "EnergyRate": dbus.Double(0.0, variant_level=1),
+            "TimeToEmpty": dbus.Int64(0, variant_level=1),
+            "TimeToFull": dbus.Int64(0, variant_level=1),
+            "IsPresent": dbus.Boolean(False, variant_level=1),
+            "IconName": dbus.String("", variant_level=1),
+            # LEVEL_NONE
+            "WarningLevel": dbus.UInt32(1, variant_level=1),
+        },
+        [
+            ("Refresh", "", "", ""),
+        ],
+    )
 
     mock.AddProperties(MAIN_IFACE, props)
 
 
-@dbus.service.method(MOCK_IFACE,
-                     in_signature='ss', out_signature='s')
+@dbus.service.method(MOCK_IFACE, in_signature="ss", out_signature="s")
 def AddAC(self, device_name, model_name):
-    '''Convenience method to add an AC object
+    """Convenience method to add an AC object
 
     You have to specify a device name which must be a valid part of an object
     path, e. g. "mock_ac", and an arbitrary model name.
@@ -91,24 +105,25 @@ def AddAC(self, device_name, model_name):
     "on-battery".
 
     Returns the new object path.
-    '''
-    path = '/org/freedesktop/UPower/devices/' + device_name
-    self.AddObject(path,
-                   DEVICE_IFACE,
-                   {
-                       'PowerSupply': dbus.Boolean(True, variant_level=1),
-                       'Model': dbus.String(model_name, variant_level=1),
-                       'Online': dbus.Boolean(True, variant_level=1),
-                   },
-                   [])
-    self.EmitSignal(MAIN_IFACE, 'DeviceAdded', 'o', [path])
+    """
+    path = "/org/freedesktop/UPower/devices/" + device_name
+    self.AddObject(
+        path,
+        DEVICE_IFACE,
+        {
+            "PowerSupply": dbus.Boolean(True, variant_level=1),
+            "Model": dbus.String(model_name, variant_level=1),
+            "Online": dbus.Boolean(True, variant_level=1),
+        },
+        [],
+    )
+    self.EmitSignal(MAIN_IFACE, "DeviceAdded", "o", [path])
     return path
 
 
-@dbus.service.method(MOCK_IFACE,
-                     in_signature='ssdx', out_signature='s')
+@dbus.service.method(MOCK_IFACE, in_signature="ssdx", out_signature="s")
 def AddDischargingBattery(self, device_name, model_name, percentage, seconds_to_empty):
-    '''Convenience method to add a discharging battery object
+    """Convenience method to add a discharging battery object
 
     You have to specify a device name which must be a valid part of an object
     path, e. g. "mock_ac", an arbitrary model name, the charge percentage, and
@@ -118,32 +133,33 @@ def AddDischargingBattery(self, device_name, model_name, percentage, seconds_to_
     "on-battery".
 
     Returns the new object path.
-    '''
-    path = '/org/freedesktop/UPower/devices/' + device_name
-    self.AddObject(path,
-                   DEVICE_IFACE,
-                   {
-                       'PowerSupply': dbus.Boolean(True, variant_level=1),
-                       'IsPresent': dbus.Boolean(True, variant_level=1),
-                       'Model': dbus.String(model_name, variant_level=1),
-                       'Percentage': dbus.Double(percentage, variant_level=1),
-                       'TimeToEmpty': dbus.Int64(seconds_to_empty, variant_level=1),
-                       'EnergyFull': dbus.Double(100.0, variant_level=1),
-                       'Energy': dbus.Double(percentage, variant_level=1),
-                       # UP_DEVICE_STATE_DISCHARGING
-                       'State': dbus.UInt32(2, variant_level=1),
-                       # UP_DEVICE_KIND_BATTERY
-                       'Type': dbus.UInt32(2, variant_level=1),
-                   },
-                   [])
-    self.EmitSignal(MAIN_IFACE, 'DeviceAdded', 'o', [path])
+    """
+    path = "/org/freedesktop/UPower/devices/" + device_name
+    self.AddObject(
+        path,
+        DEVICE_IFACE,
+        {
+            "PowerSupply": dbus.Boolean(True, variant_level=1),
+            "IsPresent": dbus.Boolean(True, variant_level=1),
+            "Model": dbus.String(model_name, variant_level=1),
+            "Percentage": dbus.Double(percentage, variant_level=1),
+            "TimeToEmpty": dbus.Int64(seconds_to_empty, variant_level=1),
+            "EnergyFull": dbus.Double(100.0, variant_level=1),
+            "Energy": dbus.Double(percentage, variant_level=1),
+            # UP_DEVICE_STATE_DISCHARGING
+            "State": dbus.UInt32(2, variant_level=1),
+            # UP_DEVICE_KIND_BATTERY
+            "Type": dbus.UInt32(2, variant_level=1),
+        },
+        [],
+    )
+    self.EmitSignal(MAIN_IFACE, "DeviceAdded", "o", [path])
     return path
 
 
-@dbus.service.method(MOCK_IFACE,
-                     in_signature='ssdx', out_signature='s')
+@dbus.service.method(MOCK_IFACE, in_signature="ssdx", out_signature="s")
 def AddChargingBattery(self, device_name, model_name, percentage, seconds_to_full):
-    '''Convenience method to add a charging battery object
+    """Convenience method to add a charging battery object
 
     You have to specify a device name which must be a valid part of an object
     path, e. g. "mock_ac", an arbitrary model name, the charge percentage, and
@@ -153,72 +169,74 @@ def AddChargingBattery(self, device_name, model_name, percentage, seconds_to_ful
     "on-battery".
 
     Returns the new object path.
-    '''
-    path = '/org/freedesktop/UPower/devices/' + device_name
-    self.AddObject(path,
-                   DEVICE_IFACE,
-                   {
-                       'PowerSupply': dbus.Boolean(True, variant_level=1),
-                       'IsPresent': dbus.Boolean(True, variant_level=1),
-                       'Model': dbus.String(model_name, variant_level=1),
-                       'Percentage': dbus.Double(percentage, variant_level=1),
-                       'TimeToFull': dbus.Int64(seconds_to_full, variant_level=1),
-                       'EnergyFull': dbus.Double(100.0, variant_level=1),
-                       'Energy': dbus.Double(percentage, variant_level=1),
-                       # UP_DEVICE_STATE_CHARGING
-                       'State': dbus.UInt32(1, variant_level=1),
-                       # UP_DEVICE_KIND_BATTERY
-                       'Type': dbus.UInt32(2, variant_level=1),
-                   },
-                   [])
-    self.EmitSignal(MAIN_IFACE, 'DeviceAdded', 'o', [path])
+    """
+    path = "/org/freedesktop/UPower/devices/" + device_name
+    self.AddObject(
+        path,
+        DEVICE_IFACE,
+        {
+            "PowerSupply": dbus.Boolean(True, variant_level=1),
+            "IsPresent": dbus.Boolean(True, variant_level=1),
+            "Model": dbus.String(model_name, variant_level=1),
+            "Percentage": dbus.Double(percentage, variant_level=1),
+            "TimeToFull": dbus.Int64(seconds_to_full, variant_level=1),
+            "EnergyFull": dbus.Double(100.0, variant_level=1),
+            "Energy": dbus.Double(percentage, variant_level=1),
+            # UP_DEVICE_STATE_CHARGING
+            "State": dbus.UInt32(1, variant_level=1),
+            # UP_DEVICE_KIND_BATTERY
+            "Type": dbus.UInt32(2, variant_level=1),
+        },
+        [],
+    )
+    self.EmitSignal(MAIN_IFACE, "DeviceAdded", "o", [path])
     return path
 
 
-@dbus.service.method(MOCK_IFACE,
-                     in_signature='uuddddxxbsu', out_signature='')
-def SetupDisplayDevice(self, _type, state, percentage, energy, energy_full,
-                       energy_rate, time_to_empty, time_to_full, is_present,
-                       icon_name, warning_level):
-    '''Convenience method to configure DisplayDevice properties
+@dbus.service.method(MOCK_IFACE, in_signature="uuddddxxbsu", out_signature="")
+def SetupDisplayDevice(
+    self,
+    _type,
+    state,
+    percentage,
+    energy,
+    energy_full,
+    energy_rate,
+    time_to_empty,
+    time_to_full,
+    is_present,
+    icon_name,
+    warning_level,
+):
+    """Convenience method to configure DisplayDevice properties
 
     This calls Set() for all properties that the DisplayDevice is defined to
     have, and is shorter if you have to completely set it up instead of
     changing just one or two properties.
-    '''
+    """
     display_props = mockobject.objects[self.p_display_dev]
-    display_props.Set(DEVICE_IFACE, 'Type',
-                      dbus.UInt32(_type))
-    display_props.Set(DEVICE_IFACE, 'State',
-                      dbus.UInt32(state))
-    display_props.Set(DEVICE_IFACE, 'Percentage',
-                      percentage)
-    display_props.Set(DEVICE_IFACE, 'Energy', energy)
-    display_props.Set(DEVICE_IFACE, 'EnergyFull',
-                      energy_full)
-    display_props.Set(DEVICE_IFACE, 'EnergyRate',
-                      energy_rate)
-    display_props.Set(DEVICE_IFACE, 'TimeToEmpty',
-                      dbus.Int64(time_to_empty))
-    display_props.Set(DEVICE_IFACE, 'TimeToFull',
-                      dbus.Int64(time_to_full))
-    display_props.Set(DEVICE_IFACE, 'IsPresent',
-                      is_present)
-    display_props.Set(DEVICE_IFACE, 'IconName',
-                      icon_name)
-    display_props.Set(DEVICE_IFACE, 'WarningLevel',
-                      dbus.UInt32(warning_level))
+    display_props.Set(DEVICE_IFACE, "Type", dbus.UInt32(_type))
+    display_props.Set(DEVICE_IFACE, "State", dbus.UInt32(state))
+    display_props.Set(DEVICE_IFACE, "Percentage", percentage)
+    display_props.Set(DEVICE_IFACE, "Energy", energy)
+    display_props.Set(DEVICE_IFACE, "EnergyFull", energy_full)
+    display_props.Set(DEVICE_IFACE, "EnergyRate", energy_rate)
+    display_props.Set(DEVICE_IFACE, "TimeToEmpty", dbus.Int64(time_to_empty))
+    display_props.Set(DEVICE_IFACE, "TimeToFull", dbus.Int64(time_to_full))
+    display_props.Set(DEVICE_IFACE, "IsPresent", is_present)
+    display_props.Set(DEVICE_IFACE, "IconName", icon_name)
+    display_props.Set(DEVICE_IFACE, "WarningLevel", dbus.UInt32(warning_level))
 
 
-@dbus.service.method(MOCK_IFACE, in_signature='oa{sv}', out_signature='')
+@dbus.service.method(MOCK_IFACE, in_signature="oa{sv}", out_signature="")
 def SetDeviceProperties(_self, object_path, properties):
-    '''Convenience method to Set a device's properties.
+    """Convenience method to Set a device's properties.
 
     object_path: the device to update
     properties: dictionary of keys to dbus variants.
 
     Changing this property will trigger the device's PropertiesChanged signal.
-    '''
+    """
     device = dbusmock.get_object(object_path)
 
     # set the properties
@@ -226,8 +244,7 @@ def SetDeviceProperties(_self, object_path, properties):
         device.Set(DEVICE_IFACE, key, value)
 
 
-@dbus.service.method(MOCK_IFACE,
-                     in_signature='o', out_signature='')
+@dbus.service.method(MOCK_IFACE, in_signature="o", out_signature="")
 def RemoveDevice(self, device_path):
     self.RemoveObject(device_path)
-    self.EmitSignal(MAIN_IFACE, 'DeviceRemoved', 'o', [device_path])
+    self.EmitSignal(MAIN_IFACE, "DeviceRemoved", "o", [device_path])

--- a/dbusmock/templates/urfkill.py
+++ b/dbusmock/templates/urfkill.py
@@ -1,9 +1,9 @@
-'''urfkill mock template
+"""urfkill mock template
 
 This creates the expected methods and properties of the main
 urfkill object, but no devices. You can specify any property
 such as urfkill in "parameters".
-'''
+"""
 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -11,31 +11,31 @@ such as urfkill in "parameters".
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Jussi Pakkanen'
-__copyright__ = '''
+__author__ = "Jussi Pakkanen"
+__copyright__ = """
 (C) 2015 Canonical ltd
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 import dbus
 
 import dbusmock
 
 SYSTEM_BUS = True
-BUS_NAME = 'org.freedesktop.URfkill'
-MAIN_OBJ = '/org/freedesktop/URfkill'
+BUS_NAME = "org.freedesktop.URfkill"
+MAIN_OBJ = "/org/freedesktop/URfkill"
 
-MAIN_IFACE = 'org.freedesktop.URfkill'
+MAIN_IFACE = "org.freedesktop.URfkill"
 
-individual_objects = ['BLUETOOTH', 'FM', 'GPS', 'NFC', 'UWB', 'WIMAX', 'WLAN', 'WWAN']
+individual_objects = ["BLUETOOTH", "FM", "GPS", "NFC", "UWB", "WIMAX", "WLAN", "WWAN"]
 type2objectname = {
-    1: 'WLAN',
-    2: 'BLUETOOTH',
-    3: 'UWB',
-    4: 'WIMAX',
-    5: 'WWAN',
-    6: 'GPS',
-    7: 'FM',
+    1: "WLAN",
+    2: "BLUETOOTH",
+    3: "UWB",
+    4: "WIMAX",
+    5: "WWAN",
+    6: "GPS",
+    7: "FM",
 }
 
 KS_NOTAVAILABLE = -1
@@ -53,15 +53,15 @@ def toggle_flight_mode(self, new_block_state):
         old_value = self.internal_states[i]
         if old_value == 1:
             continue  # It was already blocked so we don't need to do anything
-        path = '/org/freedesktop/URfkill/' + i
+        path = "/org/freedesktop/URfkill/" + i
         obj = dbusmock.get_object(path)
         if new_block_state:
-            obj.Set('org.freedesktop.URfkill.Killswitch', 'state', 1)
-            obj.EmitSignal('org.freedesktop.URfkill.Killswitch', 'StateChanged', '', [])
+            obj.Set("org.freedesktop.URfkill.Killswitch", "state", 1)
+            obj.EmitSignal("org.freedesktop.URfkill.Killswitch", "StateChanged", "", [])
         else:
-            obj.Set('org.freedesktop.URfkill.Killswitch', 'state', 0)
-            obj.EmitSignal('org.freedesktop.URfkill.Killswitch', 'StateChanged', '', [])
-    self.EmitSignal(MAIN_IFACE, 'FlightModeChanged', 'b', [self.flight_mode])
+            obj.Set("org.freedesktop.URfkill.Killswitch", "state", 0)
+            obj.EmitSignal("org.freedesktop.URfkill.Killswitch", "StateChanged", "", [])
+    self.EmitSignal(MAIN_IFACE, "FlightModeChanged", "b", [self.flight_mode])
     return True
 
 
@@ -72,11 +72,11 @@ def block(self, index, should_block):
     objname = type2objectname[index]
     new_block_state = 1 if should_block else 0
     if self.internal_states[objname] != new_block_state:
-        path = '/org/freedesktop/URfkill/' + objname
+        path = "/org/freedesktop/URfkill/" + objname
         obj = dbusmock.get_object(path)
         self.internal_states[objname] = new_block_state
-        obj.Set('org.freedesktop.URfkill.Killswitch', 'state', new_block_state)
-        obj.EmitSignal('org.freedesktop.URfkill.Killswitch', 'StateChanged', '', [])
+        obj.Set("org.freedesktop.URfkill.Killswitch", "state", new_block_state)
+        obj.EmitSignal("org.freedesktop.URfkill.Killswitch", "StateChanged", "", [])
     return True
 
 
@@ -89,18 +89,26 @@ def load(mock, parameters):
         mock.internal_states[oname] = KS_UNBLOCKED
 
     # First we create the main urfkill object.
-    mock.AddMethods(MAIN_IFACE, [
-        ('IsFlightMode', '', 'b', 'ret = self.flight_mode'),
-        ('FlightMode', 'b', 'b', 'ret = self.toggle_flight_mode(self, args[0])'),
-        ('Block', 'ub', 'b', 'ret = self.block(self, args[0], args[1])'),
-    ])
+    mock.AddMethods(
+        MAIN_IFACE,
+        [
+            ("IsFlightMode", "", "b", "ret = self.flight_mode"),
+            ("FlightMode", "b", "b", "ret = self.toggle_flight_mode(self, args[0])"),
+            ("Block", "ub", "b", "ret = self.block(self, args[0], args[1])"),
+        ],
+    )
 
-    mock.AddProperties(MAIN_IFACE,
-                       dbus.Dictionary({
-                           'DaemonVersion': parameters.get('DaemonVersion', '0.6.0'),
-                           'KeyControl': parameters.get('KeyControl', True)
-                       }, signature='sv'))
+    mock.AddProperties(
+        MAIN_IFACE,
+        dbus.Dictionary(
+            {
+                "DaemonVersion": parameters.get("DaemonVersion", "0.6.0"),
+                "KeyControl": parameters.get("KeyControl", True),
+            },
+            signature="sv",
+        ),
+    )
 
     for i in individual_objects:
-        path = '/org/freedesktop/URfkill/' + i
-        mock.AddObject(path, 'org.freedesktop.URfkill.Killswitch', {'state': mock.internal_states[i]}, [])
+        path = "/org/freedesktop/URfkill/" + i
+        mock.AddObject(path, "org.freedesktop.URfkill.Killswitch", {"state": mock.internal_states[i]}, [])

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -6,44 +6,51 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'python-dbusmock'
-copyright = '2023, Martin Pitt'  # noqa: A001
-author = 'Martin Pitt'
+project = "python-dbusmock"
+copyright = "2023, Martin Pitt"  # noqa: A001
+author = "Martin Pitt"
 
 try:
     # created by setuptools_scm
     from dbusmock._version import __version__ as release
 except ImportError:
-    release = '0.git'
+    release = "0.git"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.napoleon',
-    'myst_parser',
-    'autoapi.extension',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.napoleon",
+    "myst_parser",
+    "autoapi.extension",
 ]
 
-templates_path = ['_templates']
+templates_path = ["_templates"]
 exclude_patterns = []
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'sphinx_rtd_theme'
-html_static_path = ['_static']
+html_theme = "sphinx_rtd_theme"
+html_static_path = ["_static"]
 
 
-apidoc_module_dir = '../dbusmock'
-apidoc_output_dir = '.'
+apidoc_module_dir = "../dbusmock"
+apidoc_output_dir = "."
 apidoc_separate_modules = True
-apidoc_excluded_paths = ['tests']
+apidoc_excluded_paths = ["tests"]
 
-autoapi_dirs = ['../dbusmock']
-autoapi_type = 'python'
-autoapi_member_order = 'bysource'
-autoapi_options = ['members', 'undoc-members', 'show-inheritance', 'show-module-summary', 'special-members', 'imported-members']
+autoapi_dirs = ["../dbusmock"]
+autoapi_type = "python"
+autoapi_member_order = "bysource"
+autoapi_options = [
+    "members",
+    "undoc-members",
+    "show-inheritance",
+    "show-module-summary",
+    "special-members",
+    "imported-members",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,3 +88,6 @@ ignore = [
     "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar`
     "SIM105", # Use `contextlib.suppress(KeyError)` instead of `try`-`except`-`pass`
 ]
+
+[tool.black]
+line-length = 118

--- a/tests/run-fedora
+++ b/tests/run-fedora
@@ -10,7 +10,7 @@ if ! grep -q :el /etc/os-release; then
 fi
 
 if [ "$SKIP_STATIC_CHECKS" != "1" ]; then
-    dnf -y install python3-pylint python3-mypy python3-pip
+    dnf -y install python3-pylint python3-mypy python3-pip black
     pip install ruff
 fi
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,11 +4,11 @@
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Martin Pitt'
-__copyright__ = '''
+__author__ = "Martin Pitt"
+__copyright__ = """
 (c) 2012 Canonical Ltd.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 import importlib.util
 import os
@@ -31,11 +31,11 @@ tracemalloc.start(25)
 dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
 
 # "a <heart> b" in py2/3 compatible unicode
-UNICODE = b'a\xe2\x99\xa5b'.decode('UTF-8')
+UNICODE = b"a\xe2\x99\xa5b".decode("UTF-8")
 
 
 class TestAPI(dbusmock.DBusTestCase):
-    '''Test dbus-mock API'''
+    """Test dbus-mock API"""
 
     @classmethod
     def setUpClass(cls):
@@ -45,18 +45,17 @@ class TestAPI(dbusmock.DBusTestCase):
     def setUp(self):
         # pylint: disable=consider-using-with
         self.mock_log = tempfile.NamedTemporaryFile()
-        self.p_mock = self.spawn_server('org.freedesktop.Test',
-                                        '/',
-                                        'org.freedesktop.Test.Main',
-                                        stdout=self.mock_log)
+        self.p_mock = self.spawn_server(
+            "org.freedesktop.Test", "/", "org.freedesktop.Test.Main", stdout=self.mock_log
+        )
 
-        self.obj_test = self.dbus_con.get_object('org.freedesktop.Test', '/')
-        self.dbus_test = dbus.Interface(self.obj_test, 'org.freedesktop.Test.Main')
+        self.obj_test = self.dbus_con.get_object("org.freedesktop.Test", "/")
+        self.dbus_test = dbus.Interface(self.obj_test, "org.freedesktop.Test.Main")
         self.dbus_mock = dbus.Interface(self.obj_test, dbusmock.MOCK_IFACE)
         self.dbus_props = dbus.Interface(self.obj_test, dbus.PROPERTIES_IFACE)
 
     def assertLog(self, regex):
-        self.assertRegex(Path(self.mock_log.name,).read_bytes(), regex)
+        self.assertRegex(Path(self.mock_log.name).read_bytes(), regex)
 
     def tearDown(self):
         if self.p_mock.stdout:
@@ -65,347 +64,334 @@ class TestAPI(dbusmock.DBusTestCase):
         self.p_mock.wait()
 
     def test_noarg_noret(self):
-        '''no arguments, no return value'''
+        """no arguments, no return value"""
 
-        self.dbus_mock.AddMethod('', 'Do', '', '', '')
+        self.dbus_mock.AddMethod("", "Do", "", "", "")
         self.assertEqual(self.dbus_test.Do(), None)
 
         # check that it's logged correctly
-        self.assertLog(b'^[0-9.]+ Do$')
+        self.assertLog(b"^[0-9.]+ Do$")
 
     def test_onearg_noret(self):
-        '''one argument, no return value'''
+        """one argument, no return value"""
 
-        self.dbus_mock.AddMethod('', 'Do', 's', '', '')
-        self.assertEqual(self.dbus_test.Do('Hello'), None)
+        self.dbus_mock.AddMethod("", "Do", "s", "", "")
+        self.assertEqual(self.dbus_test.Do("Hello"), None)
 
         # check that it's logged correctly
         self.assertLog(b'^[0-9.]+ Do "Hello"$')
 
     def test_onearg_ret(self):
-        '''one argument, code for return value'''
+        """one argument, code for return value"""
 
-        self.dbus_mock.AddMethod('', 'Do', 's', 's', 'ret = args[0]')
-        self.assertEqual(self.dbus_test.Do('Hello'), 'Hello')
+        self.dbus_mock.AddMethod("", "Do", "s", "s", "ret = args[0]")
+        self.assertEqual(self.dbus_test.Do("Hello"), "Hello")
 
     def test_unicode_str(self):
-        '''unicode string roundtrip'''
+        """unicode string roundtrip"""
 
-        self.dbus_mock.AddMethod('', 'Do', 's', 's', 'ret = args[0] * 2')
+        self.dbus_mock.AddMethod("", "Do", "s", "s", "ret = args[0] * 2")
         self.assertEqual(self.dbus_test.Do(UNICODE), dbus.String(UNICODE * 2))
 
     def test_twoarg_ret(self):
-        '''two arguments, code for return value'''
+        """two arguments, code for return value"""
 
-        self.dbus_mock.AddMethod('', 'Do', 'si', 's', 'ret = args[0] * args[1]')
-        self.assertEqual(self.dbus_test.Do('foo', 3), 'foofoofoo')
+        self.dbus_mock.AddMethod("", "Do", "si", "s", "ret = args[0] * args[1]")
+        self.assertEqual(self.dbus_test.Do("foo", 3), "foofoofoo")
 
         # check that it's logged correctly
         self.assertLog(b'^[0-9.]+ Do "foo" 3$')
 
     def test_array_arg(self):
-        '''array argument'''
+        """array argument"""
 
-        self.dbus_mock.AddMethod('', 'Do', 'iaous', '',
-                                 f'''assert len(args) == 4
+        self.dbus_mock.AddMethod(
+            "",
+            "Do",
+            "iaous",
+            "",
+            f"""assert len(args) == 4
 assert args[0] == -1;
 assert args[1] == ['/foo']
 assert type(args[1]) == dbus.Array
 assert type(args[1][0]) == dbus.ObjectPath
 assert args[2] == 5
 assert args[3] == {UNICODE!r}
-''')
-        self.assertEqual(self.dbus_test.Do(-1, ['/foo'], 5, UNICODE), None)
+""",
+        )
+        self.assertEqual(self.dbus_test.Do(-1, ["/foo"], 5, UNICODE), None)
 
         # check that it's logged correctly
         self.assertLog(b'^[0-9.]+ Do -1 \\["/foo"\\] 5 "a\\xe2\\x99\\xa5b"$')
 
     def test_dict_arg(self):
-        '''dictionary argument'''
+        """dictionary argument"""
 
-        self.dbus_mock.AddMethod('', 'Do', 'ia{si}u', '',
-                                 '''assert len(args) == 3
+        self.dbus_mock.AddMethod(
+            "",
+            "Do",
+            "ia{si}u",
+            "",
+            """assert len(args) == 3
 assert args[0] == -1;
 assert args[1] == {'foo': 42}
 assert type(args[1]) == dbus.Dictionary
 assert args[2] == 5
-''')
-        self.assertEqual(self.dbus_test.Do(-1, {'foo': 42}, 5), None)
+""",
+        )
+        self.assertEqual(self.dbus_test.Do(-1, {"foo": 42}, 5), None)
 
         # check that it's logged correctly
         self.assertLog(b'^[0-9.]+ Do -1 {"foo": 42} 5$')
 
     def test_multi_output(self):
-        '''multiple output values'''
+        """multiple output values"""
 
-        self.dbus_mock.AddMethod('', 'AddSub', 'ii', 'ii', 'ret = (args[0] + args[1], args[0] - args[1])')
+        self.dbus_mock.AddMethod("", "AddSub", "ii", "ii", "ret = (args[0] + args[1], args[0] - args[1])")
         self.assertEqual(self.dbus_test.AddSub(3, 5), (8, -2))
 
     def test_exception(self):
-        '''raise a D-Bus exception'''
+        """raise a D-Bus exception"""
 
-        self.dbus_mock.AddMethod('', 'Do', '', 'i',
-                                 'raise dbus.exceptions.DBusException("no good", name="com.example.Error.NoGood")')
+        self.dbus_mock.AddMethod(
+            "", "Do", "", "i", 'raise dbus.exceptions.DBusException("no good", name="com.example.Error.NoGood")'
+        )
         with self.assertRaises(dbus.exceptions.DBusException) as cm:
             self.dbus_test.Do()
-        self.assertEqual(cm.exception.get_dbus_name(), 'com.example.Error.NoGood')
-        self.assertEqual(cm.exception.get_dbus_message(), 'no good')
-        self.assertLog(b'\n[0-9.]+ Do raised: com.example.Error.NoGood:.*\n')
+        self.assertEqual(cm.exception.get_dbus_name(), "com.example.Error.NoGood")
+        self.assertEqual(cm.exception.get_dbus_message(), "no good")
+        self.assertLog(b"\n[0-9.]+ Do raised: com.example.Error.NoGood:.*\n")
 
     def test_methods_on_other_interfaces(self):
-        '''methods on other interfaces'''
+        """methods on other interfaces"""
 
-        self.dbus_mock.AddMethod('org.freedesktop.Test.Other', 'OtherDo', '', '', '')
-        self.dbus_mock.AddMethods('org.freedesktop.Test.Other',
-                                  [('OtherDo2', '', '', ''),
-                                   ('OtherDo3', 'i', 'i', 'ret = args[0]')])
+        self.dbus_mock.AddMethod("org.freedesktop.Test.Other", "OtherDo", "", "", "")
+        self.dbus_mock.AddMethods(
+            "org.freedesktop.Test.Other", [("OtherDo2", "", "", ""), ("OtherDo3", "i", "i", "ret = args[0]")]
+        )
 
         # should not be on the main interface
-        self.assertRaises(dbus.exceptions.DBusException,
-                          self.dbus_test.OtherDo)
+        self.assertRaises(dbus.exceptions.DBusException, self.dbus_test.OtherDo)
 
         # should be on the other interface
-        self.assertEqual(self.obj_test.OtherDo(dbus_interface='org.freedesktop.Test.Other'), None)
-        self.assertEqual(self.obj_test.OtherDo2(dbus_interface='org.freedesktop.Test.Other'), None)
-        self.assertEqual(self.obj_test.OtherDo3(42, dbus_interface='org.freedesktop.Test.Other'), 42)
+        self.assertEqual(self.obj_test.OtherDo(dbus_interface="org.freedesktop.Test.Other"), None)
+        self.assertEqual(self.obj_test.OtherDo2(dbus_interface="org.freedesktop.Test.Other"), None)
+        self.assertEqual(self.obj_test.OtherDo3(42, dbus_interface="org.freedesktop.Test.Other"), 42)
 
         # check that it's logged correctly
-        self.assertLog(b'^[0-9.]+ OtherDo\n[0-9.]+ OtherDo2\n[0-9.]+ OtherDo3 42$')
+        self.assertLog(b"^[0-9.]+ OtherDo\n[0-9.]+ OtherDo2\n[0-9.]+ OtherDo3 42$")
 
     def test_methods_same_name(self):
-        '''methods with same name on different interfaces'''
+        """methods with same name on different interfaces"""
 
-        self.dbus_mock.AddMethod('org.iface1', 'Do', 'i', 'i', 'ret = args[0] + 2')
-        self.dbus_mock.AddMethod('org.iface2', 'Do', 'i', 'i', 'ret = args[0] + 3')
+        self.dbus_mock.AddMethod("org.iface1", "Do", "i", "i", "ret = args[0] + 2")
+        self.dbus_mock.AddMethod("org.iface2", "Do", "i", "i", "ret = args[0] + 3")
 
         # should not be on the main interface
-        self.assertRaises(dbus.exceptions.DBusException,
-                          self.dbus_test.Do)
+        self.assertRaises(dbus.exceptions.DBusException, self.dbus_test.Do)
 
         # should be on the other interface
-        self.assertEqual(self.obj_test.Do(10, dbus_interface='org.iface1'), 12)
-        self.assertEqual(self.obj_test.Do(11, dbus_interface='org.iface2'), 14)
+        self.assertEqual(self.obj_test.Do(10, dbus_interface="org.iface1"), 12)
+        self.assertEqual(self.obj_test.Do(11, dbus_interface="org.iface2"), 14)
 
         # check that it's logged correctly
-        self.assertLog(b'^[0-9.]+ Do 10\n[0-9.]+ Do 11$')
+        self.assertLog(b"^[0-9.]+ Do 10\n[0-9.]+ Do 11$")
 
         # now add it to the primary interface, too
-        self.dbus_mock.AddMethod('', 'Do', 'i', 'i', 'ret = args[0] + 1')
-        self.assertEqual(self.obj_test.Do(9, dbus_interface='org.freedesktop.Test.Main'), 10)
-        self.assertEqual(self.obj_test.Do(10, dbus_interface='org.iface1'), 12)
-        self.assertEqual(self.obj_test.Do(11, dbus_interface='org.iface2'), 14)
+        self.dbus_mock.AddMethod("", "Do", "i", "i", "ret = args[0] + 1")
+        self.assertEqual(self.obj_test.Do(9, dbus_interface="org.freedesktop.Test.Main"), 10)
+        self.assertEqual(self.obj_test.Do(10, dbus_interface="org.iface1"), 12)
+        self.assertEqual(self.obj_test.Do(11, dbus_interface="org.iface2"), 14)
 
     def test_methods_type_mismatch(self):
-        '''calling methods with wrong arguments'''
+        """calling methods with wrong arguments"""
 
         def check(signature, args, err):
-            self.dbus_mock.AddMethod('', 'Do', signature, '', '')
+            self.dbus_mock.AddMethod("", "Do", signature, "", "")
             try:
                 self.dbus_test.Do(*args)
                 self.fail(f'method call did not raise an error for signature "{signature}" and arguments {args}')
             except dbus.exceptions.DBusException as e:
-                self.assertEqual(e.get_dbus_name(), 'org.freedesktop.DBus.Error.InvalidArgs')
+                self.assertEqual(e.get_dbus_name(), "org.freedesktop.DBus.Error.InvalidArgs")
                 self.assertIn(err, str(e))
 
         # not enough arguments
-        check('i', [], 'More items found')
-        check('is', [1], 'More items found')
+        check("i", [], "More items found")
+        check("is", [1], "More items found")
 
         # too many arguments
-        check('', [1], 'Fewer items found')
-        check('i', [1, 'hello'], 'Fewer items found')
+        check("", [1], "Fewer items found")
+        check("i", [1, "hello"], "Fewer items found")
 
         # type mismatch
-        check('u', [-1], 'convert negative value to unsigned')
-        check('i', ['hello'], 'dbus.String')
-        check('i', ['hello'], 'integer')
-        check('s', [1], 'Expected a string')
+        check("u", [-1], "convert negative value to unsigned")
+        check("i", ["hello"], "dbus.String")
+        check("i", ["hello"], "integer")
+        check("s", [1], "Expected a string")
 
     def test_add_object(self):
-        '''add a new object'''
+        """add a new object"""
 
-        self.dbus_mock.AddObject('/obj1',
-                                 'org.freedesktop.Test.Sub',
-                                 {
-                                     'state': dbus.String('online', variant_level=1),
-                                     'cute': dbus.Boolean(True, variant_level=1),
-                                 },
-                                 [])
+        self.dbus_mock.AddObject(
+            "/obj1",
+            "org.freedesktop.Test.Sub",
+            {
+                "state": dbus.String("online", variant_level=1),
+                "cute": dbus.Boolean(True, variant_level=1),
+            },
+            [],
+        )
 
-        obj1 = self.dbus_con.get_object('org.freedesktop.Test', '/obj1')
-        dbus_sub = dbus.Interface(obj1, 'org.freedesktop.Test.Sub')
+        obj1 = self.dbus_con.get_object("org.freedesktop.Test", "/obj1")
+        dbus_sub = dbus.Interface(obj1, "org.freedesktop.Test.Sub")
         dbus_props = dbus.Interface(obj1, dbus.PROPERTIES_IFACE)
 
         # check properties
-        self.assertEqual(dbus_props.Get('org.freedesktop.Test.Sub', 'state'), 'online')
-        self.assertEqual(dbus_props.Get('org.freedesktop.Test.Sub', 'cute'), True)
-        self.assertEqual(dbus_props.GetAll('org.freedesktop.Test.Sub'),
-                         {'state': 'online', 'cute': True})
+        self.assertEqual(dbus_props.Get("org.freedesktop.Test.Sub", "state"), "online")
+        self.assertEqual(dbus_props.Get("org.freedesktop.Test.Sub", "cute"), True)
+        self.assertEqual(dbus_props.GetAll("org.freedesktop.Test.Sub"), {"state": "online", "cute": True})
 
         # add new method
-        obj1.AddMethod('', 'Do', '', 's', 'ret = "hello"',
-                       dbus_interface=dbusmock.MOCK_IFACE)
-        self.assertEqual(dbus_sub.Do(), 'hello')
+        obj1.AddMethod("", "Do", "", "s", 'ret = "hello"', dbus_interface=dbusmock.MOCK_IFACE)
+        self.assertEqual(dbus_sub.Do(), "hello")
 
     def test_add_object_existing(self):
-        '''try to add an existing object'''
+        """try to add an existing object"""
 
-        self.dbus_mock.AddObject('/obj1', 'org.freedesktop.Test.Sub', {}, [])
+        self.dbus_mock.AddObject("/obj1", "org.freedesktop.Test.Sub", {}, [])
 
-        self.assertRaises(dbus.exceptions.DBusException,
-                          self.dbus_mock.AddObject,
-                          '/obj1',
-                          'org.freedesktop.Test.Sub',
-                          {},
-                          [])
+        self.assertRaises(
+            dbus.exceptions.DBusException, self.dbus_mock.AddObject, "/obj1", "org.freedesktop.Test.Sub", {}, []
+        )
 
         # try to add the main object again
-        self.assertRaises(dbus.exceptions.DBusException,
-                          self.dbus_mock.AddObject,
-                          '/',
-                          'org.freedesktop.Test.Other',
-                          {},
-                          [])
+        self.assertRaises(
+            dbus.exceptions.DBusException, self.dbus_mock.AddObject, "/", "org.freedesktop.Test.Other", {}, []
+        )
 
     def test_add_object_with_methods(self):
-        '''add a new object with methods'''
+        """add a new object with methods"""
 
-        self.dbus_mock.AddObject('/obj1',
-                                 'org.freedesktop.Test.Sub',
-                                 {
-                                     'state': dbus.String('online', variant_level=1),
-                                     'cute': dbus.Boolean(True, variant_level=1),
-                                 },
-                                 [
-                                     ('Do0', '', 'i', 'ret = 42'),
-                                     ('Do1', 'i', 'i', 'ret = 31337'),
-                                 ])
+        self.dbus_mock.AddObject(
+            "/obj1",
+            "org.freedesktop.Test.Sub",
+            {
+                "state": dbus.String("online", variant_level=1),
+                "cute": dbus.Boolean(True, variant_level=1),
+            },
+            [
+                ("Do0", "", "i", "ret = 42"),
+                ("Do1", "i", "i", "ret = 31337"),
+            ],
+        )
 
-        obj1 = self.dbus_con.get_object('org.freedesktop.Test', '/obj1')
+        obj1 = self.dbus_con.get_object("org.freedesktop.Test", "/obj1")
 
         self.assertEqual(obj1.Do0(), 42)
         self.assertEqual(obj1.Do1(1), 31337)
-        self.assertRaises(dbus.exceptions.DBusException,
-                          obj1.Do2, 31337)
+        self.assertRaises(dbus.exceptions.DBusException, obj1.Do2, 31337)
 
     def test_properties(self):
-        '''add and change properties'''
+        """add and change properties"""
 
         # no properties by default
-        self.assertEqual(self.dbus_props.GetAll('org.freedesktop.Test.Main'), {})
+        self.assertEqual(self.dbus_props.GetAll("org.freedesktop.Test.Main"), {})
 
         # no such property
         with self.assertRaises(dbus.exceptions.DBusException) as ctx:
-            self.dbus_props.Get('org.freedesktop.Test.Main', 'version')
-        self.assertEqual(ctx.exception.get_dbus_name(),
-                         'org.freedesktop.Test.Main.UnknownProperty')
-        self.assertEqual(ctx.exception.get_dbus_message(),
-                         'no such property version')
+            self.dbus_props.Get("org.freedesktop.Test.Main", "version")
+        self.assertEqual(ctx.exception.get_dbus_name(), "org.freedesktop.Test.Main.UnknownProperty")
+        self.assertEqual(ctx.exception.get_dbus_message(), "no such property version")
 
-        self.assertRaises(dbus.exceptions.DBusException,
-                          self.dbus_props.Set,
-                          'org.freedesktop.Test.Main',
-                          'version',
-                          dbus.Int32(2, variant_level=1))
+        self.assertRaises(
+            dbus.exceptions.DBusException,
+            self.dbus_props.Set,
+            "org.freedesktop.Test.Main",
+            "version",
+            dbus.Int32(2, variant_level=1),
+        )
 
-        self.dbus_mock.AddProperty('org.freedesktop.Test.Main',
-                                   'version',
-                                   dbus.Int32(2, variant_level=1))
+        self.dbus_mock.AddProperty("org.freedesktop.Test.Main", "version", dbus.Int32(2, variant_level=1))
         # once again on default interface
-        self.dbus_mock.AddProperty('',
-                                   'connected',
-                                   dbus.Boolean(True, variant_level=1))
+        self.dbus_mock.AddProperty("", "connected", dbus.Boolean(True, variant_level=1))
 
-        self.assertEqual(self.dbus_props.Get('org.freedesktop.Test.Main', 'version'), 2)
-        self.assertEqual(self.dbus_props.Get('org.freedesktop.Test.Main', 'connected'), True)
+        self.assertEqual(self.dbus_props.Get("org.freedesktop.Test.Main", "version"), 2)
+        self.assertEqual(self.dbus_props.Get("org.freedesktop.Test.Main", "connected"), True)
 
-        self.assertEqual(self.dbus_props.GetAll('org.freedesktop.Test.Main'),
-                         {'version': 2, 'connected': True})
+        self.assertEqual(self.dbus_props.GetAll("org.freedesktop.Test.Main"), {"version": 2, "connected": True})
 
         with self.assertRaises(dbus.exceptions.DBusException) as ctx:
-            self.dbus_props.GetAll('org.freedesktop.Test.Bogus')
-        self.assertEqual(ctx.exception.get_dbus_name(),
-                         'org.freedesktop.Test.Main.UnknownInterface')
-        self.assertEqual(ctx.exception.get_dbus_message(),
-                         'no such interface org.freedesktop.Test.Bogus')
+            self.dbus_props.GetAll("org.freedesktop.Test.Bogus")
+        self.assertEqual(ctx.exception.get_dbus_name(), "org.freedesktop.Test.Main.UnknownInterface")
+        self.assertEqual(ctx.exception.get_dbus_message(), "no such interface org.freedesktop.Test.Bogus")
 
         # change property
-        self.dbus_props.Set('org.freedesktop.Test.Main', 'version',
-                            dbus.Int32(4, variant_level=1))
-        self.assertEqual(self.dbus_props.Get('org.freedesktop.Test.Main', 'version'), 4)
+        self.dbus_props.Set("org.freedesktop.Test.Main", "version", dbus.Int32(4, variant_level=1))
+        self.assertEqual(self.dbus_props.Get("org.freedesktop.Test.Main", "version"), 4)
 
         # check that the Get/Set calls get logged
         log = Path(self.mock_log.name).read_text("UTF-8")
-        self.assertRegex(log, '\n[0-9.]+ Get / org.freedesktop.Test.Main.version\n')
-        self.assertRegex(log, '\n[0-9.]+ Get / org.freedesktop.Test.Main.connected\n')
-        self.assertRegex(log, '\n[0-9.]+ GetAll / org.freedesktop.Test.Main\n')
-        self.assertRegex(log, '\n[0-9.]+ Set / org.freedesktop.Test.Main.version 4\n')
+        self.assertRegex(log, "\n[0-9.]+ Get / org.freedesktop.Test.Main.version\n")
+        self.assertRegex(log, "\n[0-9.]+ Get / org.freedesktop.Test.Main.connected\n")
+        self.assertRegex(log, "\n[0-9.]+ GetAll / org.freedesktop.Test.Main\n")
+        self.assertRegex(log, "\n[0-9.]+ Set / org.freedesktop.Test.Main.version 4\n")
 
         # add property to different interface
-        self.dbus_mock.AddProperty('org.freedesktop.Test.Other',
-                                   'color',
-                                   dbus.String('yellow', variant_level=1))
+        self.dbus_mock.AddProperty("org.freedesktop.Test.Other", "color", dbus.String("yellow", variant_level=1))
 
-        self.assertEqual(self.dbus_props.GetAll('org.freedesktop.Test.Main'),
-                         {'version': 4, 'connected': True})
-        self.assertEqual(self.dbus_props.GetAll('org.freedesktop.Test.Other'),
-                         {'color': 'yellow'})
-        self.assertEqual(self.dbus_props.Get('org.freedesktop.Test.Other', 'color'),
-                         'yellow')
+        self.assertEqual(self.dbus_props.GetAll("org.freedesktop.Test.Main"), {"version": 4, "connected": True})
+        self.assertEqual(self.dbus_props.GetAll("org.freedesktop.Test.Other"), {"color": "yellow"})
+        self.assertEqual(self.dbus_props.Get("org.freedesktop.Test.Other", "color"), "yellow")
 
         changed_props = []
         ml = GLib.MainLoop()
 
         def catch(*args, **kwargs):
-            if kwargs['interface'] != 'org.freedesktop.DBus.Properties':
+            if kwargs["interface"] != "org.freedesktop.DBus.Properties":
                 return
 
-            self.assertEqual(kwargs['interface'], 'org.freedesktop.DBus.Properties')
-            self.assertEqual(kwargs['member'], 'PropertiesChanged')
+            self.assertEqual(kwargs["interface"], "org.freedesktop.DBus.Properties")
+            self.assertEqual(kwargs["member"], "PropertiesChanged")
 
             [iface, changed, _invalidated] = args
-            self.assertEqual(iface, 'org.freedesktop.Test.Main')
+            self.assertEqual(iface, "org.freedesktop.Test.Main")
 
             changed_props.append(changed)
             ml.quit()
 
-        match = self.dbus_con.add_signal_receiver(catch,
-                                                  interface_keyword='interface',
-                                                  path_keyword='path',
-                                                  member_keyword='member')
+        match = self.dbus_con.add_signal_receiver(
+            catch, interface_keyword="interface", path_keyword="path", member_keyword="member"
+        )
 
         # change property using mock helper
-        self.dbus_mock.UpdateProperties('org.freedesktop.Test.Main', {
-            'version': 5,
-            'connected': False,
-        })
+        self.dbus_mock.UpdateProperties(
+            "org.freedesktop.Test.Main",
+            {
+                "version": 5,
+                "connected": False,
+            },
+        )
 
         GLib.timeout_add(3000, ml.quit)
         ml.run()
 
         match.remove()
 
-        self.assertEqual(self.dbus_props.GetAll('org.freedesktop.Test.Main'),
-                         {'version': 5, 'connected': False})
-        self.assertEqual(changed_props,
-                         [{'version': 5, 'connected': False}])
+        self.assertEqual(self.dbus_props.GetAll("org.freedesktop.Test.Main"), {"version": 5, "connected": False})
+        self.assertEqual(changed_props, [{"version": 5, "connected": False}])
 
         # test adding properties with the array type
-        self.dbus_mock.AddProperty('org.freedesktop.Test.Main',
-                                   'array',
-                                   dbus.Array(['first'], signature='s'))
-        self.assertEqual(self.dbus_props.Get('org.freedesktop.Test.Main', 'array'),
-                         ['first'])
+        self.dbus_mock.AddProperty("org.freedesktop.Test.Main", "array", dbus.Array(["first"], signature="s"))
+        self.assertEqual(self.dbus_props.Get("org.freedesktop.Test.Main", "array"), ["first"])
 
         # test updating properties with the array type
-        self.dbus_mock.UpdateProperties('org.freedesktop.Test.Main',
-                                        {'array': dbus.Array(['second', 'third'],
-                                                             signature='s')})
-        self.assertEqual(self.dbus_props.Get('org.freedesktop.Test.Main', 'array'),
-                         ['second', 'third'])
+        self.dbus_mock.UpdateProperties(
+            "org.freedesktop.Test.Main", {"array": dbus.Array(["second", "third"], signature="s")}
+        )
+        self.assertEqual(self.dbus_props.Get("org.freedesktop.Test.Main", "array"), ["second", "third"])
 
     def test_introspection_methods(self):
-        '''dynamically added methods appear in introspection'''
+        """dynamically added methods appear in introspection"""
 
         dbus_introspect = dbus.Interface(self.obj_test, dbus.INTROSPECTABLE_IFACE)
 
@@ -413,90 +399,91 @@ assert args[2] == 5
         self.assertIn('<interface name="org.freedesktop.DBus.Mock">', xml_empty)
         self.assertIn('<method name="AddMethod">', xml_empty)
 
-        self.dbus_mock.AddMethod('', 'Do', 'saiv', 'i', 'ret = 42')
+        self.dbus_mock.AddMethod("", "Do", "saiv", "i", "ret = 42")
 
         xml_method = dbus_introspect.Introspect()
         self.assertNotEqual(xml_empty, xml_method)
         self.assertIn('<interface name="org.freedesktop.Test.Main">', xml_method)
         # various Python versions use different name vs. type ordering
-        expected1 = '''<method name="Do">
+        expected1 = """<method name="Do">
       <arg direction="in" name="arg1" type="s" />
       <arg direction="in" name="arg2" type="ai" />
       <arg direction="in" name="arg3" type="v" />
       <arg direction="out" type="i" />
-    </method>'''
-        expected2 = '''<method name="Do">
+    </method>"""
+        expected2 = """<method name="Do">
       <arg direction="in" type="s" name="arg1" />
       <arg direction="in" type="ai" name="arg2" />
       <arg direction="in" type="v" name="arg3" />
       <arg direction="out" type="i" />
-    </method>'''
+    </method>"""
         self.assertTrue(expected1 in xml_method or expected2 in xml_method, xml_method)
 
     # properties in introspection are not supported by dbus-python right now
     def test_introspection_properties(self):
-        '''dynamically added properties appear in introspection'''
+        """dynamically added properties appear in introspection"""
 
-        self.dbus_mock.AddProperty('', 'Color', 'yellow')
-        self.dbus_mock.AddProperty('org.freedesktop.Test.Sub', 'Count', 5)
+        self.dbus_mock.AddProperty("", "Color", "yellow")
+        self.dbus_mock.AddProperty("org.freedesktop.Test.Sub", "Count", 5)
 
         xml = self.obj_test.Introspect()
 
         self.assertIn('<interface name="org.freedesktop.Test.Main">', xml)
         self.assertIn('<interface name="org.freedesktop.Test.Sub">', xml)
         # various Python versions use different attribute ordering
-        self.assertTrue('<property access="readwrite" name="Color" type="s" />' in xml or
-                        '<property name="Color" type="s" access="readwrite" />' in xml, xml)
-        self.assertTrue('<property access="readwrite" name="Count" type="i" />' in xml or
-                        '<property name="Count" type="i" access="readwrite" />' in xml, xml)
+        self.assertTrue(
+            '<property access="readwrite" name="Color" type="s" />' in xml
+            or '<property name="Color" type="s" access="readwrite" />' in xml,
+            xml,
+        )
+        self.assertTrue(
+            '<property access="readwrite" name="Count" type="i" />' in xml
+            or '<property name="Count" type="i" access="readwrite" />' in xml,
+            xml,
+        )
 
     def test_objects_map(self):
-        '''access global objects map'''
+        """access global objects map"""
 
-        self.dbus_mock.AddMethod('', 'EnumObjs', '', 'ao', 'ret = objects.keys()')
-        self.assertEqual(self.dbus_test.EnumObjs(), ['/'])
+        self.dbus_mock.AddMethod("", "EnumObjs", "", "ao", "ret = objects.keys()")
+        self.assertEqual(self.dbus_test.EnumObjs(), ["/"])
 
-        self.dbus_mock.AddObject('/obj1', 'org.freedesktop.Test.Sub', {}, [])
-        self.assertEqual(set(self.dbus_test.EnumObjs()), {'/', '/obj1'})
+        self.dbus_mock.AddObject("/obj1", "org.freedesktop.Test.Sub", {}, [])
+        self.assertEqual(set(self.dbus_test.EnumObjs()), {"/", "/obj1"})
 
     def test_signals(self):
-        '''emitting signals'''
+        """emitting signals"""
 
-        self.dbus_mock.AddObject('/obj1', 'org.freedesktop.Test.Sub', {}, [])
+        self.dbus_mock.AddObject("/obj1", "org.freedesktop.Test.Sub", {}, [])
 
         def do_emit():
-            self.dbus_mock.EmitSignal('', 'SigNoArgs', '', [])
-            self.dbus_mock.EmitSignal('org.freedesktop.Test.Sub',
-                                      'SigTwoArgs',
-                                      'su', ['hello', 42])
-            self.dbus_mock.EmitSignal('org.freedesktop.Test.Sub',
-                                      'SigTypeTest',
-                                      'iuvao',
-                                      [-42, 42, dbus.String('hello', variant_level=1), ['/a', '/b']])
-            self.dbus_mock.EmitSignalDetailed('',
-                                              'SigDetailed',
-                                              'su', ['details', 123],
-                                              {'destination': self.dbus_con.get_unique_name()})
-            self.dbus_mock.EmitSignalDetailed('',
-                                              'SigDetailedWithPath',
-                                              'su', ['details', 456],
-                                              {'path': '/obj1'})
+            self.dbus_mock.EmitSignal("", "SigNoArgs", "", [])
+            self.dbus_mock.EmitSignal("org.freedesktop.Test.Sub", "SigTwoArgs", "su", ["hello", 42])
+            self.dbus_mock.EmitSignal(
+                "org.freedesktop.Test.Sub",
+                "SigTypeTest",
+                "iuvao",
+                [-42, 42, dbus.String("hello", variant_level=1), ["/a", "/b"]],
+            )
+            self.dbus_mock.EmitSignalDetailed(
+                "", "SigDetailed", "su", ["details", 123], {"destination": self.dbus_con.get_unique_name()}
+            )
+            self.dbus_mock.EmitSignalDetailed("", "SigDetailedWithPath", "su", ["details", 456], {"path": "/obj1"})
 
         caught = []
         ml = GLib.MainLoop()
 
         def catch(*args, **kwargs):
-            if kwargs['interface'].startswith('org.freedesktop.Test'):
+            if kwargs["interface"].startswith("org.freedesktop.Test"):
                 caught.append((args, kwargs))
             if len(caught) == 5:
                 # we caught everything there is to catch, don't wait for the
                 # timeout
                 ml.quit()
 
-        self.dbus_con.add_signal_receiver(catch,
-                                          interface_keyword='interface',
-                                          path_keyword='path',
-                                          member_keyword='member')
+        self.dbus_con.add_signal_receiver(
+            catch, interface_keyword="interface", path_keyword="path", member_keyword="member"
+        )
 
         GLib.timeout_add(200, do_emit)
         # ensure that the loop quits even when we catch fewer than 2 signals
@@ -505,19 +492,19 @@ assert args[2] == 5
 
         # check SigNoArgs
         self.assertEqual(caught[0][0], ())
-        self.assertEqual(caught[0][1]['member'], 'SigNoArgs')
-        self.assertEqual(caught[0][1]['path'], '/')
-        self.assertEqual(caught[0][1]['interface'], 'org.freedesktop.Test.Main')
+        self.assertEqual(caught[0][1]["member"], "SigNoArgs")
+        self.assertEqual(caught[0][1]["path"], "/")
+        self.assertEqual(caught[0][1]["interface"], "org.freedesktop.Test.Main")
 
         # check SigTwoArgs
-        self.assertEqual(caught[1][0], ('hello', 42))
-        self.assertEqual(caught[1][1]['member'], 'SigTwoArgs')
-        self.assertEqual(caught[1][1]['path'], '/')
-        self.assertEqual(caught[1][1]['interface'], 'org.freedesktop.Test.Sub')
+        self.assertEqual(caught[1][0], ("hello", 42))
+        self.assertEqual(caught[1][1]["member"], "SigTwoArgs")
+        self.assertEqual(caught[1][1]["path"], "/")
+        self.assertEqual(caught[1][1]["interface"], "org.freedesktop.Test.Sub")
 
         # check data types in SigTypeTest
-        self.assertEqual(caught[2][1]['member'], 'SigTypeTest')
-        self.assertEqual(caught[2][1]['path'], '/')
+        self.assertEqual(caught[2][1]["member"], "SigTypeTest")
+        self.assertEqual(caught[2][1]["path"], "/")
         args = caught[2][0]
         self.assertEqual(args[0], -42)
         self.assertEqual(type(args[0]), dbus.Int32)
@@ -527,117 +514,117 @@ assert args[2] == 5
         self.assertEqual(type(args[1]), dbus.UInt32)
         self.assertEqual(args[1].variant_level, 0)
 
-        self.assertEqual(args[2], 'hello')
+        self.assertEqual(args[2], "hello")
         self.assertEqual(type(args[2]), dbus.String)
         self.assertEqual(args[2].variant_level, 1)
 
-        self.assertEqual(args[3], ['/a', '/b'])
+        self.assertEqual(args[3], ["/a", "/b"])
         self.assertEqual(type(args[3]), dbus.Array)
         self.assertEqual(args[3].variant_level, 0)
         self.assertEqual(type(args[3][0]), dbus.ObjectPath)
         self.assertEqual(args[3][0].variant_level, 0)
 
         # check SigDetailed
-        self.assertEqual(caught[3][0], ('details', 123))
-        self.assertEqual(caught[3][1]['member'], 'SigDetailed')
-        self.assertEqual(caught[3][1]['path'], '/')
-        self.assertEqual(caught[3][1]['interface'], 'org.freedesktop.Test.Main')
+        self.assertEqual(caught[3][0], ("details", 123))
+        self.assertEqual(caught[3][1]["member"], "SigDetailed")
+        self.assertEqual(caught[3][1]["path"], "/")
+        self.assertEqual(caught[3][1]["interface"], "org.freedesktop.Test.Main")
 
-        self.assertEqual(caught[4][0], ('details', 456))
-        self.assertEqual(caught[4][1]['member'], 'SigDetailedWithPath')
-        self.assertEqual(caught[4][1]['path'], '/obj1')
-        self.assertEqual(caught[4][1]['interface'], 'org.freedesktop.Test.Main')
+        self.assertEqual(caught[4][0], ("details", 456))
+        self.assertEqual(caught[4][1]["member"], "SigDetailedWithPath")
+        self.assertEqual(caught[4][1]["path"], "/obj1")
+        self.assertEqual(caught[4][1]["interface"], "org.freedesktop.Test.Main")
 
         # check correct logging
         log = Path(self.mock_log.name).read_text("UTF-8")
-        self.assertRegex(log, '[0-9.]+ emit / org.freedesktop.Test.Main.SigNoArgs\n')
+        self.assertRegex(log, "[0-9.]+ emit / org.freedesktop.Test.Main.SigNoArgs\n")
         self.assertRegex(log, '[0-9.]+ emit / org.freedesktop.Test.Sub.SigTwoArgs "hello" 42\n')
-        self.assertRegex(log, '[0-9.]+ emit / org.freedesktop.Test.Sub.SigTypeTest -42 42')
+        self.assertRegex(log, "[0-9.]+ emit / org.freedesktop.Test.Sub.SigTypeTest -42 42")
         self.assertRegex(log, r'[0-9.]+ emit / org.freedesktop.Test.Sub.SigTypeTest -42 42 "hello" \["/a", "/b"\]\n')
         self.assertRegex(log, '[0-9.]+ emit / org.freedesktop.Test.Main.SigDetailed "details" 123\n')
         self.assertRegex(log, '[0-9.]+ emit /obj1 org.freedesktop.Test.Main.SigDetailedWithPath "details" 456\n')
 
     def test_signals_type_mismatch(self):
-        '''emitting signals with wrong arguments'''
+        """emitting signals with wrong arguments"""
 
         def check(signature, args, err):
             try:
-                self.dbus_mock.EmitSignal('', 's', signature, args)
+                self.dbus_mock.EmitSignal("", "s", signature, args)
                 self.fail(f'EmitSignal did not raise an error for signature "{signature}" and arguments {args}')
             except dbus.exceptions.DBusException as e:
-                self.assertEqual(e.get_dbus_name(), 'org.freedesktop.DBus.Error.InvalidArgs')
+                self.assertEqual(e.get_dbus_name(), "org.freedesktop.DBus.Error.InvalidArgs")
                 self.assertIn(err, str(e))
 
         # not enough arguments
-        check('i', [], 'More items found')
-        check('is', [1], 'More items found')
+        check("i", [], "More items found")
+        check("is", [1], "More items found")
 
         # too many arguments
-        check('', [1], 'Fewer items found')
-        check('i', [1, 'hello'], 'Fewer items found')
+        check("", [1], "Fewer items found")
+        check("i", [1, "hello"], "Fewer items found")
 
         # type mismatch
-        check('u', [-1], 'convert negative value to unsigned')
-        check('i', ['hello'], 'dbus.String')
-        check('i', ['hello'], 'integer')
-        check('s', [1], 'Expected a string')
+        check("u", [-1], "convert negative value to unsigned")
+        check("i", ["hello"], "dbus.String")
+        check("i", ["hello"], "integer")
+        check("s", [1], "Expected a string")
 
     def test_dbus_get_log(self):
-        '''query call logs over D-Bus'''
+        """query call logs over D-Bus"""
 
         self.assertEqual(self.dbus_mock.ClearCalls(), None)
         self.assertEqual(self.dbus_mock.GetCalls(), dbus.Array([]))
 
-        self.dbus_mock.AddMethod('', 'Do', '', '', '')
+        self.dbus_mock.AddMethod("", "Do", "", "", "")
         self.assertEqual(self.dbus_test.Do(), None)
         mock_log = self.dbus_mock.GetCalls()
         self.assertEqual(len(mock_log), 1)
         self.assertGreater(mock_log[0][0], 10000)  # timestamp
-        self.assertEqual(mock_log[0][1], 'Do')
+        self.assertEqual(mock_log[0][1], "Do")
         self.assertEqual(mock_log[0][2], [])
 
         self.assertEqual(self.dbus_mock.ClearCalls(), None)
         self.assertEqual(self.dbus_mock.GetCalls(), dbus.Array([]))
 
-        self.dbus_mock.AddMethod('', 'Wop', 's', 's', 'ret="hello"')
-        self.assertEqual(self.dbus_test.Wop('foo'), 'hello')
-        self.assertEqual(self.dbus_test.Wop('bar'), 'hello')
+        self.dbus_mock.AddMethod("", "Wop", "s", "s", 'ret="hello"')
+        self.assertEqual(self.dbus_test.Wop("foo"), "hello")
+        self.assertEqual(self.dbus_test.Wop("bar"), "hello")
         mock_log = self.dbus_mock.GetCalls()
         self.assertEqual(len(mock_log), 2)
         self.assertGreater(mock_log[0][0], 10000)  # timestamp
-        self.assertEqual(mock_log[0][1], 'Wop')
-        self.assertEqual(mock_log[0][2], ['foo'])
-        self.assertEqual(mock_log[1][1], 'Wop')
-        self.assertEqual(mock_log[1][2], ['bar'])
+        self.assertEqual(mock_log[0][1], "Wop")
+        self.assertEqual(mock_log[0][2], ["foo"])
+        self.assertEqual(mock_log[1][1], "Wop")
+        self.assertEqual(mock_log[1][2], ["bar"])
 
         self.assertEqual(self.dbus_mock.ClearCalls(), None)
         self.assertEqual(self.dbus_mock.GetCalls(), dbus.Array([]))
 
     def test_dbus_get_method_calls(self):
-        '''query method call logs over D-Bus'''
+        """query method call logs over D-Bus"""
 
-        self.dbus_mock.AddMethod('', 'Do', '', '', '')
+        self.dbus_mock.AddMethod("", "Do", "", "", "")
         self.assertEqual(self.dbus_test.Do(), None)
         self.assertEqual(self.dbus_test.Do(), None)
 
-        self.dbus_mock.AddMethod('', 'Wop', 's', 's', 'ret="hello"')
-        self.assertEqual(self.dbus_test.Wop('foo'), 'hello')
-        self.assertEqual(self.dbus_test.Wop('bar'), 'hello')
+        self.dbus_mock.AddMethod("", "Wop", "s", "s", 'ret="hello"')
+        self.assertEqual(self.dbus_test.Wop("foo"), "hello")
+        self.assertEqual(self.dbus_test.Wop("bar"), "hello")
 
-        mock_calls = self.dbus_mock.GetMethodCalls('Do')
+        mock_calls = self.dbus_mock.GetMethodCalls("Do")
         self.assertEqual(len(mock_calls), 2)
         self.assertEqual(mock_calls[0][1], [])
         self.assertEqual(mock_calls[1][1], [])
 
-        mock_calls = self.dbus_mock.GetMethodCalls('Wop')
+        mock_calls = self.dbus_mock.GetMethodCalls("Wop")
         self.assertEqual(len(mock_calls), 2)
         self.assertGreater(mock_calls[0][0], 10000)  # timestamp
-        self.assertEqual(mock_calls[0][1], ['foo'])
+        self.assertEqual(mock_calls[0][1], ["foo"])
         self.assertGreater(mock_calls[1][0], 10000)  # timestamp
-        self.assertEqual(mock_calls[1][1], ['bar'])
+        self.assertEqual(mock_calls[1][1], ["bar"])
 
     def test_dbus_method_called(self):
-        '''subscribe to MethodCalled signal'''
+        """subscribe to MethodCalled signal"""
 
         loop = GLib.MainLoop()
         caught_signals = []
@@ -646,43 +633,43 @@ assert args[2] == 5
             caught_signals.append((method, args))
             loop.quit()
 
-        self.dbus_mock.AddMethod('', 'Do', 's', '', '')
-        self.dbus_mock.connect_to_signal('MethodCalled', method_called)
-        self.assertEqual(self.dbus_test.Do('foo'), None)
+        self.dbus_mock.AddMethod("", "Do", "s", "", "")
+        self.dbus_mock.connect_to_signal("MethodCalled", method_called)
+        self.assertEqual(self.dbus_test.Do("foo"), None)
 
         GLib.timeout_add(5000, loop.quit)
         loop.run()
 
         self.assertEqual(len(caught_signals), 1)
         method, args = caught_signals[0]
-        self.assertEqual(method, 'Do')
+        self.assertEqual(method, "Do")
         self.assertEqual(len(args), 1)
-        self.assertEqual(args[0], 'foo')
+        self.assertEqual(args[0], "foo")
 
     def test_reset(self):
-        '''resetting to pristine state'''
+        """resetting to pristine state"""
 
-        self.dbus_mock.AddMethod('', 'Do', '', '', '')
-        self.dbus_mock.AddProperty('', 'propone', True)
-        self.dbus_mock.AddProperty('org.Test.Other', 'proptwo', 1)
-        self.dbus_mock.AddObject('/obj1', '', {}, [])
+        self.dbus_mock.AddMethod("", "Do", "", "", "")
+        self.dbus_mock.AddProperty("", "propone", True)
+        self.dbus_mock.AddProperty("org.Test.Other", "proptwo", 1)
+        self.dbus_mock.AddObject("/obj1", "", {}, [])
 
         self.dbus_mock.Reset()
 
         # resets properties and keeps the initial object
-        self.assertEqual(self.dbus_props.GetAll(''), {})
+        self.assertEqual(self.dbus_props.GetAll(""), {})
         # resets methods
         self.assertRaises(dbus.exceptions.DBusException, self.dbus_test.Do)
         # resets other objects
-        obj1 = self.dbus_con.get_object('org.freedesktop.Test', '/obj1')
-        self.assertRaises(dbus.exceptions.DBusException, obj1.GetAll, '')
+        obj1 = self.dbus_con.get_object("org.freedesktop.Test", "/obj1")
+        self.assertRaises(dbus.exceptions.DBusException, obj1.GetAll, "")
 
     def test_version(self):
         self.assertGreater(dbusmock.__version__, "0.28.0")
 
 
 class TestTemplates(dbusmock.DBusTestCase):
-    '''Test template API'''
+    """Test template API"""
 
     @classmethod
     def setUpClass(cls):
@@ -690,10 +677,11 @@ class TestTemplates(dbusmock.DBusTestCase):
         cls.start_system_bus()
 
     def test_local(self):
-        '''Load a local template *.py file'''
+        """Load a local template *.py file"""
 
-        with tempfile.NamedTemporaryFile(prefix='answer_', suffix='.py') as my_template:
-            my_template.write(b'''import dbus
+        with tempfile.NamedTemporaryFile(prefix="answer_", suffix=".py") as my_template:
+            my_template.write(
+                b"""import dbus
 BUS_NAME = 'universe.Ultimate'
 MAIN_OBJ = '/'
 MAIN_IFACE = 'universe.Ultimate'
@@ -701,17 +689,17 @@ SYSTEM_BUS = False
 
 def load(mock, parameters):
     mock.AddMethods(MAIN_IFACE, [('Answer', 's', 'i', 'ret = 42')])
-''')
+"""
+            )
             my_template.flush()
-            (p_mock, dbus_ultimate) = self.spawn_server_template(
-                my_template.name, stdout=subprocess.PIPE)
+            (p_mock, dbus_ultimate) = self.spawn_server_template(my_template.name, stdout=subprocess.PIPE)
             self.addCleanup(p_mock.wait)
             self.addCleanup(p_mock.terminate)
             self.addCleanup(p_mock.stdout.close)
 
             # ensure that we don't use/write any .pyc files, they are dangerous
             # in a world-writable directory like /tmp
-            self.assertFalse(Path(my_template.name + 'c').exists())
+            self.assertFalse(Path(my_template.name + "c").exists())
             self.assertFalse(Path(importlib.util.cache_from_source(my_template.name)).exists())
 
         loop = GLib.MainLoop()
@@ -722,7 +710,7 @@ def load(mock, parameters):
             loop.quit()
 
         dbus_mock = dbus.Interface(dbus_ultimate, dbusmock.MOCK_IFACE)
-        dbus_mock.connect_to_signal('MethodCalled', method_called)
+        dbus_mock.connect_to_signal("MethodCalled", method_called)
 
         self.assertEqual(dbus_ultimate.Answer("foo"), 42)
         self.assertEqual(dbus_ultimate.Answer("bar"), 42)
@@ -733,14 +721,13 @@ def load(mock, parameters):
         self.assertIn('<method name="Answer">', xml)
 
         # should not have ObjectManager API by default
-        self.assertRaises(dbus.exceptions.DBusException,
-                          dbus_ultimate.GetManagedObjects)
+        self.assertRaises(dbus.exceptions.DBusException, dbus_ultimate.GetManagedObjects)
 
         # Call should have been registered
-        mock_calls = dbus_mock.GetMethodCalls('Answer')
+        mock_calls = dbus_mock.GetMethodCalls("Answer")
         self.assertEqual(len(mock_calls), 2)
-        self.assertEqual(mock_calls[0][1], ['foo'])
-        self.assertEqual(mock_calls[1][1], ['bar'])
+        self.assertEqual(mock_calls[0][1], ["foo"])
+        self.assertEqual(mock_calls[1][1], ["bar"])
 
         # Check signals
         GLib.timeout_add(5000, loop.quit)
@@ -749,19 +736,20 @@ def load(mock, parameters):
         #  only one signal because we call loop.quit() in the handler
         self.assertEqual(len(caught_signals), 1)
         method, args = caught_signals[0]
-        self.assertEqual(method, 'Answer')
+        self.assertEqual(method, "Answer")
         self.assertEqual(len(args), 1)
-        self.assertEqual(args[0], 'foo')
+        self.assertEqual(args[0], "foo")
 
     def test_xdg_data_dir(self):
-        '''Load a template from XDG_DATA_DIRS'''
+        """Load a template from XDG_DATA_DIRS"""
 
-        with tempfile.TemporaryDirectory(prefix='xdg-test') as xdg_data_dir:
-            os.environ['XDG_DATA_DIRS'] = '/non/existing:' + xdg_data_dir
-            template_dir = Path(xdg_data_dir) / 'python-dbusmock' / 'templates'
+        with tempfile.TemporaryDirectory(prefix="xdg-test") as xdg_data_dir:
+            os.environ["XDG_DATA_DIRS"] = "/non/existing:" + xdg_data_dir
+            template_dir = Path(xdg_data_dir) / "python-dbusmock" / "templates"
             template_dir.mkdir(parents=True)
 
-            (template_dir / 'answer.py').write_text('''
+            (template_dir / "answer.py").write_text(
+                """
 BUS_NAME = 'universe.Ultimate'
 MAIN_OBJ = '/'
 MAIN_IFACE = 'universe.Ultimate'
@@ -769,9 +757,10 @@ SYSTEM_BUS = False
 
 def load(mock, parameters):
     mock.AddMethods(MAIN_IFACE, [('Answer', 's', 'i', 'ret = 42')])
-''')
+"""
+            )
 
-            (p_mock, dbus_ultimate) = self.spawn_server_template('answer', stdout=subprocess.PIPE)
+            (p_mock, dbus_ultimate) = self.spawn_server_template("answer", stdout=subprocess.PIPE)
             self.addCleanup(p_mock.wait)
             self.addCleanup(p_mock.terminate)
             self.addCleanup(p_mock.stdout.close)
@@ -781,10 +770,11 @@ def load(mock, parameters):
             self.assertIn('<method name="Answer">', xml)
 
     def test_static_method(self):
-        '''Static method in a template'''
+        """Static method in a template"""
 
-        with tempfile.NamedTemporaryFile(prefix='answer_', suffix='.py') as my_template:
-            my_template.write(b'''import dbus
+        with tempfile.NamedTemporaryFile(prefix="answer_", suffix=".py") as my_template:
+            my_template.write(
+                b"""import dbus
 BUS_NAME = 'universe.Ultimate'
 MAIN_OBJ = '/'
 MAIN_IFACE = 'universe.Ultimate'
@@ -798,10 +788,10 @@ def load(mock, parameters):
                      out_signature='i')
 def Answer(self, string):
     return 42
-''')
+"""
+            )
             my_template.flush()
-            (p_mock, dbus_ultimate) = self.spawn_server_template(
-                my_template.name, stdout=subprocess.PIPE)
+            (p_mock, dbus_ultimate) = self.spawn_server_template(my_template.name, stdout=subprocess.PIPE)
             self.addCleanup(p_mock.wait)
             self.addCleanup(p_mock.terminate)
             self.addCleanup(p_mock.stdout.close)
@@ -814,7 +804,7 @@ def Answer(self, string):
             loop.quit()
 
         dbus_mock = dbus.Interface(dbus_ultimate, dbusmock.MOCK_IFACE)
-        dbus_mock.connect_to_signal('MethodCalled', method_called)
+        dbus_mock.connect_to_signal("MethodCalled", method_called)
 
         self.assertEqual(dbus_ultimate.Answer("foo"), 42)
         self.assertEqual(dbus_ultimate.Answer("bar"), 42)
@@ -824,10 +814,10 @@ def Answer(self, string):
         self.assertIn('<method name="Answer">', xml)
 
         # Call should have been registered
-        mock_calls = dbus_mock.GetMethodCalls('Answer')
+        mock_calls = dbus_mock.GetMethodCalls("Answer")
         self.assertEqual(len(mock_calls), 2)
-        self.assertEqual(mock_calls[0][1], ['foo'])
-        self.assertEqual(mock_calls[1][1], ['bar'])
+        self.assertEqual(mock_calls[0][1], ["foo"])
+        self.assertEqual(mock_calls[1][1], ["bar"])
 
         # Check signals
         GLib.timeout_add(5000, loop.quit)
@@ -836,40 +826,44 @@ def Answer(self, string):
         #  only one signal because we call loop.quit() in the handler
         self.assertEqual(len(caught_signals), 1)
         method, args = caught_signals[0]
-        self.assertEqual(method, 'Answer')
+        self.assertEqual(method, "Answer")
         self.assertEqual(len(args), 1)
-        self.assertEqual(args[0], 'foo')
+        self.assertEqual(args[0], "foo")
 
     def test_local_nonexisting(self):
-        self.assertRaises(ImportError, self.spawn_server_template, '/non/existing.py')
+        self.assertRaises(ImportError, self.spawn_server_template, "/non/existing.py")
 
     def test_explicit_bus_(self):
-        '''Explicitly set the bus for a template that does not specify SYSTEM_BUS'''
+        """Explicitly set the bus for a template that does not specify SYSTEM_BUS"""
 
-        with tempfile.NamedTemporaryFile(prefix='answer_', suffix='.py') as my_template:
-            my_template.write(b'''import dbus
+        with tempfile.NamedTemporaryFile(prefix="answer_", suffix=".py") as my_template:
+            my_template.write(
+                b"""import dbus
 BUS_NAME = 'universe.Ultimate'
 MAIN_OBJ = '/'
 MAIN_IFACE = 'universe.Ultimate'
 
 def load(mock, parameters):
     mock.AddMethods(MAIN_IFACE, [('Answer', '', 'i', 'ret = 42')])
-''')
+"""
+            )
             my_template.flush()
             (p_mock, dbus_ultimate) = self.spawn_server_template(
-                my_template.name, stdout=subprocess.PIPE, system_bus=False)
+                my_template.name, stdout=subprocess.PIPE, system_bus=False
+            )
             self.addCleanup(p_mock.wait)
             self.addCleanup(p_mock.terminate)
             self.addCleanup(p_mock.stdout.close)
 
-        self.wait_for_bus_object('universe.Ultimate', '/')
+        self.wait_for_bus_object("universe.Ultimate", "/")
         self.assertEqual(dbus_ultimate.Answer(), 42)
 
     def test_override_bus_(self):
-        '''Override the bus for a template'''
+        """Override the bus for a template"""
 
-        with tempfile.NamedTemporaryFile(prefix='answer_', suffix='.py') as my_template:
-            my_template.write(b'''import dbus
+        with tempfile.NamedTemporaryFile(prefix="answer_", suffix=".py") as my_template:
+            my_template.write(
+                b"""import dbus
 BUS_NAME = 'universe.Ultimate'
 MAIN_OBJ = '/'
 MAIN_IFACE = 'universe.Ultimate'
@@ -877,22 +871,25 @@ SYSTEM_BUS = True
 
 def load(mock, parameters):
     mock.AddMethods(MAIN_IFACE, [('Answer', '', 'i', 'ret = 42')])
-''')
+"""
+            )
             my_template.flush()
             (p_mock, dbus_ultimate) = self.spawn_server_template(
-                my_template.name, stdout=subprocess.PIPE, system_bus=False)
+                my_template.name, stdout=subprocess.PIPE, system_bus=False
+            )
             self.addCleanup(p_mock.wait)
             self.addCleanup(p_mock.terminate)
             self.addCleanup(p_mock.stdout.close)
 
-        self.wait_for_bus_object('universe.Ultimate', '/')
+        self.wait_for_bus_object("universe.Ultimate", "/")
         self.assertEqual(dbus_ultimate.Answer(), 42)
 
     def test_object_manager(self):
-        '''Template with ObjectManager API'''
+        """Template with ObjectManager API"""
 
-        with tempfile.NamedTemporaryFile(prefix='objmgr_', suffix='.py') as my_template:
-            my_template.write(b'''import dbus
+        with tempfile.NamedTemporaryFile(prefix="objmgr_", suffix=".py") as my_template:
+            my_template.write(
+                b"""import dbus
 BUS_NAME = 'org.test.Things'
 MAIN_OBJ = '/org/test/Things'
 IS_OBJECT_MANAGER = True
@@ -902,18 +899,22 @@ def load(mock, parameters):
     mock.AddObject('/org/test/Things/Thing1', 'org.test.Do', {'name': 'one'}, [])
     mock.AddObject('/org/test/Things/Thing2', 'org.test.Do', {'name': 'two'}, [])
     mock.AddObject('/org/test/Peer', 'org.test.Do', {'name': 'peer'}, [])
-''')
+"""
+            )
             my_template.flush()
-            (p_mock, dbus_objmgr) = self.spawn_server_template(
-                my_template.name, stdout=subprocess.PIPE)
+            (p_mock, dbus_objmgr) = self.spawn_server_template(my_template.name, stdout=subprocess.PIPE)
             self.addCleanup(p_mock.wait)
             self.addCleanup(p_mock.terminate)
             self.addCleanup(p_mock.stdout.close)
 
         # should have the two Things, but not the Peer
-        self.assertEqual(dbus_objmgr.GetManagedObjects(),
-                         {'/org/test/Things/Thing1': {'org.test.Do': {'name': 'one'}},
-                          '/org/test/Things/Thing2': {'org.test.Do': {'name': 'two'}}})
+        self.assertEqual(
+            dbus_objmgr.GetManagedObjects(),
+            {
+                "/org/test/Things/Thing1": {"org.test.Do": {"name": "one"}},
+                "/org/test/Things/Thing2": {"org.test.Do": {"name": "two"}},
+            },
+        )
 
         # should appear in introspection
         xml = dbus_objmgr.Introspect()
@@ -923,52 +924,45 @@ def load(mock, parameters):
         self.assertIn('<node name="Thing2" />', xml)
 
     def test_reset(self):
-        '''Reset() puts the template back to pristine state'''
+        """Reset() puts the template back to pristine state"""
 
-        (p_mock, obj_logind) = self.spawn_server_template(
-            'logind', stdout=subprocess.PIPE)
+        (p_mock, obj_logind) = self.spawn_server_template("logind", stdout=subprocess.PIPE)
         self.addCleanup(p_mock.wait)
         self.addCleanup(p_mock.terminate)
         self.addCleanup(p_mock.stdout.close)
 
         # do some property, method, and object changes
-        obj_logind.Set('org.freedesktop.login1.Manager', 'IdleAction', 'frob')
+        obj_logind.Set("org.freedesktop.login1.Manager", "IdleAction", "frob")
         mock_logind = dbus.Interface(obj_logind, dbusmock.MOCK_IFACE)
-        mock_logind.AddProperty('org.Test.Other', 'walk', 'silly')
-        mock_logind.AddMethod('', 'DoWalk', '', '', '')
-        mock_logind.AddObject('/obj1', '', {}, [])
+        mock_logind.AddProperty("org.Test.Other", "walk", "silly")
+        mock_logind.AddMethod("", "DoWalk", "", "", "")
+        mock_logind.AddObject("/obj1", "", {}, [])
 
         mock_logind.Reset()
 
         # keeps the objects from the template
         dbus_con = self.get_dbus(system_bus=True)
-        obj_logind = dbus_con.get_object('org.freedesktop.login1',
-                                         '/org/freedesktop/login1')
-        self.assertEqual(obj_logind.CanSuspend(), 'yes')
+        obj_logind = dbus_con.get_object("org.freedesktop.login1", "/org/freedesktop/login1")
+        self.assertEqual(obj_logind.CanSuspend(), "yes")
 
         # resets properties
-        self.assertRaises(dbus.exceptions.DBusException,
-                          obj_logind.GetAll, 'org.Test.Other')
-        self.assertEqual(
-            obj_logind.Get('org.freedesktop.login1.Manager', 'IdleAction'),
-            'ignore')
+        self.assertRaises(dbus.exceptions.DBusException, obj_logind.GetAll, "org.Test.Other")
+        self.assertEqual(obj_logind.Get("org.freedesktop.login1.Manager", "IdleAction"), "ignore")
         # resets methods
         self.assertRaises(dbus.exceptions.DBusException, obj_logind.DoWalk)
         # resets other objects
-        obj1 = dbus_con.get_object('org.freedesktop.login1', '/obj1')
-        self.assertRaises(dbus.exceptions.DBusException, obj1.GetAll, '')
+        obj1 = dbus_con.get_object("org.freedesktop.login1", "/obj1")
+        self.assertRaises(dbus.exceptions.DBusException, obj1.GetAll, "")
 
 
 class TestCleanup(dbusmock.DBusTestCase):
-    '''Test cleanup of resources'''
+    """Test cleanup of resources"""
 
     def test_mock_terminates_with_bus(self):
-        '''Spawned mock processes exit when bus goes down'''
+        """Spawned mock processes exit when bus goes down"""
 
         self.start_session_bus()
-        p_mock = self.spawn_server('org.freedesktop.Test',
-                                   '/',
-                                   'org.freedesktop.Test.Main')
+        p_mock = self.spawn_server("org.freedesktop.Test", "/", "org.freedesktop.Test.Main")
         self.stop_dbus(self.session_bus_pid)
 
         # give the mock 2 seconds to terminate
@@ -983,81 +977,81 @@ class TestCleanup(dbusmock.DBusTestCase):
             # clean up manually
             p_mock.terminate()
             p_mock.wait()
-            self.fail('mock process did not terminate after 2 seconds')
+            self.fail("mock process did not terminate after 2 seconds")
 
         self.assertEqual(p_mock.wait(), 0)
 
 
 class TestSubclass(dbusmock.DBusTestCase):
-    '''Test subclassing DBusMockObject'''
+    """Test subclassing DBusMockObject"""
 
     @classmethod
     def setUpClass(cls):
         cls.start_session_bus()
 
     def test_ctor(self):
-        '''Override DBusMockObject constructor'''
+        """Override DBusMockObject constructor"""
 
         class MyMock(dbusmock.mockobject.DBusMockObject):
             def __init__(self):
-                bus_name = dbus.service.BusName('org.test.MyMock',
-                                                dbusmock.testcase.DBusTestCase.get_dbus())
-                dbusmock.mockobject.DBusMockObject.__init__(
-                    self, bus_name, '/', 'org.test.A', {}, os.devnull)
-                self.AddMethod('', 'Ping', '', 'i', 'ret = 42')
+                bus_name = dbus.service.BusName("org.test.MyMock", dbusmock.testcase.DBusTestCase.get_dbus())
+                dbusmock.mockobject.DBusMockObject.__init__(self, bus_name, "/", "org.test.A", {}, os.devnull)
+                self.AddMethod("", "Ping", "", "i", "ret = 42")
 
         m = MyMock()
         self.assertEqual(m.Ping(), 42)  # pylint: disable=no-member
 
     def test_none_props(self):
-        '''object with None properties argument'''
+        """object with None properties argument"""
 
         class MyMock(dbusmock.mockobject.DBusMockObject):
             def __init__(self):
-                bus_name = dbus.service.BusName('org.test.MyMock',
-                                                dbusmock.testcase.DBusTestCase.get_dbus())
+                bus_name = dbus.service.BusName("org.test.MyMock", dbusmock.testcase.DBusTestCase.get_dbus())
                 dbusmock.mockobject.DBusMockObject.__init__(
-                    self, bus_name, '/mymock', 'org.test.MyMockI', None, os.devnull)
-                self.AddMethod('', 'Ping', '', 'i', 'ret = 42')
+                    self, bus_name, "/mymock", "org.test.MyMockI", None, os.devnull
+                )
+                self.AddMethod("", "Ping", "", "i", "ret = 42")
 
         m = MyMock()
         self.assertEqual(m.Ping(), 42)  # pylint: disable=no-member
-        self.assertEqual(m.GetAll('org.test.MyMockI'), {})
+        self.assertEqual(m.GetAll("org.test.MyMockI"), {})
 
-        m.AddProperty('org.test.MyMockI', 'blurb', 5)
-        self.assertEqual(m.GetAll('org.test.MyMockI'), {'blurb': 5})
+        m.AddProperty("org.test.MyMockI", "blurb", 5)
+        self.assertEqual(m.GetAll("org.test.MyMockI"), {"blurb": 5})
 
 
 class TestServiceAutostart(dbusmock.DBusTestCase):
-    '''Test service starting DBusMockObject'''
+    """Test service starting DBusMockObject"""
 
     @classmethod
     def setUpClass(cls):
-        cls.xdg_data_dir = tempfile.mkdtemp(prefix='dbusmock_xdg_')
+        cls.xdg_data_dir = tempfile.mkdtemp(prefix="dbusmock_xdg_")
 
-        os.environ['XDG_DATA_DIRS'] = cls.xdg_data_dir
+        os.environ["XDG_DATA_DIRS"] = cls.xdg_data_dir
 
-        dbus_dir = Path(cls.xdg_data_dir, 'dbus-1')
-        system_dir = dbus_dir / 'system-services'
-        session_dir = dbus_dir / 'services'
+        dbus_dir = Path(cls.xdg_data_dir, "dbus-1")
+        system_dir = dbus_dir / "system-services"
+        session_dir = dbus_dir / "services"
         system_dir.mkdir(parents=True)
         session_dir.mkdir()
 
-        (system_dir / 'org.TestSystem.service').write_text(
-            '[D-BUS Service]\n'
-            'Name=org.TestSystem\n'
+        (system_dir / "org.TestSystem.service").write_text(
+            "[D-BUS Service]\n"
+            "Name=org.TestSystem\n"
             'Exec=/usr/bin/python3 -c "import sys; from gi.repository import GLib, Gio; '
-            '     Gio.bus_own_name(Gio.BusType.SYSTEM, \'org.TestSystem\', 0, None, None, lambda *args: sys.exit(0)); '
+            "     Gio.bus_own_name(Gio.BusType.SYSTEM, 'org.TestSystem', 0, None, None, lambda *args: sys.exit(0)); "
             '     GLib.MainLoop().run()"\n'
-            'User=root')
+            "User=root"
+        )
 
-        (session_dir / 'org.TestSession.service').write_text(
-            '[D-BUS Service]\n'
-            'Name=org.TestSession\n'
+        (session_dir / "org.TestSession.service").write_text(
+            "[D-BUS Service]\n"
+            "Name=org.TestSession\n"
             'Exec=/usr/bin/python3 -c "import sys; from gi.repository import GLib, Gio; '
-            '     Gio.bus_own_name(Gio.BusType.SESSION, \'org.TestSession\', 0, None, None, lambda *args: sys.exit(0)); '
+            "     Gio.bus_own_name(Gio.BusType.SESSION, 'org.TestSession', 0, None, None, lambda *args: sys.exit(0)); "
             '     GLib.MainLoop().run()"\n'
-            'User=root')
+            "User=root"
+        )
 
         cls.start_system_bus()
         cls.start_session_bus()
@@ -1069,52 +1063,52 @@ class TestServiceAutostart(dbusmock.DBusTestCase):
 
     def test_session_service_function_raise(self):
         with self.assertRaises(AssertionError):
-            self.enable_service('does-not-exist')
+            self.enable_service("does-not-exist")
 
         with self.assertRaises(AssertionError):
-            self.disable_service('does-not-exist')
+            self.disable_service("does-not-exist")
 
     def test_session_service_isolation(self):
         dbus_con = self.get_dbus(system_bus=False)
-        dbus_obj = dbus_con.get_object('org.freedesktop.DBus', '/org/freedesktop/DBus')
-        dbus_if = dbus.Interface(dbus_obj, 'org.freedesktop.DBus')
+        dbus_obj = dbus_con.get_object("org.freedesktop.DBus", "/org/freedesktop/DBus")
+        dbus_if = dbus.Interface(dbus_obj, "org.freedesktop.DBus")
 
-        self.assertEqual(dbus_if.ListActivatableNames(), ['org.freedesktop.DBus'])
-        self.enable_service('org.TestSession')
-        self.addCleanup(self.disable_service, 'org.TestSession')
-        self.assertEqual(dbus_if.ListActivatableNames(), ['org.freedesktop.DBus', 'org.TestSession'])
+        self.assertEqual(dbus_if.ListActivatableNames(), ["org.freedesktop.DBus"])
+        self.enable_service("org.TestSession")
+        self.addCleanup(self.disable_service, "org.TestSession")
+        self.assertEqual(dbus_if.ListActivatableNames(), ["org.freedesktop.DBus", "org.TestSession"])
 
     def test_system_service_isolation(self):
         dbus_con = self.get_dbus(system_bus=True)
-        dbus_obj = dbus_con.get_object('org.freedesktop.DBus', '/org/freedesktop/DBus')
-        dbus_if = dbus.Interface(dbus_obj, 'org.freedesktop.DBus')
+        dbus_obj = dbus_con.get_object("org.freedesktop.DBus", "/org/freedesktop/DBus")
+        dbus_if = dbus.Interface(dbus_obj, "org.freedesktop.DBus")
 
-        self.assertEqual(dbus_if.ListActivatableNames(), ['org.freedesktop.DBus'])
-        self.enable_service('org.TestSystem', system_bus=True)
-        self.addCleanup(self.disable_service, 'org.TestSystem', system_bus=True)
-        self.assertEqual(dbus_if.ListActivatableNames(), ['org.freedesktop.DBus', 'org.TestSystem'])
+        self.assertEqual(dbus_if.ListActivatableNames(), ["org.freedesktop.DBus"])
+        self.enable_service("org.TestSystem", system_bus=True)
+        self.addCleanup(self.disable_service, "org.TestSystem", system_bus=True)
+        self.assertEqual(dbus_if.ListActivatableNames(), ["org.freedesktop.DBus", "org.TestSystem"])
 
     def test_session_service_activation(self):
         dbus_con = self.get_dbus(system_bus=False)
-        dbus_obj = dbus_con.get_object('org.freedesktop.DBus', '/org/freedesktop/DBus')
-        dbus_if = dbus.Interface(dbus_obj, 'org.freedesktop.DBus')
+        dbus_obj = dbus_con.get_object("org.freedesktop.DBus", "/org/freedesktop/DBus")
+        dbus_if = dbus.Interface(dbus_obj, "org.freedesktop.DBus")
 
-        self.enable_service('org.TestSession')
-        self.addCleanup(self.disable_service, 'org.TestSession')
+        self.enable_service("org.TestSession")
+        self.addCleanup(self.disable_service, "org.TestSession")
 
-        dbus_if.StartServiceByName('org.TestSession', 0)
+        dbus_if.StartServiceByName("org.TestSession", 0)
 
     def test_system_service_activation(self):
         dbus_con = self.get_dbus(system_bus=True)
-        dbus_obj = dbus_con.get_object('org.freedesktop.DBus', '/org/freedesktop/DBus')
-        dbus_if = dbus.Interface(dbus_obj, 'org.freedesktop.DBus')
+        dbus_obj = dbus_con.get_object("org.freedesktop.DBus", "/org/freedesktop/DBus")
+        dbus_if = dbus.Interface(dbus_obj, "org.freedesktop.DBus")
 
-        self.enable_service('org.TestSystem', system_bus=True)
-        self.addCleanup(self.disable_service, 'org.TestSystem', system_bus=True)
+        self.enable_service("org.TestSystem", system_bus=True)
+        self.addCleanup(self.disable_service, "org.TestSystem", system_bus=True)
 
-        dbus_if.StartServiceByName('org.TestSystem', 0)
+        dbus_if.StartServiceByName("org.TestSystem", 0)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # avoid writing to stderr
     unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout))

--- a/tests/test_api_pytest.py
+++ b/tests/test_api_pytest.py
@@ -4,10 +4,10 @@
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Martin Pitt'
-__copyright__ = '''
+__author__ = "Martin Pitt"
+__copyright__ = """
 (c) 2023 Martin Pitt <martin@piware.de>
-'''
+"""
 
 import subprocess
 
@@ -18,23 +18,23 @@ import dbusmock
 
 def test_dbusmock_test(dbusmock_session):
     assert dbusmock_session
-    test_iface = 'org.freedesktop.Test.Main'
+    test_iface = "org.freedesktop.Test.Main"
 
-    with dbusmock.SpawnedMock.spawn_for_name('org.freedesktop.Test', '/', test_iface) as server:
+    with dbusmock.SpawnedMock.spawn_for_name("org.freedesktop.Test", "/", test_iface) as server:
         obj_test = server.obj
-        obj_test.AddMethod('', 'Upper', 's', 's', 'ret = args[0].upper()', interface_name=dbusmock.MOCK_IFACE)
-        assert obj_test.Upper('hello', interface=test_iface) == 'HELLO'
+        obj_test.AddMethod("", "Upper", "s", "s", "ret = args[0].upper()", interface_name=dbusmock.MOCK_IFACE)
+        assert obj_test.Upper("hello", interface=test_iface) == "HELLO"
 
 
-@pytest.fixture(name='upower_mock')
+@pytest.fixture(name="upower_mock")
 def fixture_upower_mock(dbusmock_system):
     assert dbusmock_system
-    with dbusmock.SpawnedMock.spawn_with_template('upower') as server:
+    with dbusmock.SpawnedMock.spawn_with_template("upower") as server:
         yield server.obj
 
 
 def test_dbusmock_test_template(upower_mock):
     assert upower_mock
-    out = subprocess.check_output(['upower', '--dump'], universal_newlines=True)
-    assert 'version:' in out
-    assert '0.99' in out
+    out = subprocess.check_output(["upower", "--dump"], universal_newlines=True)
+    assert "version:" in out
+    assert "0.99" in out

--- a/tests/test_bluez5.py
+++ b/tests/test_bluez5.py
@@ -4,11 +4,11 @@
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Philip Withnall'
-__copyright__ = '''
+__author__ = "Philip Withnall"
+__copyright__ = """
 (c) 2013 Collabora Ltd.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 
 import os
@@ -29,29 +29,30 @@ import dbusmock
 tracemalloc.start(25)
 dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
 
-have_bluetoothctl = shutil.which('bluetoothctl')
-have_pbap_client = shutil.which('pbap-client')
+have_bluetoothctl = shutil.which("bluetoothctl")
+have_pbap_client = shutil.which("pbap-client")
 
 
 def _run_bluetoothctl(command):
-    '''Run bluetoothctl with the given command.
+    """Run bluetoothctl with the given command.
 
     Return its output as a list of lines, with the command prompt removed
     from each, and empty lines eliminated.
 
     If bluetoothctl returns a non-zero exit code, raise an Exception.
-    '''
-    with subprocess.Popen(['bluetoothctl'], stdin=subprocess.PIPE,
-                          stdout=subprocess.PIPE,
-                          universal_newlines=True) as process:
+    """
+    with subprocess.Popen(
+        ["bluetoothctl"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True
+    ) as process:
         time.sleep(0.5)  # give it time to query the bus
-        out, err = process.communicate(input='list\n' + command + '\nquit\n')
+        out, err = process.communicate(input="list\n" + command + "\nquit\n")
 
         # Ignore output on stderr unless bluetoothctl dies.
         if process.returncode != 0:
             raise dbus.exceptions.DBusException(
                 f'bluetoothctl died with status {process.returncode} and errors: {err or ""}',
-                name='org.freedesktop.DBus.Mock.Error')
+                name="org.freedesktop.DBus.Mock.Error",
+            )
 
     # Strip the prompt from the start of every line, then remove empty
     # lines.
@@ -62,137 +63,134 @@ def _run_bluetoothctl(command):
     # Sometimes we end up with the final line being `\x1b[K` (partial
     # control code), which we need to ignore.
     def remove_prefix(line):
-        if line.startswith(('[bluetooth]#', '\x1b')):
-            parts = line.split(' ', 1)
+        if line.startswith(("[bluetooth]#", "\x1b")):
+            parts = line.split(" ", 1)
             try:
                 return parts[1].strip()
             except IndexError:
-                return ''
+                return ""
         return line.strip()
 
-    lines = out.split('\n')
+    lines = out.split("\n")
     lines = map(remove_prefix, lines)
-    lines = filter(lambda line: line != '', lines)
+    lines = filter(lambda line: line != "", lines)
 
     # Filter out the echoed commands. (bluetoothctl uses readline.)
-    return list(filter(lambda line: line not in ['list', command, 'quit'], lines))
+    return list(filter(lambda line: line not in ["list", command, "quit"], lines))
 
 
-@unittest.skipUnless(have_bluetoothctl, 'bluetoothctl not installed')
+@unittest.skipUnless(have_bluetoothctl, "bluetoothctl not installed")
 class TestBlueZ5(dbusmock.DBusTestCase):
-    '''Test mocking bluetoothd'''
+    """Test mocking bluetoothd"""
 
     @classmethod
     def setUpClass(cls):
         cls.start_system_bus()
         cls.dbus_con = cls.get_dbus(True)
-        (cls.p_mock, cls.obj_bluez) = cls.spawn_server_template(
-            'bluez5', {}, stdout=subprocess.PIPE)
+        (cls.p_mock, cls.obj_bluez) = cls.spawn_server_template("bluez5", {}, stdout=subprocess.PIPE)
 
     def setUp(self):
         self.obj_bluez.Reset()
         self.dbusmock = dbus.Interface(self.obj_bluez, dbusmock.MOCK_IFACE)
-        self.dbusmock_bluez = dbus.Interface(self.obj_bluez, 'org.bluez.Mock')
+        self.dbusmock_bluez = dbus.Interface(self.obj_bluez, "org.bluez.Mock")
 
     def test_no_adapters(self):
         # Check for adapters.
-        out = _run_bluetoothctl('list')
+        out = _run_bluetoothctl("list")
         for line in out:
-            self.assertFalse(line.startswith('Controller '))
+            self.assertFalse(line.startswith("Controller "))
 
     def test_one_adapter(self):
         # Chosen parameters.
-        adapter_name = 'hci0'
-        system_name = 'my-computer'
+        adapter_name = "hci0"
+        system_name = "my-computer"
 
         # Add an adapter
         path = self.dbusmock_bluez.AddAdapter(adapter_name, system_name)
-        self.assertEqual(path, '/org/bluez/' + adapter_name)
+        self.assertEqual(path, "/org/bluez/" + adapter_name)
 
-        adapter = self.dbus_con.get_object('org.bluez', path)
-        address = adapter.Get('org.bluez.Adapter1', 'Address')
-        address_type = adapter.Get('org.bluez.Adapter1', 'AddressType')
+        adapter = self.dbus_con.get_object("org.bluez", path)
+        address = adapter.Get("org.bluez.Adapter1", "Address")
+        address_type = adapter.Get("org.bluez.Adapter1", "AddressType")
 
         # Check for the adapter.
-        out = _run_bluetoothctl('list')
-        self.assertIn('Controller ' + address + ' ' + system_name + ' [default]', out)
+        out = _run_bluetoothctl("list")
+        self.assertIn("Controller " + address + " " + system_name + " [default]", out)
 
-        out = _run_bluetoothctl('show ' + address)
+        out = _run_bluetoothctl("show " + address)
         if address_type is not None:
-            self.assertIn(f'Controller {address} ({address_type})', out)
+            self.assertIn(f"Controller {address} ({address_type})", out)
         else:
-            self.assertIn('Controller ' + address, out)
-        self.assertIn('Name: ' + system_name, out)
-        self.assertIn('Alias: ' + system_name, out)
-        self.assertIn('Powered: yes', out)
-        self.assertIn('Discoverable: no', out)
-        self.assertIn('Pairable: yes', out)
-        self.assertIn('Discovering: no', out)
+            self.assertIn("Controller " + address, out)
+        self.assertIn("Name: " + system_name, out)
+        self.assertIn("Alias: " + system_name, out)
+        self.assertIn("Powered: yes", out)
+        self.assertIn("Discoverable: no", out)
+        self.assertIn("Pairable: yes", out)
+        self.assertIn("Discovering: no", out)
 
     def test_no_devices(self):
         # Add an adapter.
-        adapter_name = 'hci0'
-        path = self.dbusmock_bluez.AddAdapter(adapter_name, 'my-computer')
-        self.assertEqual(path, '/org/bluez/' + adapter_name)
+        adapter_name = "hci0"
+        path = self.dbusmock_bluez.AddAdapter(adapter_name, "my-computer")
+        self.assertEqual(path, "/org/bluez/" + adapter_name)
 
         # Check for devices.
-        out = _run_bluetoothctl('devices')
-        self.assertIn('Controller 00:01:02:03:04:05 my-computer [default]',
-                      out)
+        out = _run_bluetoothctl("devices")
+        self.assertIn("Controller 00:01:02:03:04:05 my-computer [default]", out)
 
     def test_one_device(self):
         # Add an adapter.
-        adapter_name = 'hci0'
-        path = self.dbusmock_bluez.AddAdapter(adapter_name, 'my-computer')
-        self.assertEqual(path, '/org/bluez/' + adapter_name)
+        adapter_name = "hci0"
+        path = self.dbusmock_bluez.AddAdapter(adapter_name, "my-computer")
+        self.assertEqual(path, "/org/bluez/" + adapter_name)
 
         # Add a device.
-        address = '11:22:33:44:55:66'
-        alias = 'My Phone'
+        address = "11:22:33:44:55:66"
+        alias = "My Phone"
 
         path = self.dbusmock_bluez.AddDevice(adapter_name, address, alias)
-        self.assertEqual(path, '/org/bluez/' + adapter_name + '/dev_' + address.replace(':', '_'))
+        self.assertEqual(path, "/org/bluez/" + adapter_name + "/dev_" + address.replace(":", "_"))
 
         # Check for the device.
-        out = _run_bluetoothctl('devices')
-        self.assertIn('Device ' + address + ' ' + alias, out)
+        out = _run_bluetoothctl("devices")
+        self.assertIn("Device " + address + " " + alias, out)
 
         # Check the device's properties.
-        out = '\n'.join(_run_bluetoothctl('info ' + address))
-        self.assertIn('Device ' + address, out)
-        self.assertIn('Name: ' + alias, out)
-        self.assertIn('Alias: ' + alias, out)
-        self.assertIn('Paired: no', out)
-        self.assertIn('Trusted: no', out)
-        self.assertIn('Blocked: no', out)
-        self.assertIn('Connected: no', out)
+        out = "\n".join(_run_bluetoothctl("info " + address))
+        self.assertIn("Device " + address, out)
+        self.assertIn("Name: " + alias, out)
+        self.assertIn("Alias: " + alias, out)
+        self.assertIn("Paired: no", out)
+        self.assertIn("Trusted: no", out)
+        self.assertIn("Blocked: no", out)
+        self.assertIn("Connected: no", out)
 
     def test_pairing_device(self):
         # Add an adapter.
-        adapter_name = 'hci0'
-        path = self.dbusmock_bluez.AddAdapter(adapter_name, 'my-computer')
-        self.assertEqual(path, '/org/bluez/' + adapter_name)
+        adapter_name = "hci0"
+        path = self.dbusmock_bluez.AddAdapter(adapter_name, "my-computer")
+        self.assertEqual(path, "/org/bluez/" + adapter_name)
 
         # Add a device.
-        address = '11:22:33:44:55:66'
-        alias = 'My Phone'
+        address = "11:22:33:44:55:66"
+        alias = "My Phone"
 
         path = self.dbusmock_bluez.AddDevice(adapter_name, address, alias)
-        self.assertEqual(path, '/org/bluez/' + adapter_name + '/dev_' + address.replace(':', '_'))
+        self.assertEqual(path, "/org/bluez/" + adapter_name + "/dev_" + address.replace(":", "_"))
 
         # Pair with the device.
         self.dbusmock_bluez.PairDevice(adapter_name, address, 5898764)
 
         # Check the device's properties.
-        out = '\n'.join(_run_bluetoothctl('info ' + address))
-        self.assertIn('Device ' + address, out)
-        self.assertIn('Paired: yes', out)
+        out = "\n".join(_run_bluetoothctl("info " + address))
+        self.assertIn("Device " + address, out)
+        self.assertIn("Paired: yes", out)
 
 
-@unittest.skipUnless(have_pbap_client,
-                     'pbap-client not installed (copy it from bluez/test)')
+@unittest.skipUnless(have_pbap_client, "pbap-client not installed (copy it from bluez/test)")
 class TestBlueZObex(dbusmock.DBusTestCase):
-    '''Test mocking obexd'''
+    """Test mocking obexd"""
 
     @classmethod
     def setUpClass(cls):
@@ -202,16 +200,13 @@ class TestBlueZObex(dbusmock.DBusTestCase):
 
     def setUp(self):
         # bluetoothd
-        (self.p_mock, self.obj_bluez) = self.spawn_server_template(
-            'bluez5', {}, stdout=subprocess.PIPE)
-        self.dbusmock_bluez = dbus.Interface(self.obj_bluez, 'org.bluez.Mock')
+        (self.p_mock, self.obj_bluez) = self.spawn_server_template("bluez5", {}, stdout=subprocess.PIPE)
+        self.dbusmock_bluez = dbus.Interface(self.obj_bluez, "org.bluez.Mock")
 
         # obexd
-        (self.p_mock_obex, self.obj_obex) = self.spawn_server_template(
-            'bluez5-obex', {}, stdout=subprocess.PIPE)
+        (self.p_mock_obex, self.obj_obex) = self.spawn_server_template("bluez5-obex", {}, stdout=subprocess.PIPE)
         self.dbusmock = dbus.Interface(self.obj_obex, dbusmock.MOCK_IFACE)
-        self.dbusmock_obex = dbus.Interface(self.obj_obex,
-                                            'org.bluez.obex.Mock')
+        self.dbusmock_obex = dbus.Interface(self.obj_obex, "org.bluez.obex.Mock")
 
     def tearDown(self):
         self.p_mock.stdout.close()
@@ -224,60 +219,57 @@ class TestBlueZObex(dbusmock.DBusTestCase):
 
     def test_everything(self):
         # Set up an adapter and device.
-        adapter_name = 'hci0'
-        device_address = '11:22:33:44:55:66'
-        device_alias = 'My Phone'
+        adapter_name = "hci0"
+        device_address = "11:22:33:44:55:66"
+        device_alias = "My Phone"
 
         ml = GLib.MainLoop()
 
-        self.dbusmock_bluez.AddAdapter(adapter_name, 'my-computer')
-        self.dbusmock_bluez.AddDevice(adapter_name, device_address,
-                                      device_alias)
+        self.dbusmock_bluez.AddAdapter(adapter_name, "my-computer")
+        self.dbusmock_bluez.AddDevice(adapter_name, device_address, device_alias)
         self.dbusmock_bluez.PairDevice(adapter_name, device_address)
 
         transferred_files = []
 
         def _transfer_created_cb(path, params, transfer_filename):
             bus = self.get_dbus(False)
-            obj = bus.get_object('org.bluez.obex', path)
-            transfer = dbus.Interface(obj, 'org.bluez.obex.transfer1.Mock')
+            obj = bus.get_object("org.bluez.obex", path)
+            transfer = dbus.Interface(obj, "org.bluez.obex.transfer1.Mock")
 
             Path(transfer_filename).write_bytes(
-                b'BEGIN:VCARD\r\n'
-                b'VERSION:3.0\r\n'
-                b'FN:Forrest Gump\r\n'
-                b'TEL;TYPE=WORK,VOICE:(111) 555-1212\r\n'
-                b'TEL;TYPE=HOME,VOICE:(404) 555-1212\r\n'
-                b'EMAIL;TYPE=PREF,INTERNET:forrestgump@example.com\r\n'
-                b'EMAIL:test@example.com\r\n'
-                b'URL;TYPE=HOME:http://example.com/\r\n'
-                b'URL:http://forest.com/\r\n'
-                b'URL:https://test.com/\r\n'
-                b'END:VCARD\r\n'
+                b"BEGIN:VCARD\r\n"
+                b"VERSION:3.0\r\n"
+                b"FN:Forrest Gump\r\n"
+                b"TEL;TYPE=WORK,VOICE:(111) 555-1212\r\n"
+                b"TEL;TYPE=HOME,VOICE:(404) 555-1212\r\n"
+                b"EMAIL;TYPE=PREF,INTERNET:forrestgump@example.com\r\n"
+                b"EMAIL:test@example.com\r\n"
+                b"URL;TYPE=HOME:http://example.com/\r\n"
+                b"URL:http://forest.com/\r\n"
+                b"URL:https://test.com/\r\n"
+                b"END:VCARD\r\n"
             )
 
             transfer.UpdateStatus(True)
             transferred_files.append(transfer_filename)
 
-        self.dbusmock_obex.connect_to_signal('TransferCreated',
-                                             _transfer_created_cb)
+        self.dbusmock_obex.connect_to_signal("TransferCreated", _transfer_created_cb)
 
         # Run pbap-client, then run the GLib main loop. The main loop will quit
         # after a timeout, at which point the code handles output from
         # pbap-client and waits for it to terminate. Integrating
         # process.communicate() with the GLib main loop to avoid the timeout is
         # too difficult.
-        with subprocess.Popen(['pbap-client', device_address],
-                              stdout=subprocess.PIPE,
-                              stderr=sys.stderr,
-                              universal_newlines=True) as process:
+        with subprocess.Popen(
+            ["pbap-client", device_address], stdout=subprocess.PIPE, stderr=sys.stderr, universal_newlines=True
+        ) as process:
             GLib.timeout_add(5000, ml.quit)
             ml.run()
 
             out = process.communicate()[0]
 
-        lines = out.split('\n')
-        lines = filter(lambda line: line != '', lines)
+        lines = out.split("\n")
+        lines = filter(lambda line: line != "", lines)
         lines = list(lines)
 
         # Clean up the transferred files.
@@ -288,29 +280,20 @@ class TestBlueZObex(dbusmock.DBusTestCase):
                 pass
 
         # See what pbap-client sees.
-        self.assertIn('Creating Session', lines)
-        self.assertIn('--- Select Phonebook PB ---', lines)
-        self.assertIn('--- GetSize ---', lines)
-        self.assertIn('Size = 0', lines)
-        self.assertIn('--- List vCard ---', lines)
-        self.assertIn(
-            'Transfer /org/bluez/obex/client/session0/transfer0 complete',
-            lines)
-        self.assertIn(
-            'Transfer /org/bluez/obex/client/session0/transfer1 complete',
-            lines)
-        self.assertIn(
-            'Transfer /org/bluez/obex/client/session0/transfer2 complete',
-            lines)
-        self.assertIn(
-            'Transfer /org/bluez/obex/client/session0/transfer3 complete',
-            lines)
-        self.assertIn('FINISHED', lines)
+        self.assertIn("Creating Session", lines)
+        self.assertIn("--- Select Phonebook PB ---", lines)
+        self.assertIn("--- GetSize ---", lines)
+        self.assertIn("Size = 0", lines)
+        self.assertIn("--- List vCard ---", lines)
+        self.assertIn("Transfer /org/bluez/obex/client/session0/transfer0 complete", lines)
+        self.assertIn("Transfer /org/bluez/obex/client/session0/transfer1 complete", lines)
+        self.assertIn("Transfer /org/bluez/obex/client/session0/transfer2 complete", lines)
+        self.assertIn("Transfer /org/bluez/obex/client/session0/transfer3 complete", lines)
+        self.assertIn("FINISHED", lines)
 
-        self.assertNotIn('ERROR', lines)
+        self.assertNotIn("ERROR", lines)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # avoid writing to stderr
-    unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout,
-                                                     verbosity=2))
+    unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout, verbosity=2))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,11 +4,11 @@
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Martin Pitt'
-__copyright__ = '''
+__author__ = "Martin Pitt"
+__copyright__ = """
 (c) 2012 Canonical Ltd.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 import importlib.util
 import shutil
@@ -24,12 +24,12 @@ import dbus
 import dbusmock
 
 tracemalloc.start(25)
-have_upower = shutil.which('upower')
-have_gdbus = shutil.which('gdbus')
+have_upower = shutil.which("upower")
+have_gdbus = shutil.which("gdbus")
 
 
 class TestCLI(dbusmock.DBusTestCase):
-    '''Test running dbusmock from the command line'''
+    """Test running dbusmock from the command line"""
 
     @classmethod
     def setUpClass(cls):
@@ -53,123 +53,125 @@ class TestCLI(dbusmock.DBusTestCase):
 
     def start_mock(self, args, wait_name, wait_path, wait_system=False):
         # pylint: disable=consider-using-with
-        self.p_mock = subprocess.Popen([sys.executable, '-m', 'dbusmock', *args],
-                                       stdout=subprocess.PIPE,
-                                       universal_newlines=True)
+        self.p_mock = subprocess.Popen(
+            [sys.executable, "-m", "dbusmock", *args], stdout=subprocess.PIPE, universal_newlines=True
+        )
         self.wait_for_bus_object(wait_name, wait_path, wait_system)
 
     def start_mock_process(self, args):
-        return subprocess.check_output([sys.executable, '-m', 'dbusmock', *args],
-                                       universal_newlines=True)
+        return subprocess.check_output([sys.executable, "-m", "dbusmock", *args], universal_newlines=True)
 
     def test_session_bus(self):
-        self.start_mock(['com.example.Test', '/', 'TestIface'],
-                        'com.example.Test', '/')
+        self.start_mock(["com.example.Test", "/", "TestIface"], "com.example.Test", "/")
 
     def test_system_bus(self):
-        self.start_mock(['--system', 'com.example.Test', '/', 'TestIface'],
-                        'com.example.Test', '/', True)
+        self.start_mock(["--system", "com.example.Test", "/", "TestIface"], "com.example.Test", "/", True)
 
     def test_template_upower(self):
-        self.start_mock(['-t', 'upower'],
-                        'org.freedesktop.UPower', '/org/freedesktop/UPower', True)
+        self.start_mock(["-t", "upower"], "org.freedesktop.UPower", "/org/freedesktop/UPower", True)
         self.check_upower_running()
 
     def test_template_upower_explicit_path(self):
-        spec = importlib.util.find_spec('dbusmock.templates.upower')
+        spec = importlib.util.find_spec("dbusmock.templates.upower")
         self.assertTrue(Path(spec.origin).exists())
-        self.start_mock(['-t', spec.origin],
-                        'org.freedesktop.UPower', '/org/freedesktop/UPower', True)
+        self.start_mock(["-t", spec.origin], "org.freedesktop.UPower", "/org/freedesktop/UPower", True)
         self.check_upower_running()
 
     def check_upower_running(self):
         # check that it actually ran the template, if we have upower
         if have_upower:
-            out = subprocess.check_output(['upower', '--dump'],
-                                          universal_newlines=True)
-            self.assertRegex(out, r'on-battery:\s+no')
+            out = subprocess.check_output(["upower", "--dump"], universal_newlines=True)
+            self.assertRegex(out, r"on-battery:\s+no")
 
             mock_out = self.p_mock.stdout.readline()
-            self.assertTrue('EnumerateDevices' in mock_out or 'GetAll' in mock_out,
-                            mock_out)
+            self.assertTrue("EnumerateDevices" in mock_out or "GetAll" in mock_out, mock_out)
 
     def test_template_explicit_system(self):
         # --system is redundant here, but should not break
-        self.start_mock(['--system', '-t', 'upower'],
-                        'org.freedesktop.UPower', '/org/freedesktop/UPower', True)
+        self.start_mock(["--system", "-t", "upower"], "org.freedesktop.UPower", "/org/freedesktop/UPower", True)
         self.check_upower_running()
 
     def test_template_override_session(self):
-        self.start_mock(['--session', '-t', 'upower'],
-                        'org.freedesktop.UPower', '/org/freedesktop/UPower', False)
+        self.start_mock(["--session", "-t", "upower"], "org.freedesktop.UPower", "/org/freedesktop/UPower", False)
 
     def test_template_conflicting_bus(self):
         with self.assertRaises(subprocess.CalledProcessError) as cm:
-            subprocess.check_output([sys.executable, '-m', 'dbusmock',
-                                     '--system', '--session', '-t', 'upower'],
-                                    stderr=subprocess.STDOUT,
-                                    universal_newlines=True)
+            subprocess.check_output(
+                [sys.executable, "-m", "dbusmock", "--system", "--session", "-t", "upower"],
+                stderr=subprocess.STDOUT,
+                universal_newlines=True,
+            )
         err = cm.exception
         self.assertEqual(err.returncode, 2)
-        self.assertRegex(err.output, '--system.*--session.*exclusive')
+        self.assertRegex(err.output, "--system.*--session.*exclusive")
 
     def test_template_parameters(self):
-        self.start_mock(['-t', 'upower', '-p', '{"DaemonVersion": "0.99.0", "OnBattery": true}'],
-                        'org.freedesktop.UPower', '/org/freedesktop/UPower', True)
+        self.start_mock(
+            ["-t", "upower", "-p", '{"DaemonVersion": "0.99.0", "OnBattery": true}'],
+            "org.freedesktop.UPower",
+            "/org/freedesktop/UPower",
+            True,
+        )
 
         # check that it actually ran the template, if we have upower
         if have_upower:
-            out = subprocess.check_output(['upower', '--dump'],
-                                          universal_newlines=True)
-            self.assertRegex(out, r'daemon-version:\s+0\.99\.0')
-            self.assertRegex(out, r'on-battery:\s+yes')
+            out = subprocess.check_output(["upower", "--dump"], universal_newlines=True)
+            self.assertRegex(out, r"daemon-version:\s+0\.99\.0")
+            self.assertRegex(out, r"on-battery:\s+yes")
 
     def test_template_parameters_malformed_json(self):
         with self.assertRaises(subprocess.CalledProcessError) as cm:
-            subprocess.check_output([sys.executable, '-m', 'dbusmock',
-                                     '-t', 'upower', '-p',
-                                     '{"DaemonVersion: "0.99.0"}'],
-                                    stderr=subprocess.STDOUT,
-                                    universal_newlines=True)
+            subprocess.check_output(
+                [sys.executable, "-m", "dbusmock", "-t", "upower", "-p", '{"DaemonVersion: "0.99.0"}'],
+                stderr=subprocess.STDOUT,
+                universal_newlines=True,
+            )
         err = cm.exception
         self.assertEqual(err.returncode, 2)
-        self.assertRegex(err.output, 'Malformed JSON given for parameters:.* delimiter')
+        self.assertRegex(err.output, "Malformed JSON given for parameters:.* delimiter")
 
     def test_template_parameters_not_dict(self):
         with self.assertRaises(subprocess.CalledProcessError) as cm:
-            subprocess.check_output([sys.executable, '-m', 'dbusmock',
-                                     '-t', 'upower', '-p',
-                                     '"banana"'],
-                                    stderr=subprocess.STDOUT,
-                                    universal_newlines=True)
+            subprocess.check_output(
+                [sys.executable, "-m", "dbusmock", "-t", "upower", "-p", '"banana"'],
+                stderr=subprocess.STDOUT,
+                universal_newlines=True,
+            )
         err = cm.exception
         self.assertEqual(err.returncode, 2)
-        self.assertEqual(err.output, 'JSON parameters must be a dictionary\n')
+        self.assertEqual(err.output, "JSON parameters must be a dictionary\n")
 
-    @unittest.skipIf(not have_upower, 'No upower installed')
+    @unittest.skipIf(not have_upower, "No upower installed")
     def test_template_upower_exec(self):
-        out = self.start_mock_process(
-            ['-t', 'upower', '--exec', 'upower', '--dump'])
-        self.assertRegex(out, r'on-battery:\s+no')
-        self.assertRegex(out, r'daemon-version:\s+0\.99')
+        out = self.start_mock_process(["-t", "upower", "--exec", "upower", "--dump"])
+        self.assertRegex(out, r"on-battery:\s+no")
+        self.assertRegex(out, r"daemon-version:\s+0\.99")
 
-    @unittest.skipIf(not have_gdbus, 'No gdbus installed')
+    @unittest.skipIf(not have_gdbus, "No gdbus installed")
     def test_manual_upower_exec(self):
         out = self.start_mock_process(
-            ['--system',
-             'org.freedesktop.UPower',
-             '/org/freedesktop/UPower',
-             'org.freedesktop.UPower',
-             '--exec',
-             'gdbus', 'introspect', '--system',
-             '--dest', 'org.freedesktop.UPower',
-             '--object-path', '/org/freedesktop/UPower'])
-        self.assertRegex(out, r'AddMethod\(')
-        self.assertRegex(out, r'AddMethods\(')
+            [
+                "--system",
+                "org.freedesktop.UPower",
+                "/org/freedesktop/UPower",
+                "org.freedesktop.UPower",
+                "--exec",
+                "gdbus",
+                "introspect",
+                "--system",
+                "--dest",
+                "org.freedesktop.UPower",
+                "--object-path",
+                "/org/freedesktop/UPower",
+            ]
+        )
+        self.assertRegex(out, r"AddMethod\(")
+        self.assertRegex(out, r"AddMethods\(")
 
     def test_template_local(self):
-        with tempfile.NamedTemporaryFile(prefix='answer_', suffix='.py') as my_template:
-            my_template.write(b'''import dbus
+        with tempfile.NamedTemporaryFile(prefix="answer_", suffix=".py") as my_template:
+            my_template.write(
+                b"""import dbus
 BUS_NAME = 'universe.Ultimate'
 MAIN_OBJ = '/'
 MAIN_IFACE = 'universe.Ultimate'
@@ -177,19 +179,20 @@ SYSTEM_BUS = False
 
 def load(mock, parameters):
     mock.AddMethods(MAIN_IFACE, [('Answer', '', 'i', 'ret = 42')])
-''')
+"""
+            )
             my_template.flush()
             # template specifies session bus
-            self.start_mock(['-t', my_template.name],
-                            'universe.Ultimate', '/', False)
+            self.start_mock(["-t", my_template.name], "universe.Ultimate", "/", False)
 
-        obj = self.session_con.get_object('universe.Ultimate', '/')
-        if_u = dbus.Interface(obj, 'universe.Ultimate')
+        obj = self.session_con.get_object("universe.Ultimate", "/")
+        if_u = dbus.Interface(obj, "universe.Ultimate")
         self.assertEqual(if_u.Answer(), 42)
 
     def test_template_override_system(self):
-        with tempfile.NamedTemporaryFile(prefix='answer_', suffix='.py') as my_template:
-            my_template.write(b'''import dbus
+        with tempfile.NamedTemporaryFile(prefix="answer_", suffix=".py") as my_template:
+            my_template.write(
+                b"""import dbus
 BUS_NAME = 'universe.Ultimate'
 MAIN_OBJ = '/'
 MAIN_IFACE = 'universe.Ultimate'
@@ -197,49 +200,54 @@ SYSTEM_BUS = False
 
 def load(mock, parameters):
     mock.AddMethods(MAIN_IFACE, [('Answer', '', 'i', 'ret = 42')])
-''')
+"""
+            )
             my_template.flush()
             # template specifies session bus, but CLI overrides to system
-            self.start_mock(['--system', '-t', my_template.name],
-                            'universe.Ultimate', '/', True)
+            self.start_mock(["--system", "-t", my_template.name], "universe.Ultimate", "/", True)
 
-        obj = self.system_con.get_object('universe.Ultimate', '/')
-        if_u = dbus.Interface(obj, 'universe.Ultimate')
+        obj = self.system_con.get_object("universe.Ultimate", "/")
+        if_u = dbus.Interface(obj, "universe.Ultimate")
         self.assertEqual(if_u.Answer(), 42)
 
     def test_object_manager(self):
-        self.start_mock(['-m', 'com.example.Test', '/', 'TestIface'],
-                        'com.example.Test', '/')
+        self.start_mock(["-m", "com.example.Test", "/", "TestIface"], "com.example.Test", "/")
 
-        obj = self.session_con.get_object('com.example.Test', '/')
+        obj = self.session_con.get_object("com.example.Test", "/")
         if_om = dbus.Interface(obj, dbusmock.OBJECT_MANAGER_IFACE)
         self.assertEqual(if_om.GetManagedObjects(), {})
 
         # add a new object, should appear
-        obj.AddObject('/a/b', 'org.Test', {'name': 'foo'}, dbus.Array([], signature='(ssss)'))
+        obj.AddObject("/a/b", "org.Test", {"name": "foo"}, dbus.Array([], signature="(ssss)"))
 
-        self.assertEqual(if_om.GetManagedObjects(), {'/a/b': {'org.Test': {'name': 'foo'}}})
+        self.assertEqual(if_om.GetManagedObjects(), {"/a/b": {"org.Test": {"name": "foo"}}})
 
     def test_no_args(self):
-        with subprocess.Popen([sys.executable, '-m', 'dbusmock'],
-                              stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                              universal_newlines=True) as p:
+        with subprocess.Popen(
+            [sys.executable, "-m", "dbusmock"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        ) as p:
             (out, err) = p.communicate()
-            self.assertEqual(out, '')
-            self.assertIn('must specify NAME', err)
+            self.assertEqual(out, "")
+            self.assertIn("must specify NAME", err)
             self.assertNotEqual(p.returncode, 0)
 
     def test_help(self):
-        with subprocess.Popen([sys.executable, '-m', 'dbusmock', '--help'],
-                              stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                              universal_newlines=True) as p:
+        with subprocess.Popen(
+            [sys.executable, "-m", "dbusmock", "--help"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        ) as p:
             (out, err) = p.communicate()
-            self.assertEqual(err, '')
-            self.assertIn('INTERFACE', out)
-            self.assertIn('--system', out)
+            self.assertEqual(err, "")
+            self.assertIn("INTERFACE", out)
+            self.assertIn("--system", out)
             self.assertEqual(p.returncode, 0)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # avoid writing to stderr
     unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout))

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -4,11 +4,11 @@
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Martin Pitt'
-__copyright__ = '''
+__author__ = "Martin Pitt"
+__copyright__ = """
 (c) 2012 Canonical Ltd.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 import glob
 import importlib.util
@@ -18,35 +18,56 @@ import sys
 import unittest
 
 
-@unittest.skipIf(os.getenv("SKIP_STATIC_CHECKS", "0") == "1", "$SKIP_STATIC_CHECKS set, not running static code checks")
+@unittest.skipIf(
+    os.getenv("SKIP_STATIC_CHECKS", "0") == "1", "$SKIP_STATIC_CHECKS set, not running static code checks"
+)
 class StaticCodeTests(unittest.TestCase):
-
     @unittest.skipUnless(importlib.util.find_spec("pylint"), "pylint not available, skipping")
     def test_pylint(self):
-        subprocess.check_call([sys.executable, '-m', 'pylint', *glob.glob('dbusmock/*.py')])
+        subprocess.check_call([sys.executable, "-m", "pylint", *glob.glob("dbusmock/*.py")])
         # signatures/arguments are not determined by us, docstrings are a bit pointless, and code repetition
         # is impractical to avoid (e.g. bluez4 and bluez5)
-        subprocess.check_call([sys.executable, '-m', 'pylint', '--score=n',
-                               '--disable=missing-function-docstring,R0801',
-                               '--disable=too-many-arguments,too-many-instance-attributes',
-                               'dbusmock/templates/'])
-        subprocess.check_call([sys.executable, '-m', 'pylint', '--score=n',
-                               '--disable=missing-module-docstring,missing-class-docstring',
-                               '--disable=missing-function-docstring',
-                               '--disable=too-many-public-methods,too-many-lines,too-many-statements,R0801',
-                               'tests/'])
+        subprocess.check_call(
+            [
+                sys.executable,
+                "-m",
+                "pylint",
+                "--score=n",
+                "--disable=missing-function-docstring,R0801",
+                "--disable=too-many-arguments,too-many-instance-attributes",
+                "dbusmock/templates/",
+            ]
+        )
+        subprocess.check_call(
+            [
+                sys.executable,
+                "-m",
+                "pylint",
+                "--score=n",
+                "--disable=missing-module-docstring,missing-class-docstring",
+                "--disable=missing-function-docstring",
+                "--disable=too-many-public-methods,too-many-lines,too-many-statements,R0801",
+                "tests/",
+            ]
+        )
 
     @unittest.skipUnless(importlib.util.find_spec("mypy"), "mypy not available, skipping")
     def test_types(self):
-        subprocess.check_call([sys.executable, '-m', 'mypy', 'dbusmock/', 'tests/'])
+        subprocess.check_call([sys.executable, "-m", "mypy", "dbusmock/", "tests/"])
 
     def test_ruff(self):
         try:
-            subprocess.check_call(['ruff', 'check', '--no-cache', '.'])
+            subprocess.check_call(["ruff", "check", "--no-cache", "."])
         except FileNotFoundError:
             self.skipTest("ruff not available, skipping")
 
+    def test_black(self):
+        try:
+            subprocess.check_call(["black", "--check", "--diff", "."])
+        except FileNotFoundError:
+            self.skipTest("black not available, skipping")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     # avoid writing to stderr
     unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout))

--- a/tests/test_gnome_screensaver.py
+++ b/tests/test_gnome_screensaver.py
@@ -4,11 +4,11 @@
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Martin Pitt'
-__copyright__ = '''
+__author__ = "Martin Pitt"
+__copyright__ = """
 (c) 2013 Canonical Ltd.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 import fcntl
 import os
@@ -20,7 +20,7 @@ import dbusmock
 
 
 class TestGnomeScreensaver(dbusmock.DBusTestCase):
-    '''Test mocking gnome-screensaver'''
+    """Test mocking gnome-screensaver"""
 
     @classmethod
     def setUpClass(cls):
@@ -28,8 +28,7 @@ class TestGnomeScreensaver(dbusmock.DBusTestCase):
         cls.dbus_con = cls.get_dbus(False)
 
     def setUp(self):
-        (self.p_mock, self.obj_ss) = self.spawn_server_template(
-            'gnome_screensaver', {}, stdout=subprocess.PIPE)
+        (self.p_mock, self.obj_ss) = self.spawn_server_template("gnome_screensaver", {}, stdout=subprocess.PIPE)
         # set log to nonblocking
         flags = fcntl.fcntl(self.p_mock.stdout, fcntl.F_GETFL)
         fcntl.fcntl(self.p_mock.stdout, fcntl.F_SETFL, flags | os.O_NONBLOCK)
@@ -40,34 +39,37 @@ class TestGnomeScreensaver(dbusmock.DBusTestCase):
         self.p_mock.wait()
 
     def test_default_state(self):
-        '''Not locked by default'''
+        """Not locked by default"""
 
         self.assertEqual(self.obj_ss.GetActive(), False)
 
     def test_lock(self):
-        '''Lock()'''
+        """Lock()"""
 
         self.obj_ss.Lock()
         self.assertEqual(self.obj_ss.GetActive(), True)
         self.assertGreater(self.obj_ss.GetActiveTime(), 0)
 
-        self.assertRegex(self.p_mock.stdout.read(),
-                         b'emit /org/gnome/ScreenSaver org.gnome.ScreenSaver.ActiveChanged True\n')
+        self.assertRegex(
+            self.p_mock.stdout.read(), b"emit /org/gnome/ScreenSaver org.gnome.ScreenSaver.ActiveChanged True\n"
+        )
 
     def test_set_active(self):
-        '''SetActive()'''
+        """SetActive()"""
 
         self.obj_ss.SetActive(True)
         self.assertEqual(self.obj_ss.GetActive(), True)
-        self.assertRegex(self.p_mock.stdout.read(),
-                         b'emit /org/gnome/ScreenSaver org.gnome.ScreenSaver.ActiveChanged True\n')
+        self.assertRegex(
+            self.p_mock.stdout.read(), b"emit /org/gnome/ScreenSaver org.gnome.ScreenSaver.ActiveChanged True\n"
+        )
 
         self.obj_ss.SetActive(False)
         self.assertEqual(self.obj_ss.GetActive(), False)
-        self.assertRegex(self.p_mock.stdout.read(),
-                         b'emit /org/gnome/ScreenSaver org.gnome.ScreenSaver.ActiveChanged False\n')
+        self.assertRegex(
+            self.p_mock.stdout.read(), b"emit /org/gnome/ScreenSaver org.gnome.ScreenSaver.ActiveChanged False\n"
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # avoid writing to stderr
     unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout))

--- a/tests/test_iio_sensors_proxy.py
+++ b/tests/test_iio_sensors_proxy.py
@@ -6,11 +6,11 @@
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Marco Trevisan'
-__copyright__ = '''
+__author__ = "Marco Trevisan"
+__copyright__ = """
 (c) 2021 Canonical Ltd.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 import fcntl
 import os
@@ -28,12 +28,13 @@ import dbusmock
 
 dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
 
-have_monitor_sensor = shutil.which('monitor-sensor')
+have_monitor_sensor = shutil.which("monitor-sensor")
 
 
 class TestIIOSensorsProxyBase(dbusmock.DBusTestCase):
-    '''Test mocking iio-sensors-proxy'''
-    dbus_interface = ''
+    """Test mocking iio-sensors-proxy"""
+
+    dbus_interface = ""
 
     @classmethod
     def setUpClass(cls):
@@ -43,8 +44,7 @@ class TestIIOSensorsProxyBase(dbusmock.DBusTestCase):
 
     def setUp(self):
         super().setUp()
-        (self.p_mock, self.p_obj) = self.spawn_server_template(
-            'iio-sensors-proxy', {}, stdout=subprocess.PIPE)
+        (self.p_mock, self.p_obj) = self.spawn_server_template("iio-sensors-proxy", {}, stdout=subprocess.PIPE)
 
     def tearDown(self):
         if self.p_mock:
@@ -55,8 +55,7 @@ class TestIIOSensorsProxyBase(dbusmock.DBusTestCase):
         super().tearDown()
 
     def get_property(self, name):
-        return self.p_obj.Get(self.dbus_interface, name,
-                              dbus_interface=dbus.PROPERTIES_IFACE)
+        return self.p_obj.Get(self.dbus_interface, name, dbus_interface=dbus.PROPERTIES_IFACE)
 
     def get_internal_property(self, name):
         return self.p_obj.GetInternalProperty(name)
@@ -81,9 +80,7 @@ class TestIIOSensorsProxyBase(dbusmock.DBusTestCase):
 
         loop = GLib.MainLoop()
         timeout_id = GLib.timeout_add(max_wait, on_timeout)
-        match = self.p_obj.connect_to_signal('PropertiesChanged',
-                                             on_properties_changed,
-                                             dbus.PROPERTIES_IFACE)
+        match = self.p_obj.connect_to_signal("PropertiesChanged", on_properties_changed, dbus.PROPERTIES_IFACE)
 
         while not changed_properties and timeout_id != 0:
             loop.get_context().iteration(True)
@@ -97,211 +94,198 @@ class TestIIOSensorsProxyBase(dbusmock.DBusTestCase):
 
     def wait_for_property_changed(self, property_name, expected_value):
         self.assertIn(property_name, self.wait_for_properties_changed())
-        self.assertEqual(
-            self.get_internal_property(property_name), expected_value)
+        self.assertEqual(self.get_internal_property(property_name), expected_value)
 
 
 class TestIIOSensorsProxy(TestIIOSensorsProxyBase):
-    ''' main SensorsProxy interface tests '''
+    """main SensorsProxy interface tests"""
 
-    dbus_interface = 'net.hadess.SensorProxy'
+    dbus_interface = "net.hadess.SensorProxy"
 
     def test_accelerometer_none(self):
-        self.assertFalse(self.get_property('HasAccelerometer'))
+        self.assertFalse(self.get_property("HasAccelerometer"))
 
     def test_accelerometer_claimed(self):
         self.p_obj.ClaimAccelerometer()
-        self.assertTrue(self.get_internal_property('AccelerometerOwners'))
+        self.assertTrue(self.get_internal_property("AccelerometerOwners"))
 
     def test_accelerometer_claimed_released(self):
         self.p_obj.ClaimAccelerometer()
-        self.assertTrue(self.get_internal_property('AccelerometerOwners'))
+        self.assertTrue(self.get_internal_property("AccelerometerOwners"))
         self.p_obj.ReleaseAccelerometer()
-        self.assertFalse(self.get_internal_property('AccelerometerOwners'))
+        self.assertFalse(self.get_internal_property("AccelerometerOwners"))
 
     def test_accelerometer_available(self):
-        self.assertFalse(self.get_property('HasAccelerometer'))
-        self.set_internal_property('HasAccelerometer', True)
-        self.assertTrue(self.get_property('HasAccelerometer'))
+        self.assertFalse(self.get_property("HasAccelerometer"))
+        self.set_internal_property("HasAccelerometer", True)
+        self.assertTrue(self.get_property("HasAccelerometer"))
 
     def test_accelerometer_property_with_no_sensor(self):
         with self.assertRaises(dbus.exceptions.DBusException) as ctx:
-            self.set_internal_property('AccelerometerOrientation', 'normal')
-        self.assertEqual(ctx.exception.get_dbus_name(),
-                         'org.freedesktop.DBus.Mock.Error')
-        self.assertIn('No accelerometer sensor available',
-                      ctx.exception.get_dbus_message().split('\n'))
+            self.set_internal_property("AccelerometerOrientation", "normal")
+        self.assertEqual(ctx.exception.get_dbus_name(), "org.freedesktop.DBus.Mock.Error")
+        self.assertIn("No accelerometer sensor available", ctx.exception.get_dbus_message().split("\n"))
 
     def test_accelerometer_claimed_properties_changes(self):
-        self.set_internal_property('HasAccelerometer', True)
+        self.set_internal_property("HasAccelerometer", True)
         self.p_obj.ClaimAccelerometer()
-        self.set_internal_property('AccelerometerOrientation', 'normal')
-        self.wait_for_property_changed('AccelerometerOrientation', 'normal')
+        self.set_internal_property("AccelerometerOrientation", "normal")
+        self.wait_for_property_changed("AccelerometerOrientation", "normal")
 
     def test_accelerometer_unclaimed_properties_changes(self):
-        self.set_internal_property('HasAccelerometer', True)
-        self.assertTrue(self.get_property('HasAccelerometer'))
-        self.set_internal_property('AccelerometerOrientation', 'normal')
+        self.set_internal_property("HasAccelerometer", True)
+        self.assertTrue(self.get_property("HasAccelerometer"))
+        self.set_internal_property("AccelerometerOrientation", "normal")
         self.assertFalse(self.wait_for_properties_changed(max_wait=500))
-        self.assertEqual(self.get_property('AccelerometerOrientation'),
-                         'normal')
+        self.assertEqual(self.get_property("AccelerometerOrientation"), "normal")
 
     def test_ambient_light_none(self):
-        self.assertFalse(self.get_property('HasAmbientLight'))
+        self.assertFalse(self.get_property("HasAmbientLight"))
 
     def test_ambient_light_claimed(self):
         self.p_obj.ClaimLight()
-        self.assertTrue(self.get_internal_property('AmbientLightOwners'))
-        self.assertFalse(self.get_property('HasAmbientLight'))
+        self.assertTrue(self.get_internal_property("AmbientLightOwners"))
+        self.assertFalse(self.get_property("HasAmbientLight"))
 
     def test_ambient_light_claimed_released(self):
         self.p_obj.ClaimLight()
-        self.assertTrue(self.get_internal_property('AmbientLightOwners'))
+        self.assertTrue(self.get_internal_property("AmbientLightOwners"))
         self.p_obj.ReleaseLight()
-        self.assertFalse(self.get_internal_property('AmbientLightOwners'))
+        self.assertFalse(self.get_internal_property("AmbientLightOwners"))
 
     def test_ambient_light_available(self):
-        self.assertFalse(self.get_property('HasAmbientLight'))
-        self.set_internal_property('HasAmbientLight', True)
-        self.assertTrue(self.get_property('HasAmbientLight'))
+        self.assertFalse(self.get_property("HasAmbientLight"))
+        self.set_internal_property("HasAmbientLight", True)
+        self.assertTrue(self.get_property("HasAmbientLight"))
 
     def test_ambient_light_property_with_no_sensor(self):
         with self.assertRaises(dbus.exceptions.DBusException) as ctx:
-            self.set_internal_property('LightLevelUnit', 'vendor')
-        self.assertEqual(ctx.exception.get_dbus_name(),
-                         'org.freedesktop.DBus.Mock.Error')
-        self.assertIn('No ambient_light sensor available',
-                      ctx.exception.get_dbus_message().split('\n'))
+            self.set_internal_property("LightLevelUnit", "vendor")
+        self.assertEqual(ctx.exception.get_dbus_name(), "org.freedesktop.DBus.Mock.Error")
+        self.assertIn("No ambient_light sensor available", ctx.exception.get_dbus_message().split("\n"))
         with self.assertRaises(dbus.exceptions.DBusException) as ctx:
-            self.set_internal_property('LightLevel', 0.5)
-        self.assertEqual(ctx.exception.get_dbus_name(),
-                         'org.freedesktop.DBus.Mock.Error')
-        self.assertIn('No ambient_light sensor available',
-                      ctx.exception.get_dbus_message().split('\n'))
+            self.set_internal_property("LightLevel", 0.5)
+        self.assertEqual(ctx.exception.get_dbus_name(), "org.freedesktop.DBus.Mock.Error")
+        self.assertIn("No ambient_light sensor available", ctx.exception.get_dbus_message().split("\n"))
 
     def test_ambient_light_claimed_properties_changes(self):
-        self.set_internal_property('HasAmbientLight', True)
+        self.set_internal_property("HasAmbientLight", True)
         self.p_obj.ClaimLight()
-        self.set_internal_property('LightLevelUnit', 'vendor')
-        self.wait_for_property_changed('LightLevelUnit', 'vendor')
-        self.set_internal_property('LightLevel', 111100.0)
-        self.wait_for_property_changed('LightLevel', 111100.0)
+        self.set_internal_property("LightLevelUnit", "vendor")
+        self.wait_for_property_changed("LightLevelUnit", "vendor")
+        self.set_internal_property("LightLevel", 111100.0)
+        self.wait_for_property_changed("LightLevel", 111100.0)
 
     def test_ambient_light_unclaimed_properties_changes(self):
-        self.set_internal_property('HasAmbientLight', True)
-        self.assertTrue(self.get_property('HasAmbientLight'))
-        self.set_internal_property('LightLevelUnit', 'vendor')
+        self.set_internal_property("HasAmbientLight", True)
+        self.assertTrue(self.get_property("HasAmbientLight"))
+        self.set_internal_property("LightLevelUnit", "vendor")
         self.assertFalse(self.wait_for_properties_changed(max_wait=500))
-        self.assertEqual(self.get_property('LightLevelUnit'), 'vendor')
+        self.assertEqual(self.get_property("LightLevelUnit"), "vendor")
 
     def test_proximity_none(self):
-        self.assertFalse(self.get_property('HasProximity'))
+        self.assertFalse(self.get_property("HasProximity"))
 
     def test_proximity_claimed(self):
         self.p_obj.ClaimProximity()
-        self.assertTrue(self.get_internal_property('ProximityOwners'))
-        self.assertFalse(self.get_property('HasProximity'))
+        self.assertTrue(self.get_internal_property("ProximityOwners"))
+        self.assertFalse(self.get_property("HasProximity"))
 
     def test_proximity_claimed_released(self):
         self.p_obj.ClaimProximity()
-        self.assertTrue(self.get_internal_property('ProximityOwners'))
-        self.assertFalse(self.get_property('HasProximity'))
+        self.assertTrue(self.get_internal_property("ProximityOwners"))
+        self.assertFalse(self.get_property("HasProximity"))
         self.p_obj.ReleaseProximity()
-        self.assertFalse(self.get_internal_property('ProximityOwners'))
+        self.assertFalse(self.get_internal_property("ProximityOwners"))
 
     def test_proximity_available(self):
-        self.assertFalse(self.get_property('HasProximity'))
-        self.set_internal_property('HasProximity', True)
-        self.assertTrue(self.get_property('HasProximity'))
+        self.assertFalse(self.get_property("HasProximity"))
+        self.set_internal_property("HasProximity", True)
+        self.assertTrue(self.get_property("HasProximity"))
 
     def test_proximity_property_with_no_sensor(self):
         with self.assertRaises(dbus.exceptions.DBusException) as ctx:
-            self.set_internal_property('ProximityNear', True)
-        self.assertEqual(ctx.exception.get_dbus_name(),
-                         'org.freedesktop.DBus.Mock.Error')
-        self.assertIn('No proximity sensor available',
-                      ctx.exception.get_dbus_message().split('\n'))
+            self.set_internal_property("ProximityNear", True)
+        self.assertEqual(ctx.exception.get_dbus_name(), "org.freedesktop.DBus.Mock.Error")
+        self.assertIn("No proximity sensor available", ctx.exception.get_dbus_message().split("\n"))
 
     def test_proximity_claimed_properties_changes(self):
-        self.set_internal_property('HasProximity', True)
+        self.set_internal_property("HasProximity", True)
         self.p_obj.ClaimProximity()
-        self.set_internal_property('ProximityNear', True)
-        self.wait_for_property_changed('ProximityNear', True)
+        self.set_internal_property("ProximityNear", True)
+        self.wait_for_property_changed("ProximityNear", True)
 
     def test_proximity_unclaimed_properties_changes(self):
-        self.set_internal_property('HasProximity', True)
-        self.assertTrue(self.get_property('HasProximity'))
-        self.set_internal_property('ProximityNear', True)
+        self.set_internal_property("HasProximity", True)
+        self.assertTrue(self.get_property("HasProximity"))
+        self.set_internal_property("ProximityNear", True)
         self.assertFalse(self.wait_for_properties_changed(max_wait=500))
-        self.assertTrue(self.get_property('ProximityNear'))
+        self.assertTrue(self.get_property("ProximityNear"))
 
 
 class TestIIOSensorsProxyCompass(TestIIOSensorsProxyBase):
-    ''' main SensorsProxy compass interface tests '''
+    """main SensorsProxy compass interface tests"""
 
-    dbus_interface = 'net.hadess.SensorProxy.Compass'
+    dbus_interface = "net.hadess.SensorProxy.Compass"
 
     def test_compass_none(self):
-        self.assertFalse(self.get_property('HasCompass'))
+        self.assertFalse(self.get_property("HasCompass"))
 
     def test_compass_claimed(self):
         self.p_obj.ClaimCompass()
-        self.assertTrue(self.get_internal_property('CompassOwners'))
-        self.assertFalse(self.get_property('HasCompass'))
+        self.assertTrue(self.get_internal_property("CompassOwners"))
+        self.assertFalse(self.get_property("HasCompass"))
 
     def test_compass_claimed_released(self):
         self.p_obj.ClaimCompass()
-        self.assertTrue(self.get_internal_property('CompassOwners'))
-        self.assertFalse(self.get_property('HasCompass'))
+        self.assertTrue(self.get_internal_property("CompassOwners"))
+        self.assertFalse(self.get_property("HasCompass"))
         self.p_obj.ReleaseCompass()
-        self.assertFalse(self.get_internal_property('CompassOwners'))
+        self.assertFalse(self.get_internal_property("CompassOwners"))
 
     def test_compass_available(self):
-        self.assertFalse(self.get_property('HasCompass'))
-        self.set_internal_property('HasCompass', True)
-        self.assertTrue(self.get_property('HasCompass'))
+        self.assertFalse(self.get_property("HasCompass"))
+        self.set_internal_property("HasCompass", True)
+        self.assertTrue(self.get_property("HasCompass"))
 
     def test_compass_property_with_no_sensor(self):
         with self.assertRaises(dbus.exceptions.DBusException) as ctx:
-            self.set_internal_property('CompassHeading', 180)
-        self.assertEqual(ctx.exception.get_dbus_name(),
-                         'org.freedesktop.DBus.Mock.Error')
-        self.assertIn('No compass sensor available',
-                      ctx.exception.get_dbus_message().split('\n'))
+            self.set_internal_property("CompassHeading", 180)
+        self.assertEqual(ctx.exception.get_dbus_name(), "org.freedesktop.DBus.Mock.Error")
+        self.assertIn("No compass sensor available", ctx.exception.get_dbus_message().split("\n"))
 
     def test_compass_claimed_properties_changes(self):
-        self.set_internal_property('HasCompass', True)
+        self.set_internal_property("HasCompass", True)
         self.p_obj.ClaimCompass()
-        self.set_internal_property('CompassHeading', 55)
-        self.wait_for_property_changed('CompassHeading', 55)
+        self.set_internal_property("CompassHeading", 55)
+        self.wait_for_property_changed("CompassHeading", 55)
 
     def test_compass_unclaimed_properties_changes(self):
-        self.set_internal_property('HasCompass', True)
-        self.assertTrue(self.get_property('HasCompass'))
-        self.set_internal_property('CompassHeading', 85)
+        self.set_internal_property("HasCompass", True)
+        self.assertTrue(self.get_property("HasCompass"))
+        self.set_internal_property("CompassHeading", 85)
         self.assertFalse(self.wait_for_properties_changed(max_wait=500))
-        self.assertEqual(self.get_property('CompassHeading'), 85)
+        self.assertEqual(self.get_property("CompassHeading"), 85)
 
 
-@unittest.skipUnless(have_monitor_sensor,
-                     'monitor-sensor utility not available')
+@unittest.skipUnless(have_monitor_sensor, "monitor-sensor utility not available")
 class TestIIOSensorsProxyMonitorSensorBase(TestIIOSensorsProxyBase):
-    ''' Base SensorsProxy interface tests using monitor-sensor'''
+    """Base SensorsProxy interface tests using monitor-sensor"""
 
     p_monitor_sensor = None
 
     def start_monitor_sensor(self):
         self.assertIsNone(self.p_monitor_sensor)
         # pylint: disable=consider-using-with
-        self.p_monitor_sensor = subprocess.Popen(
-            'monitor-sensor', stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        self.p_monitor_sensor = subprocess.Popen("monitor-sensor", stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         flags = fcntl.fcntl(self.p_monitor_sensor.stdout, fcntl.F_GETFL)
-        fcntl.fcntl(self.p_monitor_sensor.stdout, fcntl.F_SETFL,
-                    flags | os.O_NONBLOCK)
-        self.assertOutputContains([
-            '    Waiting for iio-sensor-proxy to appear',
-            '+++ iio-sensor-proxy appeared',
-        ])
+        fcntl.fcntl(self.p_monitor_sensor.stdout, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+        self.assertOutputContains(
+            [
+                "    Waiting for iio-sensor-proxy to appear",
+                "+++ iio-sensor-proxy appeared",
+            ]
+        )
 
     def stop_monitor_sensor(self):
         self.assertIsNotNone(self.p_monitor_sensor)
@@ -324,9 +308,8 @@ class TestIIOSensorsProxyMonitorSensorBase(TestIIOSensorsProxyBase):
                 output = self.p_monitor_sensor.stdout.readline()
                 if output:
                     break
-                self.assertLessEqual(int(time.time() * 1000) - start_time,
-                                     max_wait, msg='Timeout exceeded')
-            self.assertEqual(output.decode('utf-8'), f'{line}\n')
+                self.assertLessEqual(int(time.time() * 1000) - start_time, max_wait, msg="Timeout exceeded")
+            self.assertEqual(output.decode("utf-8"), f"{line}\n")
 
     def assertOutputEquals(self, expected_lines, max_wait=2000):
         self.assertOutputContains(expected_lines, max_wait)
@@ -335,83 +318,93 @@ class TestIIOSensorsProxyMonitorSensorBase(TestIIOSensorsProxyBase):
     def assertEmptyOutput(self, max_wait=100):
         start_time = int(time.time() * 1000)
         while int(time.time() * 1000) - start_time < max_wait:
-            self.assertFalse(self.p_monitor_sensor.stdout.readline(),
-                             msg='Unexpected output')
+            self.assertFalse(self.p_monitor_sensor.stdout.readline(), msg="Unexpected output")
 
 
 class TestIIOSensorsProxyMonitorSensor(TestIIOSensorsProxyMonitorSensorBase):
-    ''' main SensorsProxy interface tests using monitor-sensor'''
+    """main SensorsProxy interface tests using monitor-sensor"""
 
-    dbus_interface = 'net.hadess.SensorProxy'
+    dbus_interface = "net.hadess.SensorProxy"
 
     def test_accelerometer_added(self):
-        self.set_internal_property('HasAccelerometer', True)
+        self.set_internal_property("HasAccelerometer", True)
         self.start_monitor_sensor()
 
-        self.assertOutputEquals([
-            '=== Has accelerometer (orientation: undefined)',
-            '=== No ambient light sensor',
-            '=== No proximity sensor',
-        ])
+        self.assertOutputEquals(
+            [
+                "=== Has accelerometer (orientation: undefined)",
+                "=== No ambient light sensor",
+                "=== No proximity sensor",
+            ]
+        )
 
     def test_accelerometer_changes(self):
         self.test_accelerometer_added()
-        self.set_internal_property('AccelerometerOrientation', 'normal')
-        self.set_internal_property('AccelerometerOrientation', 'left-up')
-        self.set_internal_property('AccelerometerOrientation', 'bottom-up')
-        self.assertOutputEquals([
-            '    Accelerometer orientation changed: normal',
-            '    Accelerometer orientation changed: left-up',
-            '    Accelerometer orientation changed: bottom-up',
-        ])
+        self.set_internal_property("AccelerometerOrientation", "normal")
+        self.set_internal_property("AccelerometerOrientation", "left-up")
+        self.set_internal_property("AccelerometerOrientation", "bottom-up")
+        self.assertOutputEquals(
+            [
+                "    Accelerometer orientation changed: normal",
+                "    Accelerometer orientation changed: left-up",
+                "    Accelerometer orientation changed: bottom-up",
+            ]
+        )
 
     def test_ambient_light_added(self):
-        self.set_internal_property('HasAmbientLight', True)
+        self.set_internal_property("HasAmbientLight", True)
         self.start_monitor_sensor()
 
-        self.assertOutputEquals([
-            '=== No accelerometer',
-            '=== Has ambient light sensor (value: 0.000000, unit: lux)',
-            '=== No proximity sensor',
-        ])
+        self.assertOutputEquals(
+            [
+                "=== No accelerometer",
+                "=== Has ambient light sensor (value: 0.000000, unit: lux)",
+                "=== No proximity sensor",
+            ]
+        )
 
     def test_ambient_light_changes(self):
         self.test_ambient_light_added()
-        self.set_internal_property('LightLevelUnit', 'vendor')
-        self.set_internal_property('LightLevel', 0.3)
-        self.set_internal_property('LightLevel', 0.5)
-        self.set_internal_property('LightLevelUnit', 'lux')
-        self.set_internal_property('LightLevel', 111100.0)
+        self.set_internal_property("LightLevelUnit", "vendor")
+        self.set_internal_property("LightLevel", 0.3)
+        self.set_internal_property("LightLevel", 0.5)
+        self.set_internal_property("LightLevelUnit", "lux")
+        self.set_internal_property("LightLevel", 111100.0)
 
-        self.assertOutputEquals([
-            '    Light changed: 0.300000 (vendor)',
-            '    Light changed: 0.500000 (vendor)',
-            '    Light changed: 111100.000000 (lux)',
-        ])
+        self.assertOutputEquals(
+            [
+                "    Light changed: 0.300000 (vendor)",
+                "    Light changed: 0.500000 (vendor)",
+                "    Light changed: 111100.000000 (lux)",
+            ]
+        )
 
     def test_proximity_sensor_added(self):
-        self.set_internal_property('HasProximity', True)
+        self.set_internal_property("HasProximity", True)
         self.start_monitor_sensor()
 
-        self.assertOutputEquals([
-            '=== No accelerometer',
-            '=== No ambient light sensor',
-            '=== Has proximity sensor (near: 0)',
-        ])
+        self.assertOutputEquals(
+            [
+                "=== No accelerometer",
+                "=== No ambient light sensor",
+                "=== Has proximity sensor (near: 0)",
+            ]
+        )
 
     def test_proximity_sensor_changes(self):
         self.test_proximity_sensor_added()
 
-        self.set_internal_property('ProximityNear', True)
-        self.set_internal_property('ProximityNear', False)
+        self.set_internal_property("ProximityNear", True)
+        self.set_internal_property("ProximityNear", False)
 
-        self.assertOutputEquals([
-            '    Proximity value changed: 1',
-            '    Proximity value changed: 0',
-        ])
+        self.assertOutputEquals(
+            [
+                "    Proximity value changed: 1",
+                "    Proximity value changed: 0",
+            ]
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # avoid writing to stderr
-    unittest.main(testRunner=unittest.TextTestRunner(
-        stream=sys.stdout))
+    unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout))

--- a/tests/test_logind.py
+++ b/tests/test_logind.py
@@ -4,11 +4,11 @@
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Martin Pitt'
-__copyright__ = '''
+__author__ = "Martin Pitt"
+__copyright__ = """
 (c) 2013 Canonical Ltd.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 import re
 import shutil
@@ -23,13 +23,13 @@ import dbus
 import dbusmock
 
 tracemalloc.start(25)
-have_loginctl = shutil.which('loginctl')
+have_loginctl = shutil.which("loginctl")
 
 
-@unittest.skipUnless(have_loginctl, 'loginctl not installed')
-@unittest.skipUnless(Path('/run/systemd/system').exists(), '/run/systemd/system does not exist')
+@unittest.skipUnless(have_loginctl, "loginctl not installed")
+@unittest.skipUnless(Path("/run/systemd/system").exists(), "/run/systemd/system does not exist")
 class TestLogind(dbusmock.DBusTestCase):
-    '''Test mocking logind'''
+    """Test mocking logind"""
 
     @classmethod
     def setUpClass(cls):
@@ -37,9 +37,8 @@ class TestLogind(dbusmock.DBusTestCase):
         cls.dbus_con = cls.get_dbus(True)
 
         if have_loginctl:
-            out = subprocess.check_output(['loginctl', '--version'],
-                                          universal_newlines=True)
-            cls.version = re.search(r'(\d+)', out.splitlines()[0]).group(1)
+            out = subprocess.check_output(["loginctl", "--version"], universal_newlines=True)
+            cls.version = re.search(r"(\d+)", out.splitlines()[0]).group(1)
 
     def setUp(self):
         self.p_mock = None
@@ -51,41 +50,35 @@ class TestLogind(dbusmock.DBusTestCase):
             self.p_mock.wait()
 
     def test_empty(self):
-        (self.p_mock, _) = self.spawn_server_template('logind', {}, stdout=subprocess.PIPE)
-        cmd = ['loginctl']
-        if self.version >= '209':
-            cmd.append('--no-legend')
-        out = subprocess.check_output([*cmd, 'list-sessions'],
-                                      universal_newlines=True)
-        self.assertEqual(out, '')
+        (self.p_mock, _) = self.spawn_server_template("logind", {}, stdout=subprocess.PIPE)
+        cmd = ["loginctl"]
+        if self.version >= "209":
+            cmd.append("--no-legend")
+        out = subprocess.check_output([*cmd, "list-sessions"], universal_newlines=True)
+        self.assertEqual(out, "")
 
-        out = subprocess.check_output([*cmd, 'list-seats'],
-                                      universal_newlines=True)
-        self.assertEqual(out, '')
+        out = subprocess.check_output([*cmd, "list-seats"], universal_newlines=True)
+        self.assertEqual(out, "")
 
-        out = subprocess.check_output([*cmd, 'list-users'],
-                                      universal_newlines=True)
-        self.assertEqual(out, '')
+        out = subprocess.check_output([*cmd, "list-users"], universal_newlines=True)
+        self.assertEqual(out, "")
 
     def test_session(self):
-        (self.p_mock, obj_logind) = self.spawn_server_template('logind', {}, stdout=subprocess.PIPE)
+        (self.p_mock, obj_logind) = self.spawn_server_template("logind", {}, stdout=subprocess.PIPE)
 
-        obj_logind.AddSession('c1', 'seat0', 500, 'joe', True)
+        obj_logind.AddSession("c1", "seat0", 500, "joe", True)
 
-        out = subprocess.check_output(['loginctl', 'list-seats'],
-                                      universal_newlines=True)
-        self.assertRegex(out, r'(^|\n)seat0\s+')
+        out = subprocess.check_output(["loginctl", "list-seats"], universal_newlines=True)
+        self.assertRegex(out, r"(^|\n)seat0\s+")
 
-        out = subprocess.check_output(['loginctl', 'show-seat', 'seat0'],
-                                      universal_newlines=True)
-        self.assertRegex(out, 'Id=seat0')
-        if self.version <= '208':
-            self.assertRegex(out, 'ActiveSession=c1')
-            self.assertRegex(out, 'Sessions=c1')
+        out = subprocess.check_output(["loginctl", "show-seat", "seat0"], universal_newlines=True)
+        self.assertRegex(out, "Id=seat0")
+        if self.version <= "208":
+            self.assertRegex(out, "ActiveSession=c1")
+            self.assertRegex(out, "Sessions=c1")
 
-        out = subprocess.check_output(['loginctl', 'list-users'],
-                                      universal_newlines=True)
-        self.assertRegex(out, r'(^|\n)\s*500\s+joe\s*')
+        out = subprocess.check_output(["loginctl", "list-users"], universal_newlines=True)
+        self.assertRegex(out, r"(^|\n)\s*500\s+joe\s*")
 
         # note, this does an actual getpwnam() in the client, so we cannot call
         # this with hardcoded user names; get from actual user in the system
@@ -97,57 +90,53 @@ class TestLogind(dbusmock.DBusTestCase):
         # self.assertRegex(out, 'Sessions=c1')
         # self.assertRegex(out, 'State=active')
 
-        out = subprocess.check_output(['loginctl', 'list-sessions'],
-                                      universal_newlines=True)
-        self.assertRegex(out, 'c1 +500 +joe +seat0')
+        out = subprocess.check_output(["loginctl", "list-sessions"], universal_newlines=True)
+        self.assertRegex(out, "c1 +500 +joe +seat0")
 
-        out = subprocess.check_output(['loginctl', 'show-session', 'c1'],
-                                      universal_newlines=True)
-        self.assertRegex(out, 'Id=c1')
-        self.assertRegex(out, 'Class=user')
-        self.assertRegex(out, 'Active=yes')
-        self.assertRegex(out, 'State=active')
-        self.assertRegex(out, 'Name=joe')
-        self.assertRegex(out, 'LockedHint=no')
+        out = subprocess.check_output(["loginctl", "show-session", "c1"], universal_newlines=True)
+        self.assertRegex(out, "Id=c1")
+        self.assertRegex(out, "Class=user")
+        self.assertRegex(out, "Active=yes")
+        self.assertRegex(out, "State=active")
+        self.assertRegex(out, "Name=joe")
+        self.assertRegex(out, "LockedHint=no")
 
-        session_mock = dbus.Interface(self.dbus_con.get_object(
-            'org.freedesktop.login1', '/org/freedesktop/login1/session/c1'),
-            'org.freedesktop.login1.Session')
+        session_mock = dbus.Interface(
+            self.dbus_con.get_object("org.freedesktop.login1", "/org/freedesktop/login1/session/c1"),
+            "org.freedesktop.login1.Session",
+        )
         session_mock.SetLockedHint(True)
 
-        out = subprocess.check_output(['loginctl', 'show-session', 'c1'],
-                                      universal_newlines=True)
-        self.assertRegex(out, 'Id=c1')
-        self.assertRegex(out, 'LockedHint=yes')
+        out = subprocess.check_output(["loginctl", "show-session", "c1"], universal_newlines=True)
+        self.assertRegex(out, "Id=c1")
+        self.assertRegex(out, "LockedHint=yes")
 
     def test_properties(self):
-        (self.p_mock, obj_logind) = self.spawn_server_template('logind', {}, stdout=subprocess.PIPE)
-        props = obj_logind.GetAll('org.freedesktop.login1.Manager',
-                                  interface='org.freedesktop.DBus.Properties')
-        self.assertEqual(props['PreparingForSleep'], False)
-        self.assertEqual(props['IdleSinceHint'], 0)
+        (self.p_mock, obj_logind) = self.spawn_server_template("logind", {}, stdout=subprocess.PIPE)
+        props = obj_logind.GetAll("org.freedesktop.login1.Manager", interface="org.freedesktop.DBus.Properties")
+        self.assertEqual(props["PreparingForSleep"], False)
+        self.assertEqual(props["IdleSinceHint"], 0)
 
     def test_inhibit(self):
-        (self.p_mock, obj_logind) = self.spawn_server_template('logind', {}, stdout=subprocess.PIPE)
+        (self.p_mock, obj_logind) = self.spawn_server_template("logind", {}, stdout=subprocess.PIPE)
 
         # what, who, why, mode
-        fd = obj_logind.Inhibit('suspend', 'testcode', 'purpose', 'delay')
+        fd = obj_logind.Inhibit("suspend", "testcode", "purpose", "delay")
 
         # Our inhibitor is held
-        out = subprocess.check_output(['systemd-inhibit'],
-                                      universal_newlines=True)
+        out = subprocess.check_output(["systemd-inhibit"], universal_newlines=True)
         self.assertRegex(
-            out.replace('\n', ' '),
-            '(testcode +[0-9]+ +[^ ]* +[0-9]+ +[^ ]* +suspend purpose delay)|'
-            '(Who: testcode.*What: suspend.*Why: purpose.*Mode: delay.*)')
+            out.replace("\n", " "),
+            "(testcode +[0-9]+ +[^ ]* +[0-9]+ +[^ ]* +suspend purpose delay)|"
+            "(Who: testcode.*What: suspend.*Why: purpose.*Mode: delay.*)",
+        )
 
         del fd
         # No inhibitor is held
-        out = subprocess.check_output(['systemd-inhibit'],
-                                      universal_newlines=True)
-        self.assertRegex(out, 'No inhibitors|0 inhibitors listed')
+        out = subprocess.check_output(["systemd-inhibit"], universal_newlines=True)
+        self.assertRegex(out, "No inhibitors|0 inhibitors listed")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # avoid writing to stderr
     unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout))

--- a/tests/test_low_memory_monitor.py
+++ b/tests/test_low_memory_monitor.py
@@ -4,11 +4,11 @@
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Bastien Nocera'
-__copyright__ = '''
+__author__ = "Bastien Nocera"
+__copyright__ = """
 (c) 2019 Red Hat Inc.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 import fcntl
 import os
@@ -25,7 +25,7 @@ dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
 
 
 class TestLowMemoryMonitor(dbusmock.DBusTestCase):
-    '''Test mocking low-memory-monitor'''
+    """Test mocking low-memory-monitor"""
 
     @classmethod
     def setUpClass(cls):
@@ -33,8 +33,7 @@ class TestLowMemoryMonitor(dbusmock.DBusTestCase):
         cls.dbus_con = cls.get_dbus(True)
 
     def setUp(self):
-        (self.p_mock, self.obj_lmm) = self.spawn_server_template(
-            'low_memory_monitor', {}, stdout=subprocess.PIPE)
+        (self.p_mock, self.obj_lmm) = self.spawn_server_template("low_memory_monitor", {}, stdout=subprocess.PIPE)
         # set log to nonblocking
         flags = fcntl.fcntl(self.p_mock.stdout, fcntl.F_GETFL)
         fcntl.fcntl(self.p_mock.stdout, fcntl.F_SETFL, flags | os.O_NONBLOCK)
@@ -47,17 +46,17 @@ class TestLowMemoryMonitor(dbusmock.DBusTestCase):
         self.p_mock.wait()
 
     def test_low_memory_warning_signal(self):
-        '''LowMemoryWarning signal'''
+        """LowMemoryWarning signal"""
 
         self.dbusmock.EmitWarning(100)
         log = self.p_mock.stdout.read()
-        self.assertRegex(log, b'[0-9.]+ emit .*LowMemoryWarning 100\n')
+        self.assertRegex(log, b"[0-9.]+ emit .*LowMemoryWarning 100\n")
 
         self.dbusmock.EmitWarning(255)
         log = self.p_mock.stdout.read()
-        self.assertRegex(log, b'[0-9.]+ emit .*LowMemoryWarning 255\n')
+        self.assertRegex(log, b"[0-9.]+ emit .*LowMemoryWarning 255\n")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # avoid writing to stderr
     unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout))

--- a/tests/test_notification_daemon.py
+++ b/tests/test_notification_daemon.py
@@ -4,11 +4,11 @@
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Martin Pitt'
-__copyright__ = '''
+__author__ = "Martin Pitt"
+__copyright__ = """
 (c) 2012 Canonical Ltd.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 import fcntl
 import os
@@ -21,16 +21,15 @@ import dbus
 import dbusmock
 
 try:
-    notify_send_version = subprocess.check_output(['notify-send', '--version'],
-                                                  universal_newlines=True)
+    notify_send_version = subprocess.check_output(["notify-send", "--version"], universal_newlines=True)
     notify_send_version = notify_send_version.split()[-1]
 except (OSError, subprocess.CalledProcessError):
-    notify_send_version = ''
+    notify_send_version = ""
 
 
-@unittest.skipUnless(notify_send_version, 'notify-send not installed')
+@unittest.skipUnless(notify_send_version, "notify-send not installed")
 class TestNotificationDaemon(dbusmock.DBusTestCase):
-    '''Test mocking notification-daemon'''
+    """Test mocking notification-daemon"""
 
     @classmethod
     def setUpClass(cls):
@@ -38,8 +37,7 @@ class TestNotificationDaemon(dbusmock.DBusTestCase):
         cls.dbus_con = cls.get_dbus(False)
 
     def setUp(self):
-        (self.p_mock, self.obj_daemon) = self.spawn_server_template(
-            'notification_daemon', {}, stdout=subprocess.PIPE)
+        (self.p_mock, self.obj_daemon) = self.spawn_server_template("notification_daemon", {}, stdout=subprocess.PIPE)
         # set log to nonblocking
         flags = fcntl.fcntl(self.p_mock.stdout, fcntl.F_GETFL)
         fcntl.fcntl(self.p_mock.stdout, fcntl.F_SETFL, flags | os.O_NONBLOCK)
@@ -50,69 +48,74 @@ class TestNotificationDaemon(dbusmock.DBusTestCase):
         self.p_mock.wait()
 
     def test_no_options(self):
-        '''notify-send with no options'''
+        """notify-send with no options"""
 
-        subprocess.check_call(['notify-send', 'title', 'my text'])
+        subprocess.check_call(["notify-send", "title", "my text"])
         log = self.p_mock.stdout.read()
         self.assertRegex(log, b'[0-9.]+ Notify "notify-send" 0 "" "title" "my text" \\[\\]')
 
-    @unittest.skipIf(notify_send_version < '0.7.5', 'this requires libnotify >= 0.7.5')
+    @unittest.skipIf(notify_send_version < "0.7.5", "this requires libnotify >= 0.7.5")
     def test_options(self):
-        '''notify-send with some options'''
+        """notify-send with some options"""
 
-        subprocess.check_call(['notify-send', '-t', '27', '-a', 'fooApp',
-                               '-i', 'warning_icon', 'title', 'my text'])
+        subprocess.check_call(["notify-send", "-t", "27", "-a", "fooApp", "-i", "warning_icon", "title", "my text"])
         log = self.p_mock.stdout.read()
         # HACK: Why is the timeout missing on s390x?
-        if os.uname().machine == 's390x':
-            self.assertRegex(log, b'[0-9.]+ Notify "fooApp" 0 "warning_icon" "title" "my text" \\[\\] {.*"urgency": 1')
+        if os.uname().machine == "s390x":
+            self.assertRegex(
+                log, b'[0-9.]+ Notify "fooApp" 0 "warning_icon" "title" "my text" \\[\\] {.*"urgency": 1'
+            )
         else:
-            self.assertRegex(log, b'[0-9.]+ Notify "fooApp" 0 "warning_icon" "title" "my text" \\[\\] {.*"urgency": 1.* 27\n')
+            self.assertRegex(
+                log, b'[0-9.]+ Notify "fooApp" 0 "warning_icon" "title" "my text" \\[\\] {.*"urgency": 1.* 27\n'
+            )
 
     def test_id(self):
-        '''ID handling'''
+        """ID handling"""
 
         notify_proxy = dbus.Interface(
-            self.dbus_con.get_object('org.freedesktop.Notifications', '/org/freedesktop/Notifications'),
-            'org.freedesktop.Notifications')
+            self.dbus_con.get_object("org.freedesktop.Notifications", "/org/freedesktop/Notifications"),
+            "org.freedesktop.Notifications",
+        )
 
         # with input ID 0 it should generate new IDs
-        id_ = notify_proxy.Notify('test', 0, '', 'summary', 'body', [], {}, -1)
+        id_ = notify_proxy.Notify("test", 0, "", "summary", "body", [], {}, -1)
         self.assertEqual(id_, 1)
-        id_ = notify_proxy.Notify('test', 0, '', 'summary', 'body', [], {}, -1)
+        id_ = notify_proxy.Notify("test", 0, "", "summary", "body", [], {}, -1)
         self.assertEqual(id_, 2)
 
         # an existing ID should just be bounced back
-        id_ = notify_proxy.Notify('test', 4, '', 'summary', 'body', [], {}, -1)
+        id_ = notify_proxy.Notify("test", 4, "", "summary", "body", [], {}, -1)
         self.assertEqual(id_, 4)
-        id_ = notify_proxy.Notify('test', 1, '', 'summary', 'body', [], {}, -1)
+        id_ = notify_proxy.Notify("test", 1, "", "summary", "body", [], {}, -1)
         self.assertEqual(id_, 1)
 
         # the previous doesn't forget the counter
-        id_ = notify_proxy.Notify('test', 0, '', 'summary', 'body', [], {}, -1)
+        id_ = notify_proxy.Notify("test", 0, "", "summary", "body", [], {}, -1)
         self.assertEqual(id_, 3)
 
     def test_close(self):
-        '''CloseNotification() and NotificationClosed() signal'''
+        """CloseNotification() and NotificationClosed() signal"""
 
         notify_proxy = dbus.Interface(
-            self.dbus_con.get_object('org.freedesktop.Notifications', '/org/freedesktop/Notifications'),
-            'org.freedesktop.Notifications')
+            self.dbus_con.get_object("org.freedesktop.Notifications", "/org/freedesktop/Notifications"),
+            "org.freedesktop.Notifications",
+        )
 
-        id_ = notify_proxy.Notify('test', 0, '', 'summary', 'body', [], {}, -1)
+        id_ = notify_proxy.Notify("test", 0, "", "summary", "body", [], {}, -1)
         self.assertEqual(id_, 1)
 
         # known notification, should send a signal
         notify_proxy.CloseNotification(id_)
         log = self.p_mock.stdout.read()
-        self.assertRegex(log, b'[0-9.]+ emit .*NotificationClosed 1 1\n')
+        self.assertRegex(log, b"[0-9.]+ emit .*NotificationClosed 1 1\n")
 
         # unknown notification, don't send a signal
         notify_proxy.CloseNotification(id_ + 1)
         log = self.p_mock.stdout.read()
-        self.assertNotIn(b'NotificationClosed', log)
+        self.assertNotIn(b"NotificationClosed", log)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # avoid writing to stderr
     unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout))

--- a/tests/test_ofono.py
+++ b/tests/test_ofono.py
@@ -4,11 +4,11 @@
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Martin Pitt'
-__copyright__ = '''
+__author__ = "Martin Pitt"
+__copyright__ = """
 (c) 2013 Canonical Ltd.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 import os
 import subprocess
@@ -20,149 +20,144 @@ import dbus
 
 import dbusmock
 
-script_dir = Path(os.environ.get('OFONO_SCRIPT_DIR', '/usr/share/ofono/scripts'))
+script_dir = Path(os.environ.get("OFONO_SCRIPT_DIR", "/usr/share/ofono/scripts"))
 
-have_scripts = os.access(script_dir / 'list-modems', os.X_OK)
+have_scripts = os.access(script_dir / "list-modems", os.X_OK)
 
 
-@unittest.skipUnless(have_scripts,
-                     'ofono scripts not available, set $OFONO_SCRIPT_DIR')
+@unittest.skipUnless(have_scripts, "ofono scripts not available, set $OFONO_SCRIPT_DIR")
 class TestOfono(dbusmock.DBusTestCase):
-    '''Test mocking ofonod'''
+    """Test mocking ofonod"""
 
     @classmethod
     def setUpClass(cls):
         cls.start_system_bus()
         cls.dbus_con = cls.get_dbus(True)
-        (cls.p_mock, cls.obj_ofono) = cls.spawn_server_template(
-            'ofono', {}, stdout=subprocess.PIPE)
+        (cls.p_mock, cls.obj_ofono) = cls.spawn_server_template("ofono", {}, stdout=subprocess.PIPE)
 
     def setUp(self):
         self.obj_ofono.Reset()
 
     def test_list_modems(self):
-        '''Manager.GetModems()'''
+        """Manager.GetModems()"""
 
-        out = subprocess.check_output([script_dir / 'list-modems'])
-        self.assertTrue(out.startswith(b'[ /ril_0 ]'), out)
-        self.assertIn(b'Powered = 1', out)
-        self.assertIn(b'Online = 1', out)
-        self.assertIn(b'Model = Mock Modem', out)
-        self.assertIn(b'[ org.ofono.NetworkRegistration ]', out)
-        self.assertIn(b'Status = registered', out)
-        self.assertIn(b'Name = fake.tel', out)
-        self.assertIn(b'Technology = gsm', out)
-        self.assertIn(b'[ org.ofono.SimManager ]', out)
-        self.assertIn(b'PinRequired = none', out)
-        self.assertIn(b'Present = 1', out)
-        self.assertIn(b'CardIdentifier = 893581234000000000000', out)
-        self.assertIn(b'MobileCountryCode = 310', out)
-        self.assertIn(b'MobileNetworkCode = 150', out)
-        self.assertIn(b'Serial = 12345678-1234-1234-1234-000000000000', out)
-        self.assertIn(b'SubscriberIdentity = 310150000000000', out)
+        out = subprocess.check_output([script_dir / "list-modems"])
+        self.assertTrue(out.startswith(b"[ /ril_0 ]"), out)
+        self.assertIn(b"Powered = 1", out)
+        self.assertIn(b"Online = 1", out)
+        self.assertIn(b"Model = Mock Modem", out)
+        self.assertIn(b"[ org.ofono.NetworkRegistration ]", out)
+        self.assertIn(b"Status = registered", out)
+        self.assertIn(b"Name = fake.tel", out)
+        self.assertIn(b"Technology = gsm", out)
+        self.assertIn(b"[ org.ofono.SimManager ]", out)
+        self.assertIn(b"PinRequired = none", out)
+        self.assertIn(b"Present = 1", out)
+        self.assertIn(b"CardIdentifier = 893581234000000000000", out)
+        self.assertIn(b"MobileCountryCode = 310", out)
+        self.assertIn(b"MobileNetworkCode = 150", out)
+        self.assertIn(b"Serial = 12345678-1234-1234-1234-000000000000", out)
+        self.assertIn(b"SubscriberIdentity = 310150000000000", out)
 
     def test_outgoing_call(self):
-        '''outgoing voice call'''
+        """outgoing voice call"""
 
         # no calls by default
-        out = subprocess.check_output([script_dir / 'list-calls'])
-        self.assertEqual(out, b'[ /ril_0 ]\n')
+        out = subprocess.check_output([script_dir / "list-calls"])
+        self.assertEqual(out, b"[ /ril_0 ]\n")
 
         # start call
-        out = subprocess.check_output([script_dir / 'dial-number', '12345'])
-        self.assertEqual(out, b'Using modem /ril_0\n/ril_0/voicecall01\n')
+        out = subprocess.check_output([script_dir / "dial-number", "12345"])
+        self.assertEqual(out, b"Using modem /ril_0\n/ril_0/voicecall01\n")
 
-        out = subprocess.check_output([script_dir / 'list-calls'])
-        self.assertIn(b'/ril_0/voicecall01', out)
-        self.assertIn(b'LineIdentification = 12345', out)
-        self.assertIn(b'State = dialing', out)
+        out = subprocess.check_output([script_dir / "list-calls"])
+        self.assertIn(b"/ril_0/voicecall01", out)
+        self.assertIn(b"LineIdentification = 12345", out)
+        self.assertIn(b"State = dialing", out)
 
-        out = subprocess.check_output([script_dir / 'hangup-call',
-                                      '/ril_0/voicecall01'])
-        self.assertEqual(out, b'')
+        out = subprocess.check_output([script_dir / "hangup-call", "/ril_0/voicecall01"])
+        self.assertEqual(out, b"")
 
         # no active calls any more
-        out = subprocess.check_output([script_dir / 'list-calls'])
-        self.assertEqual(out, b'[ /ril_0 ]\n')
+        out = subprocess.check_output([script_dir / "list-calls"])
+        self.assertEqual(out, b"[ /ril_0 ]\n")
 
     def test_hangup_all(self):
-        '''multiple outgoing voice calls'''
+        """multiple outgoing voice calls"""
 
-        out = subprocess.check_output([script_dir / 'dial-number', '12345'])
-        self.assertEqual(out, b'Using modem /ril_0\n/ril_0/voicecall01\n')
+        out = subprocess.check_output([script_dir / "dial-number", "12345"])
+        self.assertEqual(out, b"Using modem /ril_0\n/ril_0/voicecall01\n")
 
-        out = subprocess.check_output([script_dir / 'dial-number', '54321'])
-        self.assertEqual(out, b'Using modem /ril_0\n/ril_0/voicecall02\n')
+        out = subprocess.check_output([script_dir / "dial-number", "54321"])
+        self.assertEqual(out, b"Using modem /ril_0\n/ril_0/voicecall02\n")
 
-        out = subprocess.check_output([script_dir / 'list-calls'])
-        self.assertIn(b'/ril_0/voicecall01', out)
-        self.assertIn(b'/ril_0/voicecall02', out)
-        self.assertIn(b'LineIdentification = 12345', out)
-        self.assertIn(b'LineIdentification = 54321', out)
+        out = subprocess.check_output([script_dir / "list-calls"])
+        self.assertIn(b"/ril_0/voicecall01", out)
+        self.assertIn(b"/ril_0/voicecall02", out)
+        self.assertIn(b"LineIdentification = 12345", out)
+        self.assertIn(b"LineIdentification = 54321", out)
 
-        out = subprocess.check_output([script_dir / 'hangup-all'])
-        out = subprocess.check_output([script_dir / 'list-calls'])
-        self.assertEqual(out, b'[ /ril_0 ]\n')
+        out = subprocess.check_output([script_dir / "hangup-all"])
+        out = subprocess.check_output([script_dir / "list-calls"])
+        self.assertEqual(out, b"[ /ril_0 ]\n")
 
     def test_list_operators(self):
-        '''list operators'''
+        """list operators"""
 
-        out = subprocess.check_output([script_dir / 'list-operators'], universal_newlines=True)
-        self.assertTrue(out.startswith('[ /ril_0 ]'), out)
-        self.assertIn('[ /ril_0/operator/op1 ]', out)
-        self.assertIn('Status = current', out)
-        self.assertIn('Technologies = gsm', out)
-        self.assertIn('MobileNetworkCode = 11', out)
-        self.assertIn('MobileCountryCode = 777', out)
-        self.assertIn('Name = fake.tel', out)
+        out = subprocess.check_output([script_dir / "list-operators"], universal_newlines=True)
+        self.assertTrue(out.startswith("[ /ril_0 ]"), out)
+        self.assertIn("[ /ril_0/operator/op1 ]", out)
+        self.assertIn("Status = current", out)
+        self.assertIn("Technologies = gsm", out)
+        self.assertIn("MobileNetworkCode = 11", out)
+        self.assertIn("MobileCountryCode = 777", out)
+        self.assertIn("Name = fake.tel", out)
 
     def test_get_operators_for_two_modems(self):
-        '''Add second modem, list operators on both'''
+        """Add second modem, list operators on both"""
 
-        iface = 'org.ofono.NetworkRegistration'
+        iface = "org.ofono.NetworkRegistration"
 
         # add second modem
-        self.obj_ofono.AddModem('sim2', {'Powered': True})
+        self.obj_ofono.AddModem("sim2", {"Powered": True})
 
         # get modem proxy, get netreg interface
-        modem_0 = self.dbus_con.get_object('org.ofono', '/ril_0')
-        modem_0_netreg = dbus.Interface(
-            modem_0, dbus_interface=iface)
+        modem_0 = self.dbus_con.get_object("org.ofono", "/ril_0")
+        modem_0_netreg = dbus.Interface(modem_0, dbus_interface=iface)
         modem_0_ops = modem_0_netreg.GetOperators()
 
         # get modem proxy, get netreg interface
-        modem_1 = self.dbus_con.get_object('org.ofono', '/sim2')
-        modem_1_netreg = dbus.Interface(
-            modem_1, dbus_interface=iface)
+        modem_1 = self.dbus_con.get_object("org.ofono", "/sim2")
+        modem_1_netreg = dbus.Interface(modem_1, dbus_interface=iface)
         modem_1_ops = modem_1_netreg.GetOperators()
 
-        self.assertIn('/ril_0/operator/op1', str(modem_0_ops))
-        self.assertNotIn('/sim2', str(modem_0_ops))
+        self.assertIn("/ril_0/operator/op1", str(modem_0_ops))
+        self.assertNotIn("/sim2", str(modem_0_ops))
 
-        self.assertIn('/sim2/operator/op1', str(modem_1_ops))
-        self.assertNotIn('/ril_0', str(modem_1_ops))
+        self.assertIn("/sim2/operator/op1", str(modem_1_ops))
+        self.assertNotIn("/ril_0", str(modem_1_ops))
 
     def test_second_modem(self):
-        '''Add a second modem'''
-        out = subprocess.check_output([script_dir / 'list-modems'])
-        self.assertIn(b'CardIdentifier = 893581234000000000000', out)
-        self.assertIn(b'Serial = 12345678-1234-1234-1234-000000000000', out)
-        self.assertIn(b'SubscriberIdentity = 310150000000000', out)
+        """Add a second modem"""
+        out = subprocess.check_output([script_dir / "list-modems"])
+        self.assertIn(b"CardIdentifier = 893581234000000000000", out)
+        self.assertIn(b"Serial = 12345678-1234-1234-1234-000000000000", out)
+        self.assertIn(b"SubscriberIdentity = 310150000000000", out)
 
-        self.obj_ofono.AddModem('sim2', {'Powered': True})
+        self.obj_ofono.AddModem("sim2", {"Powered": True})
 
-        out = subprocess.check_output([script_dir / 'list-modems'])
-        self.assertTrue(out.startswith(b'[ /ril_0 ]'), out)
-        self.assertIn(b'[ /sim2 ]', out)
-        self.assertIn(b'Powered = 1', out)
-        self.assertIn(b'CardIdentifier = 893581234000000000000', out)
-        self.assertIn(b'Serial = 12345678-1234-1234-1234-000000000000', out)
-        self.assertIn(b'SubscriberIdentity = 310150000000000', out)
-        self.assertIn(b'CardIdentifier = 893581234000000000001', out)
-        self.assertIn(b'Serial = 12345678-1234-1234-1234-000000000001', out)
-        self.assertIn(b'SubscriberIdentity = 310150000000001', out)
+        out = subprocess.check_output([script_dir / "list-modems"])
+        self.assertTrue(out.startswith(b"[ /ril_0 ]"), out)
+        self.assertIn(b"[ /sim2 ]", out)
+        self.assertIn(b"Powered = 1", out)
+        self.assertIn(b"CardIdentifier = 893581234000000000000", out)
+        self.assertIn(b"Serial = 12345678-1234-1234-1234-000000000000", out)
+        self.assertIn(b"SubscriberIdentity = 310150000000000", out)
+        self.assertIn(b"CardIdentifier = 893581234000000000001", out)
+        self.assertIn(b"Serial = 12345678-1234-1234-1234-000000000001", out)
+        self.assertIn(b"SubscriberIdentity = 310150000000001", out)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # avoid writing to stderr
     unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout))

--- a/tests/test_polkitd.py
+++ b/tests/test_polkitd.py
@@ -4,11 +4,11 @@
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Martin Pitt'
-__copyright__ = '''
+__author__ = "Martin Pitt"
+__copyright__ = """
 (c) 2013 Canonical Ltd.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 import shutil
 import subprocess
@@ -21,12 +21,12 @@ import dbus.mainloop.glib
 import dbusmock
 
 dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
-have_pkcheck = shutil.which('pkcheck')
+have_pkcheck = shutil.which("pkcheck")
 
 
-@unittest.skipUnless(have_pkcheck, 'pkcheck not installed')
+@unittest.skipUnless(have_pkcheck, "pkcheck not installed")
 class TestPolkit(dbusmock.DBusTestCase):
-    '''Test mocking polkitd'''
+    """Test mocking polkitd"""
 
     @classmethod
     def setUpClass(cls):
@@ -34,8 +34,7 @@ class TestPolkit(dbusmock.DBusTestCase):
         cls.dbus_con = cls.get_dbus(True)
 
     def setUp(self):
-        (self.p_mock, self.obj_polkitd) = self.spawn_server_template(
-            'polkitd', {}, stdout=subprocess.PIPE)
+        (self.p_mock, self.obj_polkitd) = self.spawn_server_template("polkitd", {}, stdout=subprocess.PIPE)
         self.dbusmock = dbus.Interface(self.obj_polkitd, dbusmock.MOCK_IFACE)
 
     def tearDown(self):
@@ -44,24 +43,24 @@ class TestPolkit(dbusmock.DBusTestCase):
         self.p_mock.wait()
 
     def test_default(self):
-        self.check_action('org.freedesktop.test.frobnicate', False)
+        self.check_action("org.freedesktop.test.frobnicate", False)
 
     def test_allow_unknown(self):
         self.dbusmock.AllowUnknown(True)
-        self.check_action('org.freedesktop.test.frobnicate', True)
+        self.check_action("org.freedesktop.test.frobnicate", True)
         self.dbusmock.AllowUnknown(False)
-        self.check_action('org.freedesktop.test.frobnicate', False)
+        self.check_action("org.freedesktop.test.frobnicate", False)
 
     def test_set_allowed(self):
-        self.dbusmock.SetAllowed(['org.freedesktop.test.frobnicate', 'org.freedesktop.test.slap'])
-        self.check_action('org.freedesktop.test.frobnicate', True)
-        self.check_action('org.freedesktop.test.slap', True)
-        self.check_action('org.freedesktop.test.wobble', False)
+        self.dbusmock.SetAllowed(["org.freedesktop.test.frobnicate", "org.freedesktop.test.slap"])
+        self.check_action("org.freedesktop.test.frobnicate", True)
+        self.check_action("org.freedesktop.test.slap", True)
+        self.check_action("org.freedesktop.test.wobble", False)
 
     def test_hanging_call(self):
         self.dbusmock.SimulateHang(True)
         self.assertFalse(self.dbusmock.HaveHangingCalls())
-        pkcheck = self.check_action_run('org.freedesktop.test.frobnicate')
+        pkcheck = self.check_action_run("org.freedesktop.test.frobnicate")
         with self.assertRaises(subprocess.TimeoutExpired):
             pkcheck.wait(0.8)
 
@@ -71,14 +70,12 @@ class TestPolkit(dbusmock.DBusTestCase):
         pkcheck.wait()
 
     def test_hanging_call_return(self):
-        self.dbusmock.SetAllowed(['org.freedesktop.test.frobnicate'])
-        self.dbusmock.SimulateHangActions(['org.freedesktop.test.frobnicate',
-                                           'org.freedesktop.test.slap'])
+        self.dbusmock.SetAllowed(["org.freedesktop.test.frobnicate"])
+        self.dbusmock.SimulateHangActions(["org.freedesktop.test.frobnicate", "org.freedesktop.test.slap"])
         self.assertFalse(self.dbusmock.HaveHangingCalls())
 
-        frobnicate_pkcheck = self.check_action_run(
-            'org.freedesktop.test.frobnicate')
-        slap_pkcheck = self.check_action_run('org.freedesktop.test.slap')
+        frobnicate_pkcheck = self.check_action_run("org.freedesktop.test.frobnicate")
+        slap_pkcheck = self.check_action_run("org.freedesktop.test.slap")
 
         with self.assertRaises(subprocess.TimeoutExpired):
             frobnicate_pkcheck.wait(0.3)
@@ -93,7 +90,7 @@ class TestPolkit(dbusmock.DBusTestCase):
 
     def test_delayed_call(self):
         self.dbusmock.SetDelay(3)
-        pkcheck = self.check_action_run('org.freedesktop.test.frobnicate')
+        pkcheck = self.check_action_run("org.freedesktop.test.frobnicate")
         with self.assertRaises(subprocess.TimeoutExpired):
             pkcheck.wait(0.8)
         pkcheck.stdout.close()
@@ -102,8 +99,8 @@ class TestPolkit(dbusmock.DBusTestCase):
 
     def test_delayed_call_return(self):
         self.dbusmock.SetDelay(1)
-        self.dbusmock.SetAllowed(['org.freedesktop.test.frobnicate'])
-        pkcheck = self.check_action_run('org.freedesktop.test.frobnicate')
+        self.dbusmock.SetAllowed(["org.freedesktop.test.frobnicate"])
+        pkcheck = self.check_action_run("org.freedesktop.test.frobnicate")
         with self.assertRaises(subprocess.TimeoutExpired):
             pkcheck.wait(0.8)
         self.check_action_result(pkcheck, True)
@@ -111,25 +108,26 @@ class TestPolkit(dbusmock.DBusTestCase):
     @staticmethod
     def check_action_run(action):
         # pylint: disable=consider-using-with
-        return subprocess.Popen(['pkcheck', '--action-id',
-                                 action, '--process', '123'],
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.STDOUT,
-                                universal_newlines=True)
+        return subprocess.Popen(
+            ["pkcheck", "--action-id", action, "--process", "123"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+        )
 
     def check_action_result(self, pkcheck, expect_allow):
         out = pkcheck.communicate()[0]
         if expect_allow:
             self.assertEqual(pkcheck.returncode, 0)
-            self.assertEqual(out, 'test=test\n')
+            self.assertEqual(out, "test=test\n")
         else:
             self.assertNotEqual(pkcheck.returncode, 0)
-            self.assertEqual(out, 'test=test\nNot authorized.\n')
+            self.assertEqual(out, "test=test\nNot authorized.\n")
 
     def check_action(self, action, expect_allow):
         self.check_action_result(self.check_action_run(action), expect_allow)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # avoid writing to stderr
     unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout))

--- a/tests/test_systemd.py
+++ b/tests/test_systemd.py
@@ -4,11 +4,11 @@
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Jonas Ådahl'
-__copyright__ = '''
+__author__ = "Jonas Ådahl"
+__copyright__ = """
 (c) 2021 Red Hat
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 import subprocess
 import sys
@@ -24,7 +24,7 @@ dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
 
 
 class TestSystemd(dbusmock.DBusTestCase):
-    '''Test mocking systemd'''
+    """Test mocking systemd"""
 
     @classmethod
     def setUpClass(cls):
@@ -43,15 +43,13 @@ class TestSystemd(dbusmock.DBusTestCase):
             self.p_mock.wait()
 
     def _assert_unit_property(self, unit_obj, name, expect):
-        value = unit_obj.Get('org.freedesktop.systemd1.Unit', name)
+        value = unit_obj.Get("org.freedesktop.systemd1.Unit", name)
         self.assertEqual(str(value), expect)
 
     def _test_base(self, bus, system_bus=True):
-        dummy_service = 'dummy-dbusmock.service'
+        dummy_service = "dummy-dbusmock.service"
 
-        (self.p_mock, obj_systemd) = self.spawn_server_template('systemd', {},
-                                                                subprocess.PIPE,
-                                                                system_bus=system_bus)
+        (self.p_mock, obj_systemd) = self.spawn_server_template("systemd", {}, subprocess.PIPE, system_bus=system_bus)
 
         systemd_mock = dbus.Interface(obj_systemd, dbusmock.MOCK_IFACE)
         systemd_mock.AddMockUnit(dummy_service)
@@ -61,8 +59,7 @@ class TestSystemd(dbusmock.DBusTestCase):
         removed_jobs = []
 
         def catch_job_removed(*args, **kwargs):
-            if (kwargs['interface'] == 'org.freedesktop.systemd1.Manager' and
-                    kwargs['member'] == 'JobRemoved'):
+            if kwargs["interface"] == "org.freedesktop.systemd1.Manager" and kwargs["member"] == "JobRemoved":
                 job_path = str(args[1])
                 removed_jobs.append(job_path)
                 main_loop.quit()
@@ -73,28 +70,27 @@ class TestSystemd(dbusmock.DBusTestCase):
                 if path in removed_jobs:
                     break
 
-        bus.add_signal_receiver(catch_job_removed,
-                                interface_keyword='interface',
-                                path_keyword='path',
-                                member_keyword='member')
+        bus.add_signal_receiver(
+            catch_job_removed, interface_keyword="interface", path_keyword="path", member_keyword="member"
+        )
 
         unit_path = obj_systemd.GetUnit(dummy_service)
 
-        unit_obj = bus.get_object('org.freedesktop.systemd1', unit_path)
+        unit_obj = bus.get_object("org.freedesktop.systemd1", unit_path)
 
-        self._assert_unit_property(unit_obj, 'Id', dummy_service)
-        self._assert_unit_property(unit_obj, 'LoadState', 'loaded')
-        self._assert_unit_property(unit_obj, 'ActiveState', 'inactive')
+        self._assert_unit_property(unit_obj, "Id", dummy_service)
+        self._assert_unit_property(unit_obj, "LoadState", "loaded")
+        self._assert_unit_property(unit_obj, "ActiveState", "inactive")
 
-        job_path = obj_systemd.StartUnit(dummy_service, 'fail')
-
-        wait_for_job(job_path)
-        self._assert_unit_property(unit_obj, 'ActiveState', 'active')
-
-        job_path = obj_systemd.StopUnit(dummy_service, 'fail')
+        job_path = obj_systemd.StartUnit(dummy_service, "fail")
 
         wait_for_job(job_path)
-        self._assert_unit_property(unit_obj, 'ActiveState', 'inactive')
+        self._assert_unit_property(unit_obj, "ActiveState", "active")
+
+        job_path = obj_systemd.StopUnit(dummy_service, "fail")
+
+        wait_for_job(job_path)
+        self._assert_unit_property(unit_obj, "ActiveState", "inactive")
 
         self.p_mock.stdout.close()
         self.p_mock.terminate()
@@ -108,6 +104,6 @@ class TestSystemd(dbusmock.DBusTestCase):
         self._test_base(self.system_bus, system_bus=True)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # avoid writing to stderr
     unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout))

--- a/tests/test_timedated.py
+++ b/tests/test_timedated.py
@@ -4,11 +4,11 @@
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Iain Lane'
-__copyright__ = '''
+__author__ = "Iain Lane"
+__copyright__ = """
 (c) 2013 Canonical Ltd.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 import shutil
 import subprocess
@@ -19,15 +19,15 @@ from pathlib import Path
 import dbusmock
 
 # timedatectl keeps changing its CLI output
-TIMEDATECTL_NTP_LABEL = '(NTP enabled|synchronized|systemd-timesyncd.service active)'
+TIMEDATECTL_NTP_LABEL = "(NTP enabled|synchronized|systemd-timesyncd.service active)"
 
-have_timedatectl = shutil.which('timedatectl')
+have_timedatectl = shutil.which("timedatectl")
 
 
-@unittest.skipUnless(have_timedatectl, 'timedatectl not installed')
-@unittest.skipUnless(Path('/run/systemd/system').exists(), '/run/systemd/system does not exist')
+@unittest.skipUnless(have_timedatectl, "timedatectl not installed")
+@unittest.skipUnless(Path("/run/systemd/system").exists(), "/run/systemd/system does not exist")
 class TestTimedated(dbusmock.DBusTestCase):
-    '''Test mocking timedated'''
+    """Test mocking timedated"""
 
     @classmethod
     def setUpClass(cls):
@@ -35,13 +35,8 @@ class TestTimedated(dbusmock.DBusTestCase):
         cls.dbus_con = cls.get_dbus(True)
 
     def setUp(self):
-        (self.p_mock, _) = self.spawn_server_template(
-            'timedated',
-            {},
-            stdout=subprocess.PIPE)
-        self.obj_timedated = self.dbus_con.get_object(
-            'org.freedesktop.timedate1',
-            '/org/freedesktop/timedate1')
+        (self.p_mock, _) = self.spawn_server_template("timedated", {}, stdout=subprocess.PIPE)
+        self.obj_timedated = self.dbus_con.get_object("org.freedesktop.timedate1", "/org/freedesktop/timedate1")
 
     def tearDown(self):
         if self.p_mock:
@@ -50,42 +45,40 @@ class TestTimedated(dbusmock.DBusTestCase):
             self.p_mock.wait()
 
     def run_timedatectl(self):
-        return subprocess.check_output(['timedatectl'],
-                                       universal_newlines=True)
+        return subprocess.check_output(["timedatectl"], universal_newlines=True)
 
     def test_default_timezone(self):
         out = self.run_timedatectl()
         # timedatectl doesn't get the timezone offset information over dbus so
         # we can't mock that.
-        self.assertRegex(out, 'Time *zone: Etc/Utc')
+        self.assertRegex(out, "Time *zone: Etc/Utc")
 
     def test_changing_timezone(self):
-        self.obj_timedated.SetTimezone('Africa/Johannesburg', False)
+        self.obj_timedated.SetTimezone("Africa/Johannesburg", False)
         out = self.run_timedatectl()
         # timedatectl doesn't get the timezone offset information over dbus so
         # we can't mock that.
-        self.assertRegex(out, 'Time *zone: Africa/Johannesburg')
+        self.assertRegex(out, "Time *zone: Africa/Johannesburg")
 
     def test_default_ntp(self):
         out = self.run_timedatectl()
-        self.assertRegex(out, f'{TIMEDATECTL_NTP_LABEL}: yes')
+        self.assertRegex(out, f"{TIMEDATECTL_NTP_LABEL}: yes")
 
     def test_changing_ntp(self):
         self.obj_timedated.SetNTP(False, False)
         out = self.run_timedatectl()
-        self.assertRegex(out, f'{TIMEDATECTL_NTP_LABEL}: no')
+        self.assertRegex(out, f"{TIMEDATECTL_NTP_LABEL}: no")
 
     def test_default_local_rtc(self):
         out = self.run_timedatectl()
-        self.assertRegex(out, 'RTC in local TZ: no')
+        self.assertRegex(out, "RTC in local TZ: no")
 
     def test_changing_local_rtc(self):
         self.obj_timedated.SetLocalRTC(True, False, False)
         out = self.run_timedatectl()
-        self.assertRegex(out, 'RTC in local TZ: yes')
+        self.assertRegex(out, "RTC in local TZ: yes")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # avoid writing to stderr
-    unittest.main(testRunner=unittest.TextTestRunner(
-        stream=sys.stdout))
+    unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout))

--- a/tests/test_upower.py
+++ b/tests/test_upower.py
@@ -4,11 +4,11 @@
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Martin Pitt'
-__copyright__ = '''
+__author__ = "Martin Pitt"
+__copyright__ = """
 (c) 2012 Canonical Ltd.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 import fcntl
 import os
@@ -27,12 +27,12 @@ UP_DEVICE_LEVEL_UNKNOWN = 0
 UP_DEVICE_LEVEL_NONE = 1
 
 tracemalloc.start(25)
-have_upower = shutil.which('upower')
+have_upower = shutil.which("upower")
 
 
-@unittest.skipUnless(have_upower, 'upower not installed')
+@unittest.skipUnless(have_upower, "upower not installed")
 class TestUPower(dbusmock.DBusTestCase):
-    '''Test mocking upowerd'''
+    """Test mocking upowerd"""
 
     @classmethod
     def setUpClass(cls):
@@ -41,12 +41,14 @@ class TestUPower(dbusmock.DBusTestCase):
 
     def setUp(self):
         (self.p_mock, self.obj_upower) = self.spawn_server_template(
-            'upower', {
-                'OnBattery': True,
-                'HibernateAllowed': False,
-                'GetCriticalAction': 'Suspend',
+            "upower",
+            {
+                "OnBattery": True,
+                "HibernateAllowed": False,
+                "GetCriticalAction": "Suspend",
             },
-            stdout=subprocess.PIPE)
+            stdout=subprocess.PIPE,
+        )
         # set log to nonblocking
         flags = fcntl.fcntl(self.p_mock.stdout, fcntl.F_GETFL)
         fcntl.fcntl(self.p_mock.stdout, fcntl.F_SETFL, flags | os.O_NONBLOCK)
@@ -58,151 +60,154 @@ class TestUPower(dbusmock.DBusTestCase):
         self.p_mock.wait()
 
     def test_no_devices(self):
-        out = subprocess.check_output(['upower', '--dump'],
-                                      universal_newlines=True)
-        self.assertIn('/DisplayDevice\n', out)
+        out = subprocess.check_output(["upower", "--dump"], universal_newlines=True)
+        self.assertIn("/DisplayDevice\n", out)
         # should not have any other device
         for line in out.splitlines():
-            if line.endswith('/DisplayDevice'):
+            if line.endswith("/DisplayDevice"):
                 continue
-            self.assertNotIn('Device', line)
-        self.assertRegex(out, 'on-battery:\\s+yes')
-        self.assertRegex(out, 'lid-is-present:\\s+yes')
-        self.assertRegex(out, 'daemon-version:\\s+0.99')
-        self.assertRegex(out, 'critical-action:\\s+Suspend')
-        self.assertNotIn('can-suspend', out)
+            self.assertNotIn("Device", line)
+        self.assertRegex(out, "on-battery:\\s+yes")
+        self.assertRegex(out, "lid-is-present:\\s+yes")
+        self.assertRegex(out, "daemon-version:\\s+0.99")
+        self.assertRegex(out, "critical-action:\\s+Suspend")
+        self.assertNotIn("can-suspend", out)
 
     def test_one_ac(self):
-        path = self.dbusmock.AddAC('mock_AC', 'Mock AC')
-        self.assertEqual(path, '/org/freedesktop/UPower/devices/mock_AC')
+        path = self.dbusmock.AddAC("mock_AC", "Mock AC")
+        self.assertEqual(path, "/org/freedesktop/UPower/devices/mock_AC")
 
-        self.assertRegex(self.p_mock.stdout.read(),
-                         b'emit /org/freedesktop/UPower org.freedesktop.UPower.DeviceAdded '
-                         b'"/org/freedesktop/UPower/devices/mock_AC"\n')
+        self.assertRegex(
+            self.p_mock.stdout.read(),
+            b'emit /org/freedesktop/UPower org.freedesktop.UPower.DeviceAdded "/org/freedesktop/UPower/devices/mock_AC"\n',
+        )
 
-        out = subprocess.check_output(['upower', '--dump'],
-                                      universal_newlines=True)
-        self.assertRegex(out, 'Device: ' + path)
+        out = subprocess.check_output(["upower", "--dump"], universal_newlines=True)
+        self.assertRegex(out, "Device: " + path)
         # note, Add* is not magic: this just adds an object, not change
         # properties
-        self.assertRegex(out, 'on-battery:\\s+yes')
-        self.assertRegex(out, 'lid-is-present:\\s+yes')
+        self.assertRegex(out, "on-battery:\\s+yes")
+        self.assertRegex(out, "lid-is-present:\\s+yes")
         # print('--------- out --------\n%s\n------------' % out)
 
-        with subprocess.Popen(['upower', '--monitor-detail'],
-                              stdout=subprocess.PIPE,
-                              universal_newlines=True) as mon:
+        with subprocess.Popen(["upower", "--monitor-detail"], stdout=subprocess.PIPE, universal_newlines=True) as mon:
             time.sleep(0.3)
-            self.dbusmock.SetDeviceProperties(path, {
-                'PowerSupply': dbus.Boolean(True, variant_level=1)
-            })
+            self.dbusmock.SetDeviceProperties(path, {"PowerSupply": dbus.Boolean(True, variant_level=1)})
             time.sleep(0.2)
 
             mon.terminate()
             out = mon.communicate()[0]
-            self.assertRegex(out, 'device changed:\\s+' + path)
+            self.assertRegex(out, "device changed:\\s+" + path)
             # print('--------- monitor out --------\n%s\n------------' % out)
 
     def test_discharging_battery(self):
-        path = self.dbusmock.AddDischargingBattery('mock_BAT', 'Mock Battery', 30.0, 1200)
-        self.assertEqual(path, '/org/freedesktop/UPower/devices/mock_BAT')
+        path = self.dbusmock.AddDischargingBattery("mock_BAT", "Mock Battery", 30.0, 1200)
+        self.assertEqual(path, "/org/freedesktop/UPower/devices/mock_BAT")
 
-        self.assertRegex(self.p_mock.stdout.read(),
-                         b'emit /org/freedesktop/UPower org.freedesktop.UPower.DeviceAdded '
-                         b'"/org/freedesktop/UPower/devices/mock_BAT"\n')
+        self.assertRegex(
+            self.p_mock.stdout.read(),
+            b'emit /org/freedesktop/UPower org.freedesktop.UPower.DeviceAdded "/org/freedesktop/UPower/devices/mock_BAT"\n',
+        )
 
-        out = subprocess.check_output(['upower', '--dump'],
-                                      universal_newlines=True)
-        self.assertRegex(out, 'Device: ' + path)
+        out = subprocess.check_output(["upower", "--dump"], universal_newlines=True)
+        self.assertRegex(out, "Device: " + path)
         # note, Add* is not magic: this just adds an object, not change
         # properties
-        self.assertRegex(out, 'on-battery:\\s+yes')
-        self.assertRegex(out, 'lid-is-present:\\s+yes')
-        self.assertRegex(out, ' present:\\s+yes')
-        self.assertRegex(out, ' percentage:\\s+30%')
-        self.assertRegex(out, ' time to empty:\\s+20.0 min')
-        self.assertRegex(out, ' state:\\s+discharging')
+        self.assertRegex(out, "on-battery:\\s+yes")
+        self.assertRegex(out, "lid-is-present:\\s+yes")
+        self.assertRegex(out, " present:\\s+yes")
+        self.assertRegex(out, " percentage:\\s+30%")
+        self.assertRegex(out, " time to empty:\\s+20.0 min")
+        self.assertRegex(out, " state:\\s+discharging")
 
     def test_charging_battery(self):
-        path = self.dbusmock.AddChargingBattery('mock_BAT', 'Mock Battery', 30.0, 1200)
-        self.assertEqual(path, '/org/freedesktop/UPower/devices/mock_BAT')
+        path = self.dbusmock.AddChargingBattery("mock_BAT", "Mock Battery", 30.0, 1200)
+        self.assertEqual(path, "/org/freedesktop/UPower/devices/mock_BAT")
 
-        self.assertRegex(self.p_mock.stdout.read(),
-                         b'emit /org/freedesktop/UPower org.freedesktop.UPower.DeviceAdded '
-                         b'"/org/freedesktop/UPower/devices/mock_BAT"\n')
+        self.assertRegex(
+            self.p_mock.stdout.read(),
+            b'emit /org/freedesktop/UPower org.freedesktop.UPower.DeviceAdded "/org/freedesktop/UPower/devices/mock_BAT"\n',
+        )
 
-        out = subprocess.check_output(['upower', '--dump'],
-                                      universal_newlines=True)
-        self.assertRegex(out, 'Device: ' + path)
+        out = subprocess.check_output(["upower", "--dump"], universal_newlines=True)
+        self.assertRegex(out, "Device: " + path)
         # note, Add* is not magic: this just adds an object, not change
         # properties
-        self.assertRegex(out, 'on-battery:\\s+yes')
-        self.assertRegex(out, 'lid-is-present:\\s+yes')
-        self.assertRegex(out, ' present:\\s+yes')
-        self.assertRegex(out, ' percentage:\\s+30%')
-        self.assertRegex(out, ' time to full:\\s+20.0 min')
-        self.assertRegex(out, ' state:\\s+charging')
+        self.assertRegex(out, "on-battery:\\s+yes")
+        self.assertRegex(out, "lid-is-present:\\s+yes")
+        self.assertRegex(out, " present:\\s+yes")
+        self.assertRegex(out, " percentage:\\s+30%")
+        self.assertRegex(out, " time to full:\\s+20.0 min")
+        self.assertRegex(out, " state:\\s+charging")
 
     def test_enumerate(self):
-        self.dbusmock.AddAC('mock_AC', 'Mock AC')
-        self.assertEqual(self.obj_upower.EnumerateDevices(),
-                         ['/org/freedesktop/UPower/devices/mock_AC'])
+        self.dbusmock.AddAC("mock_AC", "Mock AC")
+        self.assertEqual(self.obj_upower.EnumerateDevices(), ["/org/freedesktop/UPower/devices/mock_AC"])
 
     def test_display_device_default(self):
         path = self.obj_upower.GetDisplayDevice()
-        self.assertEqual(path, '/org/freedesktop/UPower/devices/DisplayDevice')
-        display_dev = self.dbus_con.get_object('org.freedesktop.UPower', path)
-        props = display_dev.GetAll('org.freedesktop.UPower.Device')
+        self.assertEqual(path, "/org/freedesktop/UPower/devices/DisplayDevice")
+        display_dev = self.dbus_con.get_object("org.freedesktop.UPower", path)
+        props = display_dev.GetAll("org.freedesktop.UPower.Device")
 
         # http://cgit.freedesktop.org/upower/tree/src/org.freedesktop.UPower.xml
         # defines the properties which are defined
         self.assertEqual(
             set(props.keys()),
-            {'Type', 'State', 'Percentage', 'Energy', 'EnergyFull',
-             'EnergyRate', 'TimeToEmpty', 'TimeToFull', 'IsPresent',
-             'IconName', 'WarningLevel'})
+            {
+                "Type",
+                "State",
+                "Percentage",
+                "Energy",
+                "EnergyFull",
+                "EnergyRate",
+                "TimeToEmpty",
+                "TimeToFull",
+                "IsPresent",
+                "IconName",
+                "WarningLevel",
+            },
+        )
 
         # not set up by default, so should not present
-        self.assertEqual(props['IsPresent'], False)
-        self.assertEqual(props['IconName'], '')
-        self.assertEqual(props['WarningLevel'], UP_DEVICE_LEVEL_NONE)
+        self.assertEqual(props["IsPresent"], False)
+        self.assertEqual(props["IconName"], "")
+        self.assertEqual(props["WarningLevel"], UP_DEVICE_LEVEL_NONE)
 
     def test_setup_display_device(self):
-        self.dbusmock.SetupDisplayDevice(2, 1, 50.0, 40.0, 80.0, 2.5, 3600,
-                                         1800, True, 'half-battery', 3)
+        self.dbusmock.SetupDisplayDevice(2, 1, 50.0, 40.0, 80.0, 2.5, 3600, 1800, True, "half-battery", 3)
 
         path = self.obj_upower.GetDisplayDevice()
-        display_dev = self.dbus_con.get_object('org.freedesktop.UPower', path)
-        props = display_dev.GetAll('org.freedesktop.UPower.Device')
+        display_dev = self.dbus_con.get_object("org.freedesktop.UPower", path)
+        props = display_dev.GetAll("org.freedesktop.UPower.Device")
 
         # just some spot-checks, check all the values from upower -d
-        self.assertEqual(props['Type'], 2)
-        self.assertEqual(props['Percentage'], 50.0)
-        self.assertEqual(props['WarningLevel'], 3)
+        self.assertEqual(props["Type"], 2)
+        self.assertEqual(props["Percentage"], 50.0)
+        self.assertEqual(props["WarningLevel"], 3)
 
         env = os.environ.copy()
-        env['LC_ALL'] = 'C'
+        env["LC_ALL"] = "C"
         try:
-            del env['LANGUAGE']
+            del env["LANGUAGE"]
         except KeyError:
             pass
 
-        out = subprocess.check_output(['upower', '--dump'],
-                                      universal_newlines=True, env=env)
-        self.assertIn('/DisplayDevice\n', out)
-        self.assertIn('  battery\n', out)  # type
-        self.assertRegex(out, r'state:\s+charging')
-        self.assertRegex(out, r'percentage:\s+50%')
-        self.assertRegex(out, r'energy:\s+40 Wh')
-        self.assertRegex(out, r'energy-full:\s+80 Wh')
-        self.assertRegex(out, r'energy-rate:\s+2.5 W')
-        self.assertRegex(out, r'time to empty:\s+1\.0 hours')
-        self.assertRegex(out, r'time to full:\s+30\.0 minutes')
-        self.assertRegex(out, r'present:\s+yes')
+        out = subprocess.check_output(["upower", "--dump"], universal_newlines=True, env=env)
+        self.assertIn("/DisplayDevice\n", out)
+        self.assertIn("  battery\n", out)  # type
+        self.assertRegex(out, r"state:\s+charging")
+        self.assertRegex(out, r"percentage:\s+50%")
+        self.assertRegex(out, r"energy:\s+40 Wh")
+        self.assertRegex(out, r"energy-full:\s+80 Wh")
+        self.assertRegex(out, r"energy-rate:\s+2.5 W")
+        self.assertRegex(out, r"time to empty:\s+1\.0 hours")
+        self.assertRegex(out, r"time to full:\s+30\.0 minutes")
+        self.assertRegex(out, r"present:\s+yes")
         self.assertRegex(out, r"icon-name:\s+'half-battery'")
-        self.assertRegex(out, r'warning-level:\s+low')
+        self.assertRegex(out, r"warning-level:\s+low")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # avoid writing to stderr
     unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout))

--- a/tests/test_urfkill.py
+++ b/tests/test_urfkill.py
@@ -4,11 +4,11 @@
 # later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
 # of the license.
 
-__author__ = 'Jussi Pakkanen'
-__copyright__ = '''
+__author__ = "Jussi Pakkanen"
+__copyright__ = """
 (c) 2015 Canonical Ltd.
 (c) 2017 - 2022 Martin Pitt <martin@piware.de>
-'''
+"""
 
 import fcntl
 import os
@@ -23,13 +23,13 @@ import dbusmock
 
 def _get_urfkill_objects():
     bus = dbus.SystemBus()
-    remote_object = bus.get_object('org.freedesktop.URfkill', '/org/freedesktop/URfkill')
-    iface = dbus.Interface(remote_object, 'org.freedesktop.URfkill')
+    remote_object = bus.get_object("org.freedesktop.URfkill", "/org/freedesktop/URfkill")
+    iface = dbus.Interface(remote_object, "org.freedesktop.URfkill")
     return (remote_object, iface)
 
 
 class TestURfkill(dbusmock.DBusTestCase):
-    '''Test mocked URfkill'''
+    """Test mocked URfkill"""
 
     @classmethod
     def setUpClass(cls):
@@ -37,9 +37,7 @@ class TestURfkill(dbusmock.DBusTestCase):
         cls.dbus_con = cls.get_dbus(True)
 
     def setUp(self):
-        (self.p_mock, self.obj_urfkill) = self.spawn_server_template(
-            'urfkill', {},
-            stdout=subprocess.PIPE)
+        (self.p_mock, self.obj_urfkill) = self.spawn_server_template("urfkill", {}, stdout=subprocess.PIPE)
         # set log to nonblocking
         flags = fcntl.fcntl(self.p_mock.stdout, fcntl.F_GETFL)
         fcntl.fcntl(self.p_mock.stdout, fcntl.F_SETFL, flags | os.O_NONBLOCK)
@@ -53,33 +51,33 @@ class TestURfkill(dbusmock.DBusTestCase):
     def test_mainobject(self):
         (remote_object, iface) = _get_urfkill_objects()
         self.assertFalse(iface.IsFlightMode())
-        propiface = dbus.Interface(remote_object, 'org.freedesktop.DBus.Properties')
-        version = propiface.Get('org.freedesktop.URfkill', 'DaemonVersion')
-        self.assertEqual(version, '0.6.0')
+        propiface = dbus.Interface(remote_object, "org.freedesktop.DBus.Properties")
+        version = propiface.Get("org.freedesktop.URfkill", "DaemonVersion")
+        self.assertEqual(version, "0.6.0")
 
     def test_subobjects(self):
         bus = dbus.SystemBus()
-        individual_objects = ['BLUETOOTH', 'FM', 'GPS', 'NFC', 'UWB', 'WIMAX', 'WLAN', 'WWAN']
+        individual_objects = ["BLUETOOTH", "FM", "GPS", "NFC", "UWB", "WIMAX", "WLAN", "WWAN"]
         for i in individual_objects:
-            path = '/org/freedesktop/URfkill/' + i
-            remote_object = bus.get_object('org.freedesktop.URfkill', path)
-            propiface = dbus.Interface(remote_object, 'org.freedesktop.DBus.Properties')
-            state = propiface.Get('org.freedesktop.URfkill.Killswitch', 'state')
+            path = "/org/freedesktop/URfkill/" + i
+            remote_object = bus.get_object("org.freedesktop.URfkill", path)
+            propiface = dbus.Interface(remote_object, "org.freedesktop.DBus.Properties")
+            state = propiface.Get("org.freedesktop.URfkill.Killswitch", "state")
             self.assertEqual(state, 0)
 
     def test_block(self):
         bus = dbus.SystemBus()
         (_, iface) = _get_urfkill_objects()
 
-        property_object = bus.get_object('org.freedesktop.URfkill', '/org/freedesktop/URfkill/WLAN')
-        propiface = dbus.Interface(property_object, 'org.freedesktop.DBus.Properties')
-        self.assertEqual(propiface.Get('org.freedesktop.URfkill.Killswitch', 'state'), 0)
+        property_object = bus.get_object("org.freedesktop.URfkill", "/org/freedesktop/URfkill/WLAN")
+        propiface = dbus.Interface(property_object, "org.freedesktop.DBus.Properties")
+        self.assertEqual(propiface.Get("org.freedesktop.URfkill.Killswitch", "state"), 0)
 
         self.assertTrue(iface.Block(1, True))
-        self.assertEqual(propiface.Get('org.freedesktop.URfkill.Killswitch', 'state'), 1)
+        self.assertEqual(propiface.Get("org.freedesktop.URfkill.Killswitch", "state"), 1)
 
         self.assertTrue(iface.Block(1, False))
-        self.assertEqual(propiface.Get('org.freedesktop.URfkill.Killswitch', 'state'), 0)
+        self.assertEqual(propiface.Get("org.freedesktop.URfkill.Killswitch", "state"), 0)
 
         # 99 is an unknown type to the mock, so it should return false.
         self.assertFalse(iface.Block(99, False))
@@ -88,38 +86,38 @@ class TestURfkill(dbusmock.DBusTestCase):
         bus = dbus.SystemBus()
         (_, iface) = _get_urfkill_objects()
 
-        property_object = bus.get_object('org.freedesktop.URfkill', '/org/freedesktop/URfkill/WLAN')
-        propiface = dbus.Interface(property_object, 'org.freedesktop.DBus.Properties')
+        property_object = bus.get_object("org.freedesktop.URfkill", "/org/freedesktop/URfkill/WLAN")
+        propiface = dbus.Interface(property_object, "org.freedesktop.DBus.Properties")
 
         self.assertFalse(iface.IsFlightMode())
-        self.assertEqual(propiface.Get('org.freedesktop.URfkill.Killswitch', 'state'), 0)
+        self.assertEqual(propiface.Get("org.freedesktop.URfkill.Killswitch", "state"), 0)
         iface.FlightMode(True)
         self.assertTrue(iface.IsFlightMode())
-        self.assertEqual(propiface.Get('org.freedesktop.URfkill.Killswitch', 'state'), 1)
+        self.assertEqual(propiface.Get("org.freedesktop.URfkill.Killswitch", "state"), 1)
         iface.FlightMode(False)
         self.assertFalse(iface.IsFlightMode())
-        self.assertEqual(propiface.Get('org.freedesktop.URfkill.Killswitch', 'state'), 0)
+        self.assertEqual(propiface.Get("org.freedesktop.URfkill.Killswitch", "state"), 0)
 
     def test_flightmode_restore(self):
         # An interface that was blocked remains blocked once flightmode is removed.
         bus = dbus.SystemBus()
         (_, iface) = _get_urfkill_objects()
 
-        property_object = bus.get_object('org.freedesktop.URfkill', '/org/freedesktop/URfkill/WLAN')
-        propiface = dbus.Interface(property_object, 'org.freedesktop.DBus.Properties')
+        property_object = bus.get_object("org.freedesktop.URfkill", "/org/freedesktop/URfkill/WLAN")
+        propiface = dbus.Interface(property_object, "org.freedesktop.DBus.Properties")
 
         self.assertFalse(iface.IsFlightMode())
-        self.assertEqual(propiface.Get('org.freedesktop.URfkill.Killswitch', 'state'), 0)
+        self.assertEqual(propiface.Get("org.freedesktop.URfkill.Killswitch", "state"), 0)
         iface.Block(1, True)
-        self.assertEqual(propiface.Get('org.freedesktop.URfkill.Killswitch', 'state'), 1)
+        self.assertEqual(propiface.Get("org.freedesktop.URfkill.Killswitch", "state"), 1)
         iface.FlightMode(True)
         self.assertTrue(iface.IsFlightMode())
-        self.assertEqual(propiface.Get('org.freedesktop.URfkill.Killswitch', 'state'), 1)
+        self.assertEqual(propiface.Get("org.freedesktop.URfkill.Killswitch", "state"), 1)
         iface.FlightMode(False)
         self.assertFalse(iface.IsFlightMode())
-        self.assertEqual(propiface.Get('org.freedesktop.URfkill.Killswitch', 'state'), 1)
+        self.assertEqual(propiface.Get("org.freedesktop.URfkill.Killswitch", "state"), 1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # avoid writing to stderr
     unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout))


### PR DESCRIPTION
Integrated into pyproject.toml and tests/test_code.py so we can enforce the formatting in the CI.

Fixes #187

---
Quick! let's do this before someone has an idea of refactoring everything :)