### PR TITLE
drop python<=3.7 support

### DIFF
--- a/dbusmock/__init__.py
+++ b/dbusmock/__init__.py
@@ -1,4 +1,3 @@
-# coding: UTF-8
 """Mock D-Bus objects for test suites."""
 
 # This program is free software; you can redistribute it and/or modify it under

--- a/dbusmock/__main__.py
+++ b/dbusmock/__main__.py
@@ -1,4 +1,3 @@
-# coding: UTF-8
 """Main entry point for running mock server."""
 
 # This program is free software; you can redistribute it and/or modify it under

--- a/dbusmock/mockobject.py
+++ b/dbusmock/mockobject.py
@@ -1,4 +1,3 @@
-# coding: UTF-8
 """Mock D-Bus objects for test suites."""
 
 # This program is free software; you can redistribute it and/or modify it under

--- a/dbusmock/testcase.py
+++ b/dbusmock/testcase.py
@@ -321,7 +321,7 @@ class DBusTestCase(unittest.TestCase):
             argv.append("--config-file=" + str(conf))
         else:
             argv.append("--session")
-        lines = subprocess.check_output(argv, universal_newlines=True).strip().splitlines()
+        lines = subprocess.check_output(argv, text=True).strip().splitlines()
         assert len(lines) == 2, "expected exactly 2 lines of output from dbus-daemon"
         # usually the first line is the address, but be lenient and accept any order
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dynamic = ["version"]
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 
 dependencies = ["dbus-python"]
 

--- a/tests/test_api_pytest.py
+++ b/tests/test_api_pytest.py
@@ -35,6 +35,6 @@ def fixture_upower_mock(dbusmock_system):
 
 def test_dbusmock_test_template(upower_mock):
     assert upower_mock
-    out = subprocess.check_output(["upower", "--dump"], universal_newlines=True)
+    out = subprocess.check_output(["upower", "--dump"], text=True)
     assert "version:" in out
     assert "0.99" in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,7 +59,7 @@ class TestCLI(dbusmock.DBusTestCase):
         self.wait_for_bus_object(wait_name, wait_path, wait_system)
 
     def start_mock_process(self, args):
-        return subprocess.check_output([sys.executable, "-m", "dbusmock", *args], universal_newlines=True)
+        return subprocess.check_output([sys.executable, "-m", "dbusmock", *args], text=True)
 
     def test_session_bus(self):
         self.start_mock(["com.example.Test", "/", "TestIface"], "com.example.Test", "/")
@@ -80,7 +80,7 @@ class TestCLI(dbusmock.DBusTestCase):
     def check_upower_running(self):
         # check that it actually ran the template, if we have upower
         if have_upower:
-            out = subprocess.check_output(["upower", "--dump"], universal_newlines=True)
+            out = subprocess.check_output(["upower", "--dump"], text=True)
             self.assertRegex(out, r"on-battery:\s+no")
 
             mock_out = self.p_mock.stdout.readline()
@@ -99,7 +99,7 @@ class TestCLI(dbusmock.DBusTestCase):
             subprocess.check_output(
                 [sys.executable, "-m", "dbusmock", "--system", "--session", "-t", "upower"],
                 stderr=subprocess.STDOUT,
-                universal_newlines=True,
+                text=True,
             )
         err = cm.exception
         self.assertEqual(err.returncode, 2)
@@ -115,7 +115,7 @@ class TestCLI(dbusmock.DBusTestCase):
 
         # check that it actually ran the template, if we have upower
         if have_upower:
-            out = subprocess.check_output(["upower", "--dump"], universal_newlines=True)
+            out = subprocess.check_output(["upower", "--dump"], text=True)
             self.assertRegex(out, r"daemon-version:\s+0\.99\.0")
             self.assertRegex(out, r"on-battery:\s+yes")
 
@@ -124,7 +124,7 @@ class TestCLI(dbusmock.DBusTestCase):
             subprocess.check_output(
                 [sys.executable, "-m", "dbusmock", "-t", "upower", "-p", '{"DaemonVersion: "0.99.0"}'],
                 stderr=subprocess.STDOUT,
-                universal_newlines=True,
+                text=True,
             )
         err = cm.exception
         self.assertEqual(err.returncode, 2)
@@ -135,7 +135,7 @@ class TestCLI(dbusmock.DBusTestCase):
             subprocess.check_output(
                 [sys.executable, "-m", "dbusmock", "-t", "upower", "-p", '"banana"'],
                 stderr=subprocess.STDOUT,
-                universal_newlines=True,
+                text=True,
             )
         err = cm.exception
         self.assertEqual(err.returncode, 2)

