### PR TITLE
Drop redundant manual BuildRequires

### DIFF
--- a/distro/python-dbusmock.spec
+++ b/distro/python-dbusmock.spec
@@ -11,11 +11,7 @@ Source0:          https://files.pythonhosted.org/packages/source/p/%{name}/pytho
 
 BuildArch:        noarch
 BuildRequires:    git
-BuildRequires:    python3-dbus
 BuildRequires:    python3-devel
-BuildRequires:    python3dist(setuptools-scm)
-BuildRequires:    python3dist(wheel)
-BuildRequires:    python3-setuptools
 BuildRequires:    python3-gobject
 BuildRequires:    python3-pytest
 BuildRequires:    dbus-x11


### PR DESCRIPTION
Drop unused BuildRequires on python3dist(wheel)

See https://github.com/fedora-eln/eln/issues/284

---

By way of https://src.fedoraproject.org/rpms/python-dbusmock from @hroncok , thanks!