### PR TITLE
bluez5: Fix invalid arguments to PairDevice

### DIFF
--- a/dbusmock/templates/bluez5.py
+++ b/dbusmock/templates/bluez5.py
@@ -333,7 +333,7 @@ def Pair(device):
         raise dbus.exceptions.DBusException("Device already paired", name="org.bluez.Error.AlreadyExists")
     device_address = device.props[DEVICE_IFACE]["Address"]
     adapter_device_name = Path(device.props[DEVICE_IFACE]["Adapter"]).name
-    device.PairDevice(adapter_device_name, device_address, MOCK_PHONE_CLASS)
+    device.PairDevice(adapter_device_name, device_address)
 
 
 @dbus.service.method(DEVICE_IFACE, in_signature="", out_signature="")


### PR DESCRIPTION
The third (device class) argument to PairDevice was removed in 0.30.1, but this call to it was still passing a third parameter, resulting in an error from dbus-python whenever Pair() was called. This caused a unit test regression in gnome-bluetooth.

Fixes: 63264e18 "bluez5: Clean up static default properties, re-drop PairDevice class_ parameter"  
Resolves: https://github.com/martinpitt/python-dbusmock/issues/193  
Bug-Debian: https://bugs.debian.org/1057564