### PR TITLE
modemmanager: Allow to add Cell broadcast messages

### DIFF
--- a/dbusmock/templates/modemmanager.py
+++ b/dbusmock/templates/modemmanager.py
@@ -172,7 +172,6 @@ def AddSimpleModem(self):
         ("CallWaitingQuery", "", "b", "ret = self.call_waiting"),
         ("CallWaitingSetup", "b", "", "self.call_waiting = args[0]"),
     ]
-    modem = mockobject.objects[modem_path]
     modem.AddProperties(MODEM_VOICE_IFACE, modem_voice_props)
     modem.AddMethods(MODEM_VOICE_IFACE, modem_voice_methods)
 


### PR DESCRIPTION
 Doing userspace development for cell broadcast messages can be tricky as they're very rare in the wild. If one doesn't mock ModemManager one needs to have a small GSM cell for testing.
    
Hence add a `AddCbm()` message to add cell broadcast messages to the MM mock.
    
```
 mm_server.obj.AddCbm(2, 4383, "This is a test)
```
    
Messages can be deleted via MMs API:
    
```
busctl call --system org.freedesktop.ModemManager1 /org/freedesktop/ModemManager1/Modems/8 org.freedesktop.ModemManager1.Modem.CellBroadcast Delete o /org/freedesktop/ModemManager1/Cbm/5
```
    
and listed via MMs API:
    
```
busctl call --system org.freedesktop.ModemManager1 /org/freedesktop/ModemManager1/Modems/8 org.freedesktop.ModemManager1.Modem.CellBroadcast List
```

This functionality is not yet in a released MM version (but merged into main). I've tested that MMs `mmcbmmonitor` handles it, [phosh](https://gitlab.gnome.org/World/Phosh/phosh) can use it to test its CBM display and we intend to use it to implement CBM support in [Chatty](https://gitlab.gnome.org/World/Chatty).

As a preparation we improve the general MM implementation. We so far used the default ObjectManager but that would be too much as e.g. SIM (or CBM) shouldn't be announced via that interface. Hence we implement `GetManagedObjects` ourself to only handle modems.