### PR TITLE
Add upower_power_profiles_daemon template

### DIFF
--- a/dbusmock/templates/power_profiles_daemon.py
+++ b/dbusmock/templates/power_profiles_daemon.py
@@ -15,14 +15,14 @@ This provides only the non-deprecated D-Bus API as of version 0.9.
 __author__ = "Bastien Nocera"
 __copyright__ = """
 (c) 2021, Red Hat Inc.
-(c) 2017 - 2024 Martin Pitt <martin@piware.de>
+(c) 2017 - 2022 Martin Pitt <martin@piware.de>
 """
 
 import dbus
 
-BUS_NAME = "org.freedesktop.UPower.PowerProfiles"
-MAIN_OBJ = "/org/freedesktop/UPower/PowerProfiles"
-MAIN_IFACE = "org.freedesktop.UPower.PowerProfiles"
+BUS_NAME = "net.hadess.PowerProfiles"
+MAIN_OBJ = "/net/hadess/PowerProfiles"
+MAIN_IFACE = "net.hadess.PowerProfiles"
 SYSTEM_BUS = True
 
 

--- a/dbusmock/templates/upower_power_profiles_daemon.py
+++ b/dbusmock/templates/upower_power_profiles_daemon.py
@@ -1,11 +1,9 @@
-"""power-profiles-daemon < 0.20 mock template
+"""power-profiles-daemon >= 0.20 mock template
 
 This creates the expected methods and properties of the main
-net.hadess.PowerProfiles object.
+org.freedesktop.UPower.PowerProfiles object.
 
-This provides only the non-deprecated D-Bus API as of version 0.9.
-Note that this template is deprecated: Version 0.20 listens on a different
-bus name/object path, it is provided in upower_power_profiles_daemon.py
+This provides the D-Bus API as of version 0.20.
 """
 
 # This program is free software; you can redistribute it and/or modify it under
@@ -17,14 +15,14 @@ bus name/object path, it is provided in upower_power_profiles_daemon.py
 __author__ = "Bastien Nocera"
 __copyright__ = """
 (c) 2021, Red Hat Inc.
-(c) 2017 - 2022 Martin Pitt <martin@piware.de>
+(c) 2017 - 2024 Martin Pitt <martin@piware.de>
 """
 
 import dbus
 
-BUS_NAME = "net.hadess.PowerProfiles"
-MAIN_OBJ = "/net/hadess/PowerProfiles"
-MAIN_IFACE = "net.hadess.PowerProfiles"
+BUS_NAME = "org.freedesktop.UPower.PowerProfiles"
+MAIN_OBJ = "/org/freedesktop/UPower/PowerProfiles"
+MAIN_IFACE = "org.freedesktop.UPower.PowerProfiles"
 SYSTEM_BUS = True
 
 

--- a/tests/run-debian
+++ b/tests/run-debian
@@ -14,13 +14,7 @@ eatmydata apt-get -y --purge dist-upgrade
 eatmydata apt-get install --no-install-recommends -y git \
     python3-all python3-setuptools python3-setuptools-scm python3-build python3-venv \
     python3-dbus python3-pytest python3-gi gir1.2-glib-2.0 \
-    dbus libnotify-bin upower network-manager bluez ofono ofono-scripts
-
-# power-profiles-daemon 0.20 did not yet land in Ubuntu 24.04
-. /etc/os-release
-if [ "$ID" = "debian" ]; then
-    eatmydata apt-get install -y power-profiles-daemon
-fi
+    dbus libnotify-bin upower network-manager bluez ofono ofono-scripts power-profiles-daemon
 
 # systemd's tools otherwise fail on "not been booted with systemd"
 mkdir -p /run/systemd/system


### PR DESCRIPTION
This works like the existing power_profiles_daemon template, but for the
new D-Bus name/object path introduced in
https://gitlab.freedesktop.org/upower/power-profiles-daemon/-/releases/0.20

Enable integration test on Ubuntu, which has version 0.13 in 22.04 LTS.