### PR TITLE
test: Drop iio-sensor-proxy tests on Fedora

### DIFF
--- a/tests/run-fedora
+++ b/tests/run-fedora
@@ -6,7 +6,8 @@ dnf -y install python3-setuptools python3 python3-gobject-base \
     upower NetworkManager ModemManager bluez libnotify polkit
 
 if ! grep -q :el /etc/os-release; then
-    dnf -y install power-profiles-daemon iio-sensor-proxy python3-pytest
+    # skip iio-sensor-proxy: https://github.com/martinpitt/python-dbusmock/issues/241
+    dnf -y install power-profiles-daemon python3-pytest
 else
     dnf -y install python3-pip
     pip install pytest


### PR DESCRIPTION
The template has broken logic, and does not work any more with iio-sensor-proxy 3.7. See https://github.com/martinpitt/python-dbusmock/issues/241