### PR TITLE
Add gsd-rfkill mock

### DIFF
--- a/dbusmock/templates/gsd_rfkill.py
+++ b/dbusmock/templates/gsd_rfkill.py
@@ -1,0 +1,54 @@
+"""gsd-rfkill mock template
+
+This creates the expected properties of the GNOME Settings Daemon's
+rfkill object. You can specify any property such as AirplaneMode in
+"parameters".
+"""
+
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 3 of the License, or (at your option) any
+# later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
+# of the license.
+
+__author__ = "Guido Günther"
+__copyright__ = "2024 The Phosh Developers"
+
+import dbus
+
+from dbusmock import MOCK_IFACE
+
+SYSTEM_BUS = False
+BUS_NAME = "org.gnome.SettingsDaemon.Rfkill"
+MAIN_OBJ = "/org/gnome/SettingsDaemon/Rfkill"
+MAIN_IFACE = "org.gnome.SettingsDaemon.Rfkill"
+
+
+def load(mock, parameters):
+    props = dbus.Dictionary(
+        {
+            "AirplaneMode": parameters.get("AirplaneMode", False),
+            "BluetoothAirplaneMode": parameters.get("BluetoothAirplaneMode", False),
+            "BluetoothHardwareAirplaneMode": parameters.get("BluetoothHardwareAirplaneMode", False),
+            "BluetoothHasAirplaneMode": parameters.get("BluetoothHasAirplanemode", True),
+            "HardwareAirplaneMode": parameters.get("HardwareAirplaneMode", False),
+            "HasAirplaneMode": parameters.get("HasAirplaneMode", True),
+            "ShouldShowAirplaneMode": parameters.get("ShouldShowAirplaneMode", True),
+            "WwanAirplaneMode": parameters.get("WwanAirplaneMode", False),
+            "WwanHardwareAirplaneMode": parameters.get("WwanHardwareAirplaneMode", False),
+            "WwanHasAirplaneMode": parameters.get("WwanHasAirplaneMode", True),
+        },
+        signature="sv",
+    )
+    mock.AddProperties(MAIN_IFACE, props)
+
+
+@dbus.service.method(MOCK_IFACE, in_signature="b", out_signature="b")
+def SetAirplaneMode(self, mode):
+    """
+    Convenience method to toggle airplane mode
+    """
+    self.props[MAIN_IFACE]["AirplaneMode"] = mode
+    self.props[MAIN_IFACE]["BluetoothAirplaneMode"] = mode
+    self.props[MAIN_IFACE]["WwanAirplaneMode"] = mode
+    return mode

--- a/tests/test_gsd_rfkill.py
+++ b/tests/test_gsd_rfkill.py
@@ -1,0 +1,63 @@
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 3 of the License, or (at your option) any
+# later version.  See http://www.gnu.org/copyleft/lgpl.html for the full text
+# of the license.
+
+__author__ = "Guido Günther"
+__copyright__ = "2024 The Phosh Developers"
+
+import fcntl
+import os
+import subprocess
+import sys
+import unittest
+
+import dbus
+
+import dbusmock
+
+
+class TestGsdRfkill(dbusmock.DBusTestCase):
+    """Test mocked GNOME Settings Daemon Rfkill"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.start_session_bus()
+        cls.dbus_con = cls.get_dbus()
+
+    def setUp(self):
+        (self.p_mock, self.p_obj) = self.spawn_server_template("gsd_rfkill", {}, stdout=subprocess.PIPE)
+        # set log to nonblocking
+        flags = fcntl.fcntl(self.p_mock.stdout, fcntl.F_GETFL)
+        fcntl.fcntl(self.p_mock.stdout, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+
+    def tearDown(self):
+        self.p_mock.stdout.close()
+        self.p_mock.terminate()
+        self.p_mock.wait()
+
+    def test_mainobject(self):
+        propiface = dbus.Interface(self.p_obj, dbus.PROPERTIES_IFACE)
+
+        mode = propiface.Get("org.gnome.SettingsDaemon.Rfkill", "AirplaneMode")
+        self.assertEqual(mode, False)
+        mode = propiface.Get("org.gnome.SettingsDaemon.Rfkill", "HasAirplaneMode")
+        self.assertEqual(mode, True)
+
+    def test_airplane_mode(self):
+        propiface = dbus.Interface(self.p_obj, dbus.PROPERTIES_IFACE)
+
+        self.p_obj.SetAirplaneMode(True)
+
+        mode = propiface.Get("org.gnome.SettingsDaemon.Rfkill", "AirplaneMode")
+        self.assertEqual(mode, True)
+        mode = propiface.Get("org.gnome.SettingsDaemon.Rfkill", "BluetoothAirplaneMode")
+        self.assertEqual(mode, True)
+        mode = propiface.Get("org.gnome.SettingsDaemon.Rfkill", "WwanAirplaneMode")
+        self.assertEqual(mode, True)
+
+
+if __name__ == "__main__":
+    # avoid writing to stderr
+    unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout))


### PR DESCRIPTION
This can be useful to test behavior of dependent components like desktop shells.

Single properties can be toggled via

```
   gdbus call --session -d org.gnome.SettingsDaemon.Rfkill -o /org/gnome/SettingsDaemon/Rfkill -m org.freedesktop.DBus.Properties.Set 'org.gnome.SettingsDaemon.Rfkill' 'BluetoothHasAirplaneMode' "<true>"
```

and airplane mode for all wwan/bt/wifi at once:

```
   gdbus call --session -d org.gnome.SettingsDaemon.Rfkill -o /org/gnome/SettingsDaemon/Rfkill -m org.freedesktop.DBus.Mock.SetAirplaneMode true
```

I can see that this might be to DE specific but I thought I'd submit it as it might be useful to others.