### PR TITLE
tests: Drop outdated doc strings

### DIFF
--- a/tests/test_iio_sensors_proxy.py
+++ b/tests/test_iio_sensors_proxy.py
@@ -1,5 +1,3 @@
-""" Tests for accounts service """
-
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
 # Software Foundation; either version 3 of the License, or (at your option) any

--- a/tests/test_modemmanager.py
+++ b/tests/test_modemmanager.py
@@ -1,5 +1,3 @@
-""" Tests for accounts service """
-
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
 # Software Foundation; either version 3 of the License, or (at your option) any


### PR DESCRIPTION
Two files tried to documen what is being tested and got it wrong.  Drop that duplicate informtion as it's obvious from the class names.