### PR TITLE
Add pre-commit rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.5.0
+  hooks:
+  - id: end-of-file-fixer
+  - id: trailing-whitespace
+  - id: check-merge-conflict
+  - id: check-toml
+  - id: check-symlinks
+  - id: no-commit-to-branch
+    args: ['--branch', 'main']
+- repo: https://github.com/psf/black
+  rev: 23.11.0
+  hooks:
+  - id: black
+    args: ['--check', '--diff', '.']
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  rev: v0.1.6
+  hooks:
+  - id: ruff

--- a/packit.yaml
+++ b/packit.yaml
@@ -25,7 +25,7 @@ jobs:
     - fedora-all
     - centos-stream-8-x86_64
     - centos-stream-9-x86_64
-  
+
   - job: tests
     trigger: pull_request
     targets:


### PR DESCRIPTION
A little (optional) helper to avoid screwups. After `pre-commit install` once every `git commit` then runs black and ruff and a bunch of general helpers that looked useful.

Possibly controversial: prevents direct commits to `main`, easy to drop (or work around with `git commit --no-verify` if need be).