### PR TITLE
modemmanager: Add operator ID and allow to set channels

### DIFF
--- a/dbusmock/templates/modemmanager.py
+++ b/dbusmock/templates/modemmanager.py
@@ -189,6 +189,7 @@ def AddSimpleModem(self):
     modem_3gpp_props = {
         "Imei": dbus.String("doesnotmatter"),
         "OperatorName": dbus.String("TheOperator"),
+        "OperatorCode": dbus.String("00101"),
         "Pco": dbus.Array([], signature="(ubay)"),
     }
     modem = mockobject.objects[modem_path]

--- a/dbusmock/templates/modemmanager.py
+++ b/dbusmock/templates/modemmanager.py
@@ -151,6 +151,17 @@ def deleteCbm(self, cbm_path):
     )
 
 
+def setChannels(_self, channels):
+    modem_obj = mockobject.objects[SIMPLE_MODEM_PATH]
+
+    modem_obj.UpdateProperties(
+        MODEM_CELL_BROADCAST_IFACE,
+        {
+            "Channels": dbus.Array(channels),
+        },
+    )
+
+
 @dbus.service.method(MOCK_IFACE, in_signature="", out_signature="ss")
 def AddSimpleModem(self):
     """Convenience method to add a simple Modem object
@@ -196,11 +207,13 @@ def AddSimpleModem(self):
     modem.AddProperties(MODEM_3GPP_IFACE, modem_3gpp_props)
 
     modem_cell_broadcast_props = {
+        "Channels": dbus.Array([], signature="(uu)"),
         "CellBroadcasts": dbus.Array([], signature="o"),
     }
     modem_cell_broadcast_methods = [
         ("List", "", "ao", listCbm),
         ("Delete", "o", "", deleteCbm),
+        ("SetChannels", "a(uu)", "", setChannels),
     ]
     modem.AddProperties(MODEM_CELL_BROADCAST_IFACE, modem_cell_broadcast_props)
     modem.AddMethods(MODEM_CELL_BROADCAST_IFACE, modem_cell_broadcast_methods)

--- a/tests/test_modemmanager.py
+++ b/tests/test_modemmanager.py
@@ -108,6 +108,7 @@ class TestModemManagerModemMmcli(TestModemManagerMmcliBase):
                 "           |           current: allowed: 4g; preferred: 4g",
                 "  -----------------------------",
                 "  3GPP     |              imei: doesnotmatter",
+                "           |       operator id: 00101",
                 "           |     operator name: TheOperator",
                 "           |      registration: idle",
                 "  -----------------------------",


### PR DESCRIPTION
The channel setting API is not yet in a released version of ModemManager so I didn't add a `mmcli` test.