### PR TITLE
mockobject: Fix _wrap_in_dbus_variant for Struct and Dict types

### DIFF
--- a/dbusmock/mockobject.py
+++ b/dbusmock/mockobject.py
@@ -116,10 +116,8 @@ def _wrap_in_dbus_variant(value):
         dbus.types.ByteArray,
         dbus.types.Int16,
         dbus.types.ObjectPath,
-        dbus.types.Struct,
         dbus.types.UInt64,
         dbus.types.Boolean,
-        dbus.types.Dictionary,
         dbus.types.Int32,
         dbus.types.Signature,
         dbus.types.UInt16,
@@ -130,9 +128,14 @@ def _wrap_in_dbus_variant(value):
         dbus.types.String,
         dbus.types.UInt32,
     ]
+    container_types = [
+        dbus.types.Array,
+        dbus.types.Struct,
+        dbus.types.Dictionary,
+    ]
     if isinstance(value, dbus.String):
         return dbus.String(str(value), variant_level=1)
-    if isinstance(value, dbus.types.Array):
+    if type(value) in container_types:
         return value
     if type(value) in dbus_types:
         return type(value)(value.conjugate(), variant_level=1)


### PR DESCRIPTION
Updating a Struct or Dict property fails because they have no conjugate method. We don't need to wrap them, so they really behave like Array, so let's just treat them in the same way.