### PR TITLE
tests: fix test_monitor on musl

### DIFF
--- a/tests/test_bluez5.py
+++ b/tests/test_bluez5.py
@@ -493,7 +493,7 @@ class TestBlueZ5(dbusmock.DBusTestCase):
         adapter = self.dbus_con.get_object("org.bluez", path)
 
         # When an advertisement monitor is configured via bluetoothctl
-        out = _run_bluetoothctl("monitor.add-or-pattern 0 255 0x01")
+        out = _run_bluetoothctl("monitor.add-or-pattern 0 255 01")
 
         # Then bluetoothctl reports success
         self.assertIn("Advertisement Monitor 0 added", out)


### PR DESCRIPTION
[It is probably a Glibc bug that sscanf as used by bluez accepts 0x01 for this value.][1]  For portability, use the unprefixed hex value. Based on bluez's own [documentation][2], I don't think the 0x is required.

[1]: https://www.openwall.com/lists/libc-coord/2024/10/15/2
[2]: https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/client/bluetoothctl-monitor.rst?id=3d9900eb754d277ef6abf21bed827cdc9e79ddb4