--- a/tests/test_logind.py
+++ b/tests/test_logind.py
@@ -37,7 +37,7 @@ class TestLogind(dbusmock.DBusTestCase):
         cls.dbus_con = cls.get_dbus(True)
 
         if have_loginctl:
-            out = subprocess.check_output(["loginctl", "--version"], universal_newlines=True)
+            out = subprocess.check_output(["loginctl", "--version"], text=True)
             cls.version = re.search(r"(\d+)", out.splitlines()[0]).group(1)
 
     def setUp(self):
@@ -54,13 +54,13 @@ class TestLogind(dbusmock.DBusTestCase):
         cmd = ["loginctl"]
         if self.version >= "209":
             cmd.append("--no-legend")
-        out = subprocess.check_output([*cmd, "list-sessions"], universal_newlines=True)
+        out = subprocess.check_output([*cmd, "list-sessions"], text=True)
         self.assertEqual(out, "")
 
-        out = subprocess.check_output([*cmd, "list-seats"], universal_newlines=True)
+        out = subprocess.check_output([*cmd, "list-seats"], text=True)
         self.assertEqual(out, "")
 
-        out = subprocess.check_output([*cmd, "list-users"], universal_newlines=True)
+        out = subprocess.check_output([*cmd, "list-users"], text=True)
         self.assertEqual(out, "")
 
     def test_session(self):
@@ -68,16 +68,16 @@ class TestLogind(dbusmock.DBusTestCase):
 
         obj_logind.AddSession("c1", "seat0", 500, "joe", True)
 
-        out = subprocess.check_output(["loginctl", "list-seats"], universal_newlines=True)
+        out = subprocess.check_output(["loginctl", "list-seats"], text=True)
         self.assertRegex(out, r"(^|\n)seat0\s+")
 
-        out = subprocess.check_output(["loginctl", "show-seat", "seat0"], universal_newlines=True)
+        out = subprocess.check_output(["loginctl", "show-seat", "seat0"], text=True)
         self.assertRegex(out, "Id=seat0")
         if self.version <= "208":
             self.assertRegex(out, "ActiveSession=c1")
             self.assertRegex(out, "Sessions=c1")
 
-        out = subprocess.check_output(["loginctl", "list-users"], universal_newlines=True)
+        out = subprocess.check_output(["loginctl", "list-users"], text=True)
         self.assertRegex(out, r"(^|\n)\s*500\s+joe\s*")
 
         # note, this does an actual getpwnam() in the client, so we cannot call
@@ -90,10 +90,10 @@ class TestLogind(dbusmock.DBusTestCase):
         # self.assertRegex(out, 'Sessions=c1')
         # self.assertRegex(out, 'State=active')
 
-        out = subprocess.check_output(["loginctl", "list-sessions"], universal_newlines=True)
+        out = subprocess.check_output(["loginctl", "list-sessions"], text=True)
         self.assertRegex(out, "c1 +500 +joe +seat0")
 
-        out = subprocess.check_output(["loginctl", "show-session", "c1"], universal_newlines=True)
+        out = subprocess.check_output(["loginctl", "show-session", "c1"], text=True)
         self.assertRegex(out, "Id=c1")
         self.assertRegex(out, "Class=user")
         self.assertRegex(out, "Active=yes")
@@ -107,7 +107,7 @@ class TestLogind(dbusmock.DBusTestCase):
         )
         session_mock.SetLockedHint(True)
 
-        out = subprocess.check_output(["loginctl", "show-session", "c1"], universal_newlines=True)
+        out = subprocess.check_output(["loginctl", "show-session", "c1"], text=True)
         self.assertRegex(out, "Id=c1")
         self.assertRegex(out, "LockedHint=yes")
 
@@ -124,7 +124,7 @@ class TestLogind(dbusmock.DBusTestCase):
         fd = obj_logind.Inhibit("suspend", "testcode", "purpose", "delay")
 
         # Our inhibitor is held
