### PR TITLE
packit: Test builds on other architectures

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -23,9 +23,11 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets:
-    - fedora-all
-    - centos-stream-9-x86_64
-    - centos-stream-10-x86_64
+      - fedora-latest-i386
+      - fedora-latest-aarch64
+      - fedora-latest-ppc64le
+      - fedora-latest-s390x
+      - fedora-latest-armhfp
 
   - job: tests
     trigger: pull_request


### PR DESCRIPTION
Drop the redundant targets which are already implicitly triggered by the "tests" job.