### PR TITLE
Adjust to ruff 0.3.0

### DIFF
--- a/dbusmock/__main__.py
+++ b/dbusmock/__main__.py
@@ -51,7 +51,7 @@ def parse_args():
         help="template to load (instead of specifying name, path, interface)",
     )
     parser.add_argument(
-        "name",  # fmt: off
+        "name",
         metavar="NAME",
         nargs="?",
         help='D-Bus name to claim (e. g. "com.example.MyService") (if not using -t)',

--- a/dbusmock/templates/gnome_screensaver.py
+++ b/dbusmock/templates/gnome_screensaver.py
@@ -28,8 +28,12 @@ def load(mock, _parameters):
         [
             ("GetActive", "", "b", "ret = self.is_active"),
             ("GetActiveTime", "", "u", "ret = 1"),
-            # fmt: off
-            ("SetActive", "b", "", 'self.is_active = args[0]; self.EmitSignal("", "ActiveChanged", "b", [self.is_active])'),
+            (
+                "SetActive",
+                "b",
+                "",
+                'self.is_active = args[0]; self.EmitSignal("", "ActiveChanged", "b", [self.is_active])',
+            ),
             ("Lock", "", "", "time.sleep(1); self.SetActive(True)"),
             ("ShowMessage", "sss", "", ""),
             ("SimulateUserActivity", "", "", ""),


### PR DESCRIPTION
That doesn't like the `# fmt off` annotations:

> RUF028 This suppression comment is invalid because it cannot be in an expression, pattern, argument list, or other non-statement

So throw beauty out of the door and concede to the battling tools.

---

Fixes [recent nightly unit test run](https://github.com/martinpitt/python-dbusmock/actions/runs/8106463065/job/22156433476)