### PR TITLE
power_profiles_daemon: Move to org.freedesktop.UPower.PowerProfiles

### DIFF
--- a/dbusmock/templates/power_profiles_daemon.py
+++ b/dbusmock/templates/power_profiles_daemon.py
@@ -15,14 +15,14 @@ This provides only the non-deprecated D-Bus API as of version 0.9.
 __author__ = "Bastien Nocera"
 __copyright__ = """
 (c) 2021, Red Hat Inc.
-(c) 2017 - 2022 Martin Pitt <martin@piware.de>
+(c) 2017 - 2024 Martin Pitt <martin@piware.de>
 """
 
 import dbus
 
-BUS_NAME = "net.hadess.PowerProfiles"
-MAIN_OBJ = "/net/hadess/PowerProfiles"
-MAIN_IFACE = "net.hadess.PowerProfiles"
+BUS_NAME = "org.freedesktop.UPower.PowerProfiles"
+MAIN_OBJ = "/org/freedesktop/UPower/PowerProfiles"
+MAIN_IFACE = "org.freedesktop.UPower.PowerProfiles"
 SYSTEM_BUS = True
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ ignore_missing_imports = true
 line-length = 130
 preview = true
 
+[tool.ruff.lint]
 select = [
     "A",       # flake8-builtins
     "B",       # flake8-bugbear

--- a/tests/run-debian
+++ b/tests/run-debian
@@ -16,6 +16,12 @@ eatmydata apt-get install --no-install-recommends -y git \
     python3-dbus python3-pytest python3-gi gir1.2-glib-2.0 \
     dbus libnotify-bin upower network-manager bluez ofono ofono-scripts
 
+# power-profiles-daemon 0.20 did not yet land in Ubuntu 24.04
+. /etc/os-release
+if [ "$ID" = "debian" ]; then
+    eatmydata apt-get install -y power-profiles-daemon
+fi
+
 # systemd's tools otherwise fail on "not been booted with systemd"
 mkdir -p /run/systemd/system
 


### PR DESCRIPTION
Version 0.20 moved to D-Bus name `org.freedesktop.UPower.PowerProfiles`, and corresponding changes to the object path/interface: https://gitlab.freedesktop.org/upower/power-profiles-daemon/-/releases/0.20

The real daemon also still listens to the old name, but we can't do that in dbusmock: BUS_NAME and friends cannot be parameterized, as their loading and instantiation happens before calling the `load()` function.

`powerprofilesctl` now only looks at the new name, so we need to adjust the template. The new version is in Fedora 39 to rawhide and also in Debian testing, so for ongoing development it's more useful to present the current API.

---

See [recent test failures](https://github.com/martinpitt/python-dbusmock/actions/runs/8014608956)