### PR TITLE
bluez5: Clean up static default properties, re-drop PairDevice class_ parameter

### DIFF
--- a/tests/test_bluez5.py
+++ b/tests/test_bluez5.py
@@ -180,7 +180,7 @@ class TestBlueZ5(dbusmock.DBusTestCase):
         self.assertEqual(path, "/org/bluez/" + adapter_name + "/dev_" + address.replace(":", "_"))
 
         # Pair with the device.
-        self.dbusmock_bluez.PairDevice(adapter_name, address, 5898764)
+        self.dbusmock_bluez.PairDevice(adapter_name, address)
 
         # Check the device's properties.
         out = "\n".join(_run_bluetoothctl("info " + address))


### PR DESCRIPTION
Over the years, this template has accumulated some hacks and bad API which made PairDevice()'s handling of the Modalias/Class/Icon properties buggy and hard to understand:

 * These are *static* device properties, they are not supposed to change during pairing.
 * Commit ee29a4403359b6a added these as some kind of "dynamic fallback default" when they were not initialized by the caller after AddDevice().
 * Commit 59d6af0dca3e silently broke that fallback default by changing AddDevice() to set these device properties to empty strings.
 * Commit fae4be7f49c0861 added another really bad API for setting Class in PairDevice()(). That API didn't fit into D-Bus (see commit 8968284e8b which had to make it a non-default parameter) and also broke the API, and moreover it is totally unintuitive -- the device class has nothing to do with pairing.

Clean up all of these: Set the static property defaults in AddDevice() right away, so that the caller can adjust them afterwards. Re-drop the `class_` argument in PairDevice(). Adjust the documentation of AddDevice() to point out that properties should be changed after calling that.

Consequently, PairDevice() will stop claiming that the static properties changed. This also gets rid of some redundant code.


-----

@z3ntu, this is meant to fix and Closes #190 .

@pwithnall @hadess @bjoernh I admittedly don't understand the use cases/current callers of this code. I think some API change is inevitable here to clean up, but it should at least make sense. I'd appreciate if you could check my reasoning and do some sanity testing on this with your existing tests. Cheers!