### PR TITLE
test: Drop CentOS 8, add CentOS 10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,8 @@ jobs:
           - docker.io/ubuntu:latest
           - registry.fedoraproject.org/fedora:latest
           - registry.fedoraproject.org/fedora:rawhide
-          - quay.io/centos/centos:stream8
           - quay.io/centos/centos:stream9
+          - quay.io/centos/centos:stream10-development
 
     timeout-minutes: 30
     steps:

--- a/packit.yaml
+++ b/packit.yaml
@@ -23,15 +23,17 @@ jobs:
     trigger: pull_request
     targets:
     - fedora-all
-    - centos-stream-8-x86_64
     - centos-stream-9-x86_64
+    # FIXME: broken
+    # - centos-stream-10-x86_64
 
   - job: tests
     trigger: pull_request
     targets:
       - fedora-all
-      - centos-stream-8-x86_64
       - centos-stream-9-x86_64
+      # FIXME: broken rpm build above
+      # - centos-stream-10-x86_64
 
   - job: propose_downstream
     trigger: release


### PR DESCRIPTION
CentOS 8 is EOL now.