### PR TITLE
bluez5: Implement Advertising APIs

### DIFF
--- a/dbusmock/templates/bluez5.py
+++ b/dbusmock/templates/bluez5.py
@@ -59,6 +59,10 @@ def RegisterAgent(manager, agent_path, capability):
             "Another agent is already registered " + manager.agent_path, name="org.bluez.Error.AlreadyExists"
         )
 
+    # Fallback to "KeyboardDisplay" as per BlueZ spec
+    if not capability:
+        capability = "KeyboardDisplay"
+
     if capability not in all_caps:
         raise dbus.exceptions.DBusException(
             "Unsupported capability " + capability, name="org.bluez.Error.InvalidArguments"

--- a/tests/test_bluez5.py
+++ b/tests/test_bluez5.py
@@ -145,10 +145,13 @@ class TestBlueZ5(dbusmock.DBusTestCase):
         self.assertIn("SupportedIncludes: local-name", out)
         self.assertIn("SupportedSecondaryChannels: 1M", out)
         self.assertIn("SupportedSecondaryChannels: 2M", out)
-        self.assertIn("SupportedFeatures: CanSetTxPower", out)
-        self.assertIn("SupportedFeatures: HardwareOffload", out)
 
-        # Capabilities key-value format depends on bluez version
+        # SupportedFeatures was added to the API with BlueZ 5.57
+        if self.bluez5_version >= Version("5.57"):
+            self.assertIn("SupportedFeatures: CanSetTxPower", out)
+            self.assertIn("SupportedFeatures: HardwareOffload", out)
+
+        # Capabilities key-value format was changed in BlueZ 5.70
         if self.bluez5_version <= Version("5.70"):
             capabilities = [
                 ["SupportedCapabilities Key: MinTxPower", "SupportedCapabilities Value: -34"],


### PR DESCRIPTION
Basic implementation of the `org.bluez.LEAdvertisingManager1` and `org.bluez.AdvertisementMonitorManager1` interfaces on mock adapters.

Fixes #20 