-        out = subprocess.check_output(["systemd-inhibit"], universal_newlines=True)
+        out = subprocess.check_output(["systemd-inhibit"], text=True)
         self.assertRegex(
             out.replace("\n", " "),
             "(testcode +[0-9]+ +[^ ]* +[0-9]+ +[^ ]* +suspend purpose delay)|"
@@ -133,7 +133,7 @@ class TestLogind(dbusmock.DBusTestCase):
 
         del fd
         # No inhibitor is held
-        out = subprocess.check_output(["systemd-inhibit"], universal_newlines=True)
+        out = subprocess.check_output(["systemd-inhibit"], text=True)
         self.assertRegex(out, "No inhibitors|0 inhibitors listed")
 
 

--- a/tests/test_networkmanager.py
+++ b/tests/test_networkmanager.py
@@ -79,31 +79,27 @@ class TestNetworkManager(dbusmock.DBusTestCase):
         self.p_mock.wait()
 
     def read_general(self):
-        return subprocess.check_output(["nmcli", "--nocheck", "general"], env=self.lang_env, universal_newlines=True)
+        return subprocess.check_output(["nmcli", "--nocheck", "general"], env=self.lang_env, text=True)
 
     def read_networking(self):
-        return subprocess.check_output(
-            ["nmcli", "--nocheck", "networking"], env=self.lang_env, universal_newlines=True
-        )
+        return subprocess.check_output(["nmcli", "--nocheck", "networking"], env=self.lang_env, text=True)
 
     def read_connection(self):
-        return subprocess.check_output(
-            ["nmcli", "--nocheck", "connection"], env=self.lang_env, universal_newlines=True
-        )
+        return subprocess.check_output(["nmcli", "--nocheck", "connection"], env=self.lang_env, text=True)
 
     def read_active_connection(self):
         return subprocess.check_output(
-            ["nmcli", "--nocheck", "connection", "show", "--active"], env=self.lang_env, universal_newlines=True
+            ["nmcli", "--nocheck", "connection", "show", "--active"], env=self.lang_env, text=True
         )
 
     def read_device(self):
-        return subprocess.check_output(["nmcli", "--nocheck", "dev"], env=self.lang_env, universal_newlines=True)
+        return subprocess.check_output(["nmcli", "--nocheck", "dev"], env=self.lang_env, text=True)
 
     def read_device_wifi(self):
         return subprocess.check_output(
             ["nmcli", "--nocheck", "dev", "wifi", "list", "--rescan", "no"],
             env=self.lang_env,
-            universal_newlines=True,
+            text=True,
         )
 
     def test_one_eth_disconnected(self):
@@ -174,7 +170,7 @@ class TestNetworkManager(dbusmock.DBusTestCase):
 
         # TODO: for connecting to password protected Wifi we need to implement secrets agent
         # https://github.com/martinpitt/python-dbusmock/issues/216
-        out = subprocess.check_output(["nmcli", "--version"], universal_newlines=True)
+        out = subprocess.check_output(["nmcli", "--version"], text=True)
         m = re.search(r"([1-9.]+[0-9])", out)
         assert m, "could not parse version from " + out
         if Version(m.group(1)) >= Version("1.49.3"):
@@ -254,7 +250,7 @@ class TestNetworkManager(dbusmock.DBusTestCase):
         self.assertEqual(con1, "/org/freedesktop/NetworkManager/Settings/Mock_Con1")
 
         settings = subprocess.check_output(
-            ["nmcli", "--nocheck", "connection", "show", "The_SSID"], env=self.lang_env, universal_newlines=True
+            ["nmcli", "--nocheck", "connection", "show", "The_SSID"], env=self.lang_env, text=True
         )
         self.assertRegex(settings, r"ipv4.method:\s*auto")
         self.assertRegex(settings, r"ipv4.gateway:\s*--")

--- a/tests/test_notification_daemon.py
+++ b/tests/test_notification_daemon.py
@@ -21,7 +21,7 @@ import dbus
 import dbusmock
 
 try:
-    notify_send_version = subprocess.check_output(["notify-send", "--version"], universal_newlines=True)
+    notify_send_version = subprocess.check_output(["notify-send", "--version"], text=True)
     notify_send_version = notify_send_version.split()[-1]
 except (OSError, subprocess.CalledProcessError):
     notify_send_version = ""

--- a/tests/test_ofono.py
+++ b/tests/test_ofono.py
@@ -104,7 +104,7 @@ class TestOfono(dbusmock.DBusTestCase):
     def test_list_operators(self):
         """list operators"""
 
-        out = subprocess.check_output([script_dir / "list-operators"], universal_newlines=True)
+        out = subprocess.check_output([script_dir / "list-operators"], text=True)
         self.assertTrue(out.startswith("[ /ril_0 ]"), out)
         self.assertIn("[ /ril_0/operator/op1 ]", out)
         self.assertIn("Status = current", out)

--- a/tests/test_power_profiles_daemon.py
+++ b/tests/test_power_profiles_daemon.py
@@ -64,7 +64,7 @@ class TestPowerProfilesDaemon(dbusmock.DBusTestCase):
     def test_list_profiles(self):
         """List Profiles and check active profile"""
 
-        out = subprocess.check_output(["powerprofilesctl"], universal_newlines=True)
+        out = subprocess.check_output(["powerprofilesctl"], text=True)
 
         self.assertIn("performance:\n", out)
         self.assertIn("\n* balanced:\n", out)
@@ -72,12 +72,12 @@ class TestPowerProfilesDaemon(dbusmock.DBusTestCase):
     def test_change_profile(self):
         """Change ActiveProfile"""
 
-        subprocess.check_output(["powerprofilesctl", "set", "performance"], universal_newlines=True)
-        out = subprocess.check_output(["powerprofilesctl", "get"], universal_newlines=True)
+        subprocess.check_output(["powerprofilesctl", "set", "performance"], text=True)
+        out = subprocess.check_output(["powerprofilesctl", "get"], text=True)
         self.assertEqual(out, "performance\n")
 
     def run_powerprofilesctl_list_holds(self):
-        return subprocess.check_output(["powerprofilesctl", "list-holds"], universal_newlines=True)
+        return subprocess.check_output(["powerprofilesctl", "list-holds"], text=True)
 
     def test_list_holds(self):
         """Test holds"""

--- a/tests/test_timedated.py
+++ b/tests/test_timedated.py
@@ -45,7 +45,7 @@ class TestTimedated(dbusmock.DBusTestCase):
             self.p_mock.wait()
 
     def run_timedatectl(self):
-        return subprocess.check_output(["timedatectl"], universal_newlines=True)
+        return subprocess.check_output(["timedatectl"], text=True)
 
     def test_default_timezone(self):
         out = self.run_timedatectl()

--- a/tests/test_upower.py
+++ b/tests/test_upower.py
@@ -60,7 +60,7 @@ class TestUPower(dbusmock.DBusTestCase):
         self.p_mock.wait()
 
     def test_no_devices(self):
-        out = subprocess.check_output(["upower", "--dump"], universal_newlines=True)
+        out = subprocess.check_output(["upower", "--dump"], text=True)
         self.assertIn("/DisplayDevice\n", out)
         # should not have any other device
         for line in out.splitlines():
@@ -82,7 +82,7 @@ class TestUPower(dbusmock.DBusTestCase):
             b'emit /org/freedesktop/UPower org.freedesktop.UPower.DeviceAdded "/org/freedesktop/UPower/devices/mock_AC"\n',
         )
 
