### PR TITLE
Fix dbus-daemon startup race condition

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,6 +13,7 @@ __copyright__ = """
 import importlib.util
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -1026,7 +1027,8 @@ class TestCleanup(dbusmock.DBusTestCase):
 
         self.start_session_bus()
         p_mock = self.spawn_server("org.freedesktop.Test", "/", "org.freedesktop.Test.Main")
-        self.stop_dbus(self.session_bus_pid)
+        assert self.session_bus_pid is not None
+        os.kill(self.session_bus_pid, signal.SIGTERM)
 
         # give the mock 2 seconds to terminate
         timeout = 20


### PR DESCRIPTION
With the previous polling loop there was a short window where the socket
existed, but dbus-daemon didn't listen to it yet. Fix this by using
`--print-pid` and waiting for the result. dbus-daemon guarantees that
this will only be printed after it is ready to accept connections.

Thanks to Simon McVittie for finding this and proposing the solution!
(Ironically, the dead code removed in the previous commit did it right.
But avoid forking here.)

https://bugs.debian.org/1109272

---

Thanks @smcv !