### PR TITLE
bluez5: Fix AttributeError when registering an agent twice

### DIFF
--- a/dbusmock/templates/bluez5.py
+++ b/dbusmock/templates/bluez5.py
@@ -56,7 +56,7 @@ def RegisterAgent(manager, agent_path, capability):
 
     if agent_path in manager.agent_paths:
         raise dbus.exceptions.DBusException(
-            "Another agent is already registered " + manager.agent_path, name="org.bluez.Error.AlreadyExists"
+            "Another agent is already registered " + agent_path, name="org.bluez.Error.AlreadyExists"
         )
 
     # Fallback to "KeyboardDisplay" as per BlueZ spec


### PR DESCRIPTION
While I'm in there..

I noticed during some further testing that when starting `bluetoothctl` multiple times, with the bluez5 mock active,  an `AttributeError` is raised instead of the expected `org.bluez.Error.AlreadyExists`:

```sh
$ systemctl mask bluetooth
$ systemctl stop bluetooth
$ python3 -m dbusmock --system -t bluez5 -e $SHELL

$ bluetoothctl
Waiting to connect to bluetoothd...
1720009617.228 RegisterAgent "/org/bluez/agent" ""
[SIGNAL] org.freedesktop.DBus.Mock.MethodCalled
[bluetooth]# Agent registered
[bluetooth]# quit

$ bluetoothctl
Waiting to connect to bluetoothd...
1720009619.963 RegisterAgent "/org/bluez/agent" ""
1720009619.963 RegisterAgent raised: 'DBusMockObject' object has no attribute 'agent_path'
[SIGNAL] org.freedesktop.DBus.Mock.MethodCalled
[bluetooth]# Failed to register agent: org.freedesktop.DBus.Python.AttributeError
[bluetooth]# quit
```

Actually, against the real bluez5 implementation, the agent would be automatically unregistered when the bluetoothctl client disconnects from DBus.. but that's a limitation of this mock/template.