### PR TITLE
test: Skip test_notification_daemon with AppArmor profile

### DIFF
--- a/dbusmock/templates/systemd.py
+++ b/dbusmock/templates/systemd.py
@@ -1,5 +1,4 @@
-"""systemd mock template
-"""
+"""systemd mock template"""
 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free

--- a/tests/test_notification_daemon.py
+++ b/tests/test_notification_daemon.py
@@ -28,6 +28,7 @@ except (OSError, subprocess.CalledProcessError):
 
 
 @unittest.skipUnless(notify_send_version, "notify-send not installed")
+@unittest.skipIf(os.path.exists("/etc/apparmor.d/notify-send"), "AppArmor profile for notify-send active")
 class TestNotificationDaemon(dbusmock.DBusTestCase):
     """Test mocking notification-daemon"""
 


### PR DESCRIPTION
Ubuntu 25.10 introduces an AppArmor profile for notify-send, which only allows it to talk to the real daemon.

https://launchpad.net/bugs/2121092