-        out = subprocess.check_output(["upower", "--dump"], universal_newlines=True)
+        out = subprocess.check_output(["upower", "--dump"], text=True)
         self.assertRegex(out, "Device: " + path)
         # note, Add* is not magic: this just adds an object, not change
         # properties
@@ -109,7 +109,7 @@ class TestUPower(dbusmock.DBusTestCase):
             b'emit /org/freedesktop/UPower org.freedesktop.UPower.DeviceAdded "/org/freedesktop/UPower/devices/mock_BAT"\n',
         )
 
-        out = subprocess.check_output(["upower", "--dump"], universal_newlines=True)
+        out = subprocess.check_output(["upower", "--dump"], text=True)
         self.assertRegex(out, "Device: " + path)
         # note, Add* is not magic: this just adds an object, not change
         # properties
@@ -129,7 +129,7 @@ class TestUPower(dbusmock.DBusTestCase):
             b'emit /org/freedesktop/UPower org.freedesktop.UPower.DeviceAdded "/org/freedesktop/UPower/devices/mock_BAT"\n',
         )
 
-        out = subprocess.check_output(["upower", "--dump"], universal_newlines=True)
+        out = subprocess.check_output(["upower", "--dump"], text=True)
         self.assertRegex(out, "Device: " + path)
         # note, Add* is not magic: this just adds an object, not change
         # properties
@@ -193,7 +193,7 @@ class TestUPower(dbusmock.DBusTestCase):
         except KeyError:
             pass
 
-        out = subprocess.check_output(["upower", "--dump"], universal_newlines=True, env=env)
+        out = subprocess.check_output(["upower", "--dump"], text=True, env=env)
         self.assertIn("/DisplayDevice\n", out)
         self.assertIn("  battery\n", out)  # type
         self.assertRegex(out, r"state:\s+charging")


### PR DESCRIPTION
According to https://endoflife.date/python python 3.7 has been EOSed 27 Jun 2023.
Filter all code over `pyupgracde --py38-plus`.