### PR TITLE
mockobject: Allow adding objects derived from DBusMockObject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ version_scheme = 'post-release'
 
 [tool.pylint]
 format = { max-line-length = 130 }
-"messages control" = { disable = ["invalid-name"] }
+"messages control" = { disable = ["invalid-name", "too-many-arguments"] }
 design = { max-args = 7, max-locals = 25,  max-public-methods = 25 }
 
 [tool.mypy]


### PR DESCRIPTION
This allows to create objects instanciated from a DBusMockObject subclass in mock templates. That way, implementing dynamic objects becomes easier by using dbus decorators:

```python
    class ColordDevice(mockobject.DBusMockObject):
        @dbus.service.method(DEVICE_IFACE, in_signature='', out_signature='i')
	def Test(self):
		return 42

    self.add_object(ColordDevice, device_path, DEVICE_IFACE, {}, [